### PR TITLE
Make 'Stream' classes implement Serializable

### DIFF
--- a/stream_info/AudioStream.java
+++ b/stream_info/AudioStream.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.extractor.stream_info;
 
+import java.io.Serializable;
+
 /**
  * Created by Christian Schabesberger on 04.03.16.
  *
@@ -20,7 +22,7 @@ package org.schabi.newpipe.extractor.stream_info;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class AudioStream {
+public class AudioStream implements Serializable{
     public String url = "";
     public int format = -1;
     public int bandwidth = -1;

--- a/stream_info/VideoStream.java
+++ b/stream_info/VideoStream.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.extractor.stream_info;
 
+import java.io.Serializable;
+
 /**
  * Created by Christian Schabesberger on 04.03.16.
  *
@@ -20,7 +22,7 @@ package org.schabi.newpipe.extractor.stream_info;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class VideoStream {
+public class VideoStream implements Serializable{
     //url of the stream
     public String url = "";
     public int format = -1;


### PR DESCRIPTION
We have to implement `Serializable` in order to be able to pass Objects (lists, streams) between activitys, services through Intents (putExtra) .
I've been implementing the quality selector, so it's necessary.

PS: I was thinking in implement the `Parcelable` (faster) , but that would break the command-line, as this class only exist in Android