### PR TITLE
Fix wrong view count

### DIFF
--- a/services/youtube/YoutubeChannelExtractor.java
+++ b/services/youtube/YoutubeChannelExtractor.java
@@ -244,7 +244,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                             return -1;
                         }
 
-                        output = Parser.matchGroup1("([0-9,\\. ]*)", input)
+                        output = Parser.matchGroup1("([0-9,\\. \u00a0]*)", input)
+                                .replace("\u00a0", "")
                                 .replace(" ", "")
                                 .replace(".", "")
                                 .replace(",", "");


### PR DESCRIPTION
This commit fixes view counter on channel page.

The number of views came with non-breaking spaces like `2&nbsp;782&nbsp;442 views` (for 2 782 442 views). Parser fails and I see 2 views instead of 2M views:

![screenshot_1499564766](https://user-images.githubusercontent.com/2663397/27990574-d0a770a2-6463-11e7-8ebc-41e28fce32d2.png)
