### PR TITLE
Fix channel extractor error

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
+++ b/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
@@ -57,7 +57,7 @@ public class ChannelInfo extends ListInfo {
     public static ChannelInfo getInfo(StreamingService service, String url) throws IOException, ExtractionException {
         ChannelExtractor extractor = service.getChannelExtractor(url);
         extractor.fetchPage();
-        return getInfo(service.getChannelExtractor(url));
+        return getInfo(extractor);
     }
 
     public static ChannelInfo getInfo(ChannelExtractor extractor) throws ParsingException {


### PR DESCRIPTION
getInfo is using a new extractor instead of using the loaded extractor, which later causes NPE.