### PR TITLE
Age-gated Video Info Retrieval Fix

### DIFF
--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorRestrictedTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractorRestrictedTest.java
@@ -12,6 +12,8 @@ import org.schabi.newpipe.extractor.stream.SubtitlesFormat;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
@@ -103,7 +105,12 @@ public class YoutubeStreamExtractorRestrictedTest {
 
     @Test
     public void testGetVideoStreams() throws IOException, ExtractionException {
-        for (VideoStream s : extractor.getVideoStreams()) {
+        List<VideoStream> streams = new ArrayList<>();
+        streams.addAll(extractor.getVideoStreams());
+        streams.addAll(extractor.getVideoOnlyStreams());
+
+        assertTrue(streams.size() > 0);
+        for (VideoStream s : streams) {
             assertTrue(s.getUrl(),
                     s.getUrl().contains(HTTPS));
             assertTrue(s.resolution.length() > 0);


### PR DESCRIPTION
This fix is a reprint of the method used in [youtube-dl](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/youtube.py#L1519). Should also fix gated videos that weren't accessible before the "Content Not Available" errors.

_Shameless plug_: I've also made an attempt to [integrate youtube-dl with Newpipe](https://github.com/karyogamy/NewPipe/tree/youtubedl_integration). Though it kind of worked, it didn't go too well. If anybody is interested, I can create a PR (not to be merged) and give some details. 