### PR TITLE
Makes ChannelInfo.getInfo(String url) able to use channel RSS url

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
+++ b/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
@@ -59,6 +59,11 @@ public abstract class StreamingService {
         return getPlaylistExtractor(url, null);
     }
 
+    public abstract boolean isFeedUrl(String url);
+
+    public abstract String getUrlFromFeed(String feedUrl);
+
+
     /**
      * figure out where the link is pointing to (a channel, video, playlist, etc.)
      */

--- a/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
+++ b/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 
 import java.io.IOException;
@@ -43,6 +44,8 @@ public class ChannelInfo extends ListInfo {
     }
 
     public static ChannelInfo getInfo(String url) throws IOException, ExtractionException {
+        if(isFeedUrl(url))
+                return getInfo(NewPipe.getServiceByUrl(url), getUrlFromFeed(url));
         return getInfo(NewPipe.getServiceByUrl(url), url);
     }
 
@@ -52,6 +55,22 @@ public class ChannelInfo extends ListInfo {
 
     public static ChannelInfo getInfo(StreamingService service, String url) throws IOException, ExtractionException {
         return getInfo(service.getChannelExtractor(url));
+    }
+
+    public static Boolean isFeedUrl(String url) throws ExtractionException {
+        return isFeedUrl(NewPipe.getServiceByUrl(url), url);
+    }
+
+    public static Boolean isFeedUrl(StreamingService service, String url) {
+        return service.isFeedUrl(url);
+    }
+
+    public static String getUrlFromFeed(String feedUrl) throws ExtractionException {
+        return getUrlFromFeed(NewPipe.getServiceByUrl(feedUrl), feedUrl);
+    }
+
+    public static String getUrlFromFeed(StreamingService service, String feedUrl) {
+        return service.getUrlFromFeed(feedUrl);
     }
 
     public static ChannelInfo getInfo(ChannelExtractor extractor) throws ParsingException {

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
@@ -1,17 +1,25 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+
 import java.io.IOException;
 
+import org.schabi.newpipe.extractor.Downloader;
+import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.SuggestionExtractor;
 import org.schabi.newpipe.extractor.UrlIdHandler;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.kiosk.KioskList;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.utils.Parser;
 
 public class SoundcloudService extends StreamingService {
 
@@ -88,5 +96,46 @@ public class SoundcloudService extends StreamingService {
         }
 
         return list;
+    }
+
+    public boolean isFeedUrl(String url) {
+        return url.contains("sounds.rss");
+    }
+
+    public String getUrlFromFeed(String feedUrl) {
+        Downloader dl = NewPipe.getDownloader();
+        String userId = feedUrl.split(":users:")[1];
+        String apiUrl;
+        try {
+            apiUrl = "https://api.soundcloud.com/users/" + userId +
+                    "?client_id=" + SoundcloudParsingHelper.clientId();
+        } catch (ReCaptchaException e) {
+            e.printStackTrace();
+            return null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        } catch (Parser.RegexException e) {
+            e.printStackTrace();
+            return null;
+        }
+        String response;
+        try {
+            response = dl.download(apiUrl);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        } catch (ReCaptchaException e) {
+            e.printStackTrace();
+            return null;
+        }
+        JsonObject user;
+        try {
+            user = JsonParser.object().from(response);
+        } catch (JsonParserException e) {
+            e.printStackTrace();
+            return null;
+        }
+        return user.getString("permalink_url");
     }
 }

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
@@ -96,6 +96,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
 
             return element.attr("data-channel-external-id");
         } catch (Exception e) {
+
             throw new ParsingException("Could not get channel id", e);
         }
     }

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelUrlIdHandler.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelUrlIdHandler.java
@@ -51,6 +51,6 @@ public class YoutubeChannelUrlIdHandler implements UrlIdHandler {
     @Override
     public boolean acceptUrl(String url) {
         return (url.contains("youtube") || url.contains("youtu.be"))
-                && (url.contains("/user/") || url.contains("/channel/"));
+                && ((url.contains("/user/") || url.contains("/channel/")) || url.contains("videos.xml"));
     }
 }

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -102,4 +102,12 @@ public class YoutubeService extends StreamingService {
 
         return list;
     }
+
+    public boolean isFeedUrl(String url) {
+        return url.contains("videos.xml");
+    }
+
+    public String getUrlFromFeed(String feedUrl) {
+        return "https://www.youtube.com/channel/" + feedUrl.split("=")[1];
+    }
 }


### PR DESCRIPTION
This pull request makes ChannelInfo.getInfo(String url) able to use the channel's RSS url (for subscription importing and exporting in NewPipe).