### PR TITLE
Fix uploader url for related streams

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -783,6 +783,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             }
 
             @Override
+            public String getUploaderUrl() throws ParsingException {
+                return ""; // The uploader is not linked
+            }
+
+            @Override
             public String getUploadDate() throws ParsingException {
                 return "";
             }


### PR DESCRIPTION
Override method to get the uploader url so no exception is thrown. The uploader url is not available in related streams in the legacy view.