### PR TITLE
Fix channel info item collector

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemCollector.java
+++ b/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemCollector.java
@@ -35,7 +35,7 @@ public class ChannelInfoItemCollector extends InfoItemCollector<ChannelInfoItem,
         String name = extractor.getName();
         String  url = extractor.getUrl();
 
-        ChannelInfoItem resultItem = new ChannelInfoItem(serviceId, name, url);
+        ChannelInfoItem resultItem = new ChannelInfoItem(serviceId, url, name);
 
 
         // optional information

--- a/src/test/java/org/schabi/newpipe/extractor/ExtractorAsserts.java
+++ b/src/test/java/org/schabi/newpipe/extractor/ExtractorAsserts.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.extractor;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 public class ExtractorAsserts {
@@ -9,6 +11,14 @@ public class ExtractorAsserts {
                 message += "\n  * " + throwable.getMessage();
             }
             throw new AssertionError(message, errors.get(0));
+        }
+    }
+
+    public static void assertIsValidUrl(String url) {
+        try {
+            new URL(url);
+        } catch (MalformedURLException e) {
+            throw new AssertionError("Invalid url: " + url, e);
         }
     }
 }

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineAllTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineAllTest.java
@@ -4,12 +4,18 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.Downloader;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.search.SearchResult;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsValidUrl;
 
 /*
  * Created by Christian Schabesberger on 29.12.15.
@@ -42,16 +48,27 @@ public class YoutubeSearchEngineAllTest {
         NewPipe.init(Downloader.getInstance());
         YoutubeSearchEngine engine = new YoutubeSearchEngine(1);
 
-        // Youtube will suggest "asdf" instead of "asdgff"
-        // keep in mind that the suggestions can change by country (the parameter "de")
-        result = engine.search("asdgff", 0, "de", SearchEngine.Filter.ANY)
+        result = engine.search("pewdiepie", 0, "de", SearchEngine.Filter.ANY)
                 .getSearchResult();
     }
 
     @Test
     public void testResultList() {
-        System.out.println("Results: " + result.getResults());
-        assertFalse("Results are empty: " + result.resultList, result.resultList.isEmpty());
+        final List<InfoItem> results = result.getResults();
+        System.out.println("Results: " + results);
+        assertFalse("Results are empty: " + results, results.isEmpty());
+
+        InfoItem firstInfoItem = results.get(0);
+
+        // THe channel should be the first item
+        assertTrue(firstInfoItem instanceof ChannelInfoItem);
+        assertEquals("name", "PewDiePie", firstInfoItem.name);
+        assertEquals("url","https://www.youtube.com/user/PewDiePie", firstInfoItem.url);
+
+        for(InfoItem item: results) {
+            assertIsValidUrl(item.url);
+        }
+
     }
 
     @Test

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineChannelTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineChannelTest.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.search.SearchResult;
 
 import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsValidUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 
@@ -53,6 +54,9 @@ public class YoutubeSearchEngineChannelTest {
     @Test
     public void testResultList() {
         assertFalse(result.resultList.isEmpty());
+        for(InfoItem item: result.getResults()) {
+            assertIsValidUrl(item.url);
+        }
     }
 
     @Test

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEnginePlaylistTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEnginePlaylistTest.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.search.SearchResult;
 
 import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsValidUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 
@@ -53,6 +54,9 @@ public class YoutubeSearchEnginePlaylistTest {
     @Test
     public void testResultList() {
         assertFalse(result.resultList.isEmpty());
+        for(InfoItem item: result.getResults()) {
+            assertIsValidUrl(item.url);
+        }
     }
 
     @Test

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineStreamTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineStreamTest.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.search.SearchResult;
 
 import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsValidUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 
@@ -53,6 +54,9 @@ public class YoutubeSearchEngineStreamTest {
     @Test
     public void testResultList() {
         assertFalse(result.resultList.isEmpty());
+        for(InfoItem item: result.getResults()) {
+            assertIsValidUrl(item.url);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix for TeamNewPipe/NewPipe#901 and TeamNewPipe/NewPipe#905

* Fix switched url and name arguments
 * Add tests