### PR TITLE
Automatically deploy Javadocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,13 @@
 language: java
+
+script:
+  - ./gradlew check
+  - ./gradlew javadoc
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  local_dir: build/docs
+  on:
+    branch: master

--- a/src/main/java/org/schabi/newpipe/extractor/Info.java
+++ b/src/main/java/org/schabi/newpipe/extractor/Info.java
@@ -10,7 +10,7 @@ public abstract class Info implements Serializable {
     public final int service_id;
     /**
      * Id of this Info object <br>
-     * e.g. Youtube:  https://www.youtube.com/watch?v=RER5qCTzZ7     >    RER5qCTzZ7
+     * e.g. Youtube:  https://www.youtube.com/watch?v=RER5qCTzZ7     &gt;    RER5qCTzZ7
      */
     public final String id;
     public final String url;

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -63,7 +63,8 @@ public class SoundcloudParsingHelper {
     }
 
     /**
-     * Call the endpoint "/resolve" of the api.<br/>
+     * Call the endpoint "/resolve" of the api.<p>
+     * 
      * See https://developers.soundcloud.com/docs/api/reference#resolve
      */
     public static JsonObject resolveFor(String url) throws IOException, ReCaptchaException, ParsingException {
@@ -79,7 +80,7 @@ public class SoundcloudParsingHelper {
     }
 
     /**
-     * Fetch the embed player with the apiUrl and return the canonical url (like the permalink_url from the json api).<br/>
+     * Fetch the embed player with the apiUrl and return the canonical url (like the permalink_url from the json api).
      *
      * @return the url resolved
      */
@@ -92,7 +93,7 @@ public class SoundcloudParsingHelper {
     }
 
     /**
-     * Fetch the embed player with the url and return the id (like the id from the json api).<br/>
+     * Fetch the embed player with the url and return the id (like the id from the json api).
      *
      * @return the id resolved
      */

--- a/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -12,9 +12,9 @@ public class Utils {
 
     /**
      * Remove all non-digit characters from a string.<p>
-     * Examples:<br/>
-     * <ul><li>1 234 567 views -> 1234567</li>
-     * <li>$31,133.124 -> 31133124</li></ul>
+     * Examples:<p>
+     * <ul><li>1 234 567 views -&gt; 1234567</li>
+     * <li>$31,133.124 -&gt; 31133124</li></ul>
      *
      * @param toRemove string to remove non-digit chars
      * @return a string that contains only digits


### PR DESCRIPTION
As discussed in #34 Javadocs can be useful. I've created the Travis configuration so that it deploys the Javadocs the the projects github page. To allow deployment an access token as the environment variable `GITHUB_TOKEN`  needs to be registered in [travis](https://travis-ci.org/TeamNewPipe/NewPipeExtractor/settings) as described in the [documentation](https://docs.travis-ci.com/user/deployment/pages/). 

I've run it on my fork and it would look like this: https://coffeemakr.github.io/NewPipeExtractor/javadoc/

Note: It won't work until all tests are fixed (e.g. with #48)