### PR TITLE
Fast tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 .idea
 local.properties
 out/
+*.iml
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.ListExtractor;
@@ -16,10 +16,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 
 public class SoundcloudChannelExtractorTest {
 
-    ChannelExtractor extractor;
+    static ChannelExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = SoundCloud.getService()
                 .getChannelExtractor("https://soundcloud.com/liluzivert");

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -19,10 +19,10 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
  */
 public class SoundcloudChartsExtractorTest {
 
-    KioskExtractor extractor;
+    static KioskExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = SoundCloud.getService()
                 .getKioskList()

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsUrlIdHandlerTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsUrlIdHandlerTest.java
@@ -4,7 +4,7 @@ import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -13,10 +13,10 @@ import org.schabi.newpipe.extractor.NewPipe;
  * Test for {@link SoundcloudChartsUrlIdHandler}
  */
 public class SoundcloudChartsUrlIdHandlerTest {
-    private SoundcloudChartsUrlIdHandler urlIdHandler;
+    private static SoundcloudChartsUrlIdHandler urlIdHandler;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         urlIdHandler = new SoundcloudChartsUrlIdHandler();
         NewPipe.init(Downloader.getInstance());
     }

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -15,10 +15,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  */
 
 public class SoundcloudPlaylistExtractorTest {
-    private PlaylistExtractor extractor;
+    private static PlaylistExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = SoundCloud.getService()
                 .getPlaylistExtractor("https://soundcloud.com/liluzivert/sets/the-perfect-luv-tape-r");

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineAllTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineAllTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -17,10 +17,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link SearchEngine}
  */
 public class SoundcloudSearchEngineAllTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = SoundCloud.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineChannelTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineChannelTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -16,10 +16,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link SearchEngine}
  */
 public class SoundcloudSearchEngineChannelTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = SoundCloud.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEnginePlaylistTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEnginePlaylistTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -37,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link SearchEngine}
  */
 public class SoundcloudSearchEnginePlaylistTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = SoundCloud.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineStreamTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSearchEngineStreamTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -16,10 +16,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link SearchEngine}
  */
 public class SoundcloudSearchEngineStreamTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = SoundCloud.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -1,11 +1,9 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import com.grack.nanojson.JsonParserException;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.Subtitles;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
@@ -14,7 +12,6 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.SubtitlesFormat;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
@@ -23,10 +20,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link StreamExtractor}
  */
 public class SoundcloudStreamExtractorDefaultTest {
-    private SoundcloudStreamExtractor extractor;
+    private static SoundcloudStreamExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (SoundcloudStreamExtractor) SoundCloud.getService().getStreamExtractor("https://soundcloud.com/liluzivert/do-what-i-want-produced-by-maaly-raw-don-cannon");
         extractor.fetchPage();

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamUrlIdHandlerTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamUrlIdHandlerTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -15,10 +15,10 @@ import static org.junit.Assert.*;
  * Test for {@link SoundcloudStreamUrlIdHandler}
  */
 public class SoundcloudStreamUrlIdHandlerTest {
-    private SoundcloudStreamUrlIdHandler urlIdHandler;
+    private static SoundcloudStreamUrlIdHandler urlIdHandler;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         urlIdHandler = SoundcloudStreamUrlIdHandler.getInstance();
         NewPipe.init(Downloader.getInstance());
     }

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSuggestionExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSuggestionExtractorTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -16,10 +16,10 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link SuggestionExtractor}
  */
 public class SoundcloudSuggestionExtractorTest {
-    private SuggestionExtractor suggestionExtractor;
+    private static SuggestionExtractor suggestionExtractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         suggestionExtractor = SoundCloud.getService().getSuggestionExtractor();
     }

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -1,13 +1,12 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 
-import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmptyErrors;
@@ -38,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  */
 public class YoutubeChannelExtractorTest {
 
-    YoutubeChannelExtractor extractor;
+    static YoutubeChannelExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (YoutubeChannelExtractor) YouTube.getService()
                 .getChannelExtractor("https://www.youtube.com/user/Gronkh");

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -1,11 +1,10 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.util.List;
@@ -18,15 +17,15 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link YoutubePlaylistExtractor}
  */
 public class YoutubePlaylistExtractorTest {
-    private YoutubePlaylistExtractor extractor;
+    private static YoutubePlaylistExtractor extractor;
 
     private static void assertNotEmpty(String message, String value) {
         assertNotNull(message, value);
         assertFalse(message, value.isEmpty());
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (YoutubePlaylistExtractor) YouTube.getService()
                 .getPlaylistExtractor("https://www.youtube.com/playlist?list=PL7XlqX4npddfrdpMCxBnNZXg2GFll7t5y");

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineChannelTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineChannelTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -37,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link SearchEngine}
  */
 public class YoutubeSearchEngineChannelTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = YouTube.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEnginePlaylistTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEnginePlaylistTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -37,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link SearchEngine}
  */
 public class YoutubeSearchEnginePlaylistTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = YouTube.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineStreamTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineStreamTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -37,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link SearchEngine}
  */
 public class YoutubeSearchEngineStreamTest {
-    private SearchResult result;
+    private static SearchResult result;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         SearchEngine engine = YouTube.getService().getSearchEngine();
 

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeServiceTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeServiceTest.java
@@ -20,7 +20,7 @@ package org.schabi.newpipe.extractor.services.youtube;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -35,11 +35,11 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link YoutubeService}
  */
 public class YoutubeServiceTest {
-    StreamingService service;
-    KioskList kioskList;
+    static StreamingService service;
+    static KioskList kioskList;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         service = YouTube.getService();
         kioskList = service.getKioskList();

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorDefaultTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorDefaultTest.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import com.grack.nanojson.JsonParserException;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -11,7 +10,6 @@ import org.schabi.newpipe.extractor.stream.*;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
@@ -41,10 +39,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  */
 public class YoutubeStreamExtractorDefaultTest {
     public static final String HTTPS = "https://";
-    private YoutubeStreamExtractor extractor;
+    private static YoutubeStreamExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (YoutubeStreamExtractor) YouTube.getService()
                 .getStreamExtractor("https://www.youtube.com/watch?v=rYEDA3JcQqw");

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorRestrictedTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorRestrictedTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
@@ -21,10 +21,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  */
 public class YoutubeStreamExtractorRestrictedTest {
     public static final String HTTPS = "https://";
-    private YoutubeStreamExtractor extractor;
+    private static YoutubeStreamExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (YoutubeStreamExtractor) YouTube.getService()
                 .getStreamExtractor("https://www.youtube.com/watch?v=i6JTvzrpBy0");

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandlerTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandlerTest.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -17,10 +17,10 @@ import static org.junit.Assert.*;
  */
 public class YoutubeStreamUrlIdHandlerTest {
     private static String AD_URL = "https://googleads.g.doubleclick.net/aclk?sa=l&ai=C-2IPgeVTWPf4GcOStgfOnIOADf78n61GvKmmobYDrgIQASDj-5MDKAJg9ZXOgeAEoAGgy_T-A8gBAakC2gkpmquIsT6oAwGqBJMBT9BgD5kVgbN0dX602bFFaDw9vsxq-We-S8VkrXVBi6W_e7brZ36GCz1WO3EPEeklYuJjXLUowwCOKsd-8xr1UlS_tusuFJv9iX35xoBHKTRvs8-0aDbfEIm6in37QDfFuZjqgEMB8-tg0Jn_Pf1RU5OzbuU40B4Gy25NUTnOxhDKthOhKBUSZEksCEerUV8GMu10iAXCxquwApIFBggDEAEYAaAGGsgGlIjthrUDgAfItIsBqAemvhvYBwHSCAUIgGEQAbgT6AE&num=1&sig=AOD64_1DybDd4qAm5O7o9UAbTNRdqXXHFQ&ctype=21&video_id=dMO_IXYPZew&client=ca-pub-6219811747049371&adurl=http://www.youtube.com/watch%3Fv%3DdMO_IXYPZew";
-    private YoutubeStreamUrlIdHandler urlIdHandler;
+    private static YoutubeStreamUrlIdHandler urlIdHandler;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         urlIdHandler = YoutubeStreamUrlIdHandler.getInstance();
         NewPipe.init(Downloader.getInstance());
     }

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSuggestionExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSuggestionExtractorTest.java
@@ -20,7 +20,7 @@ package org.schabi.newpipe.extractor.services.youtube;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -36,10 +36,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link SuggestionExtractor}
  */
 public class YoutubeSuggestionExtractorTest {
-    private SuggestionExtractor suggestionExtractor;
+    private static SuggestionExtractor suggestionExtractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         suggestionExtractor = YouTube.getService().getSuggestionExtractor();
     }

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTreindingKioskInfoTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTreindingKioskInfoTest.java
@@ -1,26 +1,26 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-/*
- * Created by Christian Schabesberger on 12.08.17.
- *
- * Copyright (C) Christian Schabesberger 2017 <chris.schabesberger@mailbox.org>
- * YoutubeTreindingKioskInfoTest.java is part of NewPipe.
- *
- * NewPipe is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * NewPipe is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
- */
+        /*
+         * Created by Christian Schabesberger on 12.08.17.
+         *
+         * Copyright (C) Christian Schabesberger 2017 <chris.schabesberger@mailbox.org>
+         * YoutubeTreindingKioskInfoTest.java is part of NewPipe.
+         *
+         * NewPipe is free software: you can redistribute it and/or modify
+         * it under the terms of the GNU General Public License as published by
+         * the Free Software Foundation, either version 3 of the License, or
+         * (at your option) any later version.
+         *
+         * NewPipe is distributed in the hope that it will be useful,
+         * but WITHOUT ANY WARRANTY; without even the implied warranty of
+         * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+         * GNU General Public License for more details.
+         *
+         * You should have received a copy of the GNU General Public License
+         * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+         */
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -37,10 +37,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link KioskInfo}
  */
 public class YoutubeTreindingKioskInfoTest {
-    KioskInfo kioskInfo;
+    static KioskInfo kioskInfo;
 
-    @Before
-    public void setUp()
+    @BeforeClass
+    public static void setUp()
             throws Exception {
         NewPipe.init(Downloader.getInstance());
         StreamingService service = YouTube.getService();

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractorTest.java
@@ -20,7 +20,7 @@ package org.schabi.newpipe.extractor.services.youtube;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -40,10 +40,10 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  */
 public class YoutubeTrendingExtractorTest {
 
-    YoutubeTrendingExtractor extractor;
+    static YoutubeTrendingExtractor extractor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance());
         extractor = (YoutubeTrendingExtractor) YouTube.getService()
                 .getKioskList()

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingUrlIdHandlerTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingUrlIdHandlerTest.java
@@ -20,7 +20,7 @@ package org.schabi.newpipe.extractor.services.youtube;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -36,10 +36,10 @@ import static org.junit.Assert.assertTrue;
  * Test for {@link YoutubeTrendingUrlIdHandler}
  */
 public class YoutubeTrendingUrlIdHandlerTest {
-    private UrlIdHandler urlIdHandler;
+    private static UrlIdHandler urlIdHandler;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         urlIdHandler = YouTube.getService().getKioskList().getUrlIdHandlerByType("Trending");
         NewPipe.init(Downloader.getInstance());
     }


### PR DESCRIPTION
Heya,

Looks like tests were using `@Before` instead of `@BeforeClass` to initialize static things.  In reality, `@Before` runs before each test, and `@BeforeClass` runs before all tests. 

This reduced tests from taking 2 min 9 seconds on my machine to 15.49 seconds