### PR TITLE
Playlist Info Fix

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
+++ b/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
@@ -48,7 +48,7 @@ public class PlaylistInfo extends ListInfo {
         String url = extractor.getCleanUrl();
         String id = extractor.getId();
         String name = extractor.getName();
-        PlaylistInfo info = new PlaylistInfo(serviceId, url, id, name);
+        PlaylistInfo info = new PlaylistInfo(serviceId, id, url, name);
 
         try {
             info.setStreamCount(extractor.getStreamCount());


### PR DESCRIPTION
Fixed incorrect order of inputs on playlist info construction, swapping id and url when used later.