### PR TITLE
Fix Playlist id extraction when length is not 34

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistUrlIdHandler.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistUrlIdHandler.java
@@ -8,7 +8,7 @@ import org.schabi.newpipe.extractor.utils.Parser;
 public class YoutubePlaylistUrlIdHandler implements UrlIdHandler {
 
     private static final YoutubePlaylistUrlIdHandler instance = new YoutubePlaylistUrlIdHandler();
-    private static final String ID_PATTERN = "([\\-a-zA-Z0-9_]{34})";
+    private static final String ID_PATTERN = "([\\-a-zA-Z0-9_]*)";
 
     public static YoutubePlaylistUrlIdHandler getInstance() {
         return instance;


### PR DESCRIPTION
[Example](https://www.youtube.com/playlist?list=PL3418E30855DF35AB)