### PR TITLE
Parse the upload dates of StreamInfoItems.

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/Extractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/Extractor.java
@@ -7,12 +7,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-public abstract class Extractor {
+public abstract class Extractor<S extends StreamingService> {
     /**
      * {@link StreamingService} currently related to this extractor.<br/>
      * Useful for getting other things from a service (like the url handlers for cleaning/accepting/get id from urls).
      */
-    private final StreamingService service;
+    private final S service;
 
     /**
      * Dirty/original url that was passed in the constructor.
@@ -36,7 +36,7 @@ public abstract class Extractor {
     private boolean pageFetched = false;
     private final Downloader downloader;
 
-    public Extractor(StreamingService service, String url) throws ExtractionException {
+    public Extractor(S service, String url) throws ExtractionException {
         if(service == null) throw new NullPointerException("service is null");
         if(url == null) throw new NullPointerException("url is null");
         this.service = service;
@@ -113,7 +113,7 @@ public abstract class Extractor {
     }
 
     @Nonnull
-    public StreamingService getService() {
+    public S getService() {
         return service;
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/ListExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/ListExtractor.java
@@ -10,13 +10,13 @@ import java.util.List;
 /**
  * Base class to extractors that have a list (e.g. playlists, users).
  */
-public abstract class ListExtractor extends Extractor {
+public abstract class ListExtractor<S extends StreamingService> extends Extractor<S> {
     protected String nextStreamsUrl;
 
     /**
      * Get a new ListExtractor with the given nextStreamsUrl set.
      */
-    public ListExtractor(StreamingService service, String url, String nextStreamsUrl) throws ExtractionException {
+    public ListExtractor(S service, String url, String nextStreamsUrl) throws ExtractionException {
         super(service, url);
         setNextStreamsUrl(nextStreamsUrl);
     }

--- a/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
@@ -29,9 +29,9 @@ import java.io.IOException;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public abstract class ChannelExtractor extends ListExtractor {
+public abstract class ChannelExtractor<S extends StreamingService> extends ListExtractor<S> {
 
-    public ChannelExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public ChannelExtractor(S service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/kiosk/KioskExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/kiosk/KioskExtractor.java
@@ -28,11 +28,11 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
-public abstract class KioskExtractor extends ListExtractor {
+public abstract class KioskExtractor<S extends StreamingService> extends ListExtractor<S> {
     private String contentCountry = null;
     private final String id;
 
-    public KioskExtractor(StreamingService streamingService,
+    public KioskExtractor(S streamingService,
                           String url,
                           String nextStreamsUrl,
                           String kioskId)

--- a/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -9,9 +9,9 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
-public abstract class PlaylistExtractor extends ListExtractor {
+public abstract class PlaylistExtractor<S extends StreamingService> extends ListExtractor<S> {
 
-    public PlaylistExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public PlaylistExtractor(S service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
@@ -3,23 +3,23 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.schabi.newpipe.extractor.Downloader;
-import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+
 @SuppressWarnings("WeakerAccess")
-public class SoundcloudChannelExtractor extends ChannelExtractor {
+public class SoundcloudChannelExtractor extends ChannelExtractor<SoundcloudService> {
     private String userId;
     private JsonObject user;
 
-    public SoundcloudChannelExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public SoundcloudChannelExtractor(SoundcloudService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractor.java
@@ -1,23 +1,22 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-
 import org.schabi.newpipe.extractor.Downloader;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.UrlIdHandler;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
-public class SoundcloudChartsExtractor extends KioskExtractor {
+public class SoundcloudChartsExtractor extends KioskExtractor<SoundcloudService> {
 	private String url;
 
-    public SoundcloudChartsExtractor(StreamingService service, String url, String nextStreamsUrl, String kioskId)
+    public SoundcloudChartsExtractor(SoundcloudService service, String url, String nextStreamsUrl, String kioskId)
             throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl, kioskId);
         this.url = url;

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -45,21 +45,20 @@ public class SoundcloudParsingHelper {
         return clientId = Parser.matchGroup1(",client_id:\"(.*?)\"", js);
     }
 
-    public static String toDateString(String time) throws ParsingException {
+    static Date parseDate(String time) throws ParsingException {
         try {
-            Date date;
-            // Have two date formats, one for the 'api.soundc...' and the other 'api-v2.soundc...'.
+            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(time);
+        } catch (ParseException e1) {
             try {
-                date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(time);
-            } catch (Exception e) {
-                date = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss +0000").parse(time);
+                return new SimpleDateFormat("yyyy/MM/dd HH:mm:ss +0000").parse(time);
+            } catch (ParseException e2) {
+                throw new ParsingException(e1.getMessage(), e2);
             }
-
-            SimpleDateFormat newDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-            return newDateFormat.format(date);
-        } catch (ParseException e) {
-            throw new ParsingException(e.getMessage(), e);
         }
+    }
+
+    static String toTextualDate(String time) throws ParsingException {
+        return new SimpleDateFormat("yyyy-MM-dd").format(parseDate(time));
     }
 
     /**

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -3,22 +3,23 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.schabi.newpipe.extractor.Downloader;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+
 @SuppressWarnings("WeakerAccess")
-public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
+public class SoundcloudPlaylistExtractor extends PlaylistExtractor<SoundcloudService> {
     private String playlistId;
     private JsonObject playlist;
 
-    public SoundcloudPlaylistExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public SoundcloudPlaylistExtractor(SoundcloudService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -66,7 +66,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor<SoundcloudService
     @Nonnull
     @Override
     public String getUploadDate() throws ParsingException {
-        return SoundcloudParsingHelper.toDateString(track.getString("created_at"));
+        return SoundcloudParsingHelper.toTextualDate(track.getString("created_at"));
     }
 
     @Nonnull

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -3,23 +3,35 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
-import org.schabi.newpipe.extractor.*;
+
+import org.schabi.newpipe.extractor.Downloader;
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.Subtitles;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.stream.*;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.SubtitlesFormat;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-public class SoundcloudStreamExtractor extends StreamExtractor {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SoundcloudStreamExtractor extends StreamExtractor<SoundcloudService> {
     private JsonObject track;
 
-    public SoundcloudStreamExtractor(StreamingService service, String url) throws IOException, ExtractionException {
+    public SoundcloudStreamExtractor(SoundcloudService service, String url) throws IOException, ExtractionException {
         super(service, url);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -43,12 +43,18 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
 
     @Override
     public String getTextualUploadDate() throws ParsingException {
-        return SoundcloudParsingHelper.toDateString(searchResult.getString("created_at"));
+        return SoundcloudParsingHelper.toTextualDate(getCreatedAt());
     }
 
     @Override
     public Calendar getUploadDate() throws ParsingException {
-        throw new ParsingException("SoundcloudStreamInfoItemExtractor.getUploadDate() not implemented.");
+        Calendar uploadTime = Calendar.getInstance();
+        uploadTime.setTime(SoundcloudParsingHelper.parseDate(getCreatedAt()));
+        return uploadTime;
+    }
+
+    private String getCreatedAt() {
+        return searchResult.getString("created_at");
     }
 
     @Override

--- a/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -1,9 +1,12 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
 import com.grack.nanojson.JsonObject;
+
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
+
+import java.util.Calendar;
 
 public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
@@ -39,8 +42,13 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
     }
 
     @Override
-    public String getUploadDate() throws ParsingException {
+    public String getTextualUploadDate() throws ParsingException {
         return SoundcloudParsingHelper.toDateString(searchResult.getString("created_at"));
+    }
+
+    @Override
+    public Calendar getUploadDate() throws ParsingException {
+        throw new ParsingException("SoundcloudStreamInfoItemExtractor.getUploadDate() not implemented.");
     }
 
     @Override

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
@@ -4,22 +4,24 @@ package org.schabi.newpipe.extractor.services.youtube;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.schabi.newpipe.extractor.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
+
+import javax.annotation.Nonnull;
 
 /*
  * Created by Christian Schabesberger on 25.07.16.
@@ -42,9 +44,11 @@ import java.io.IOException;
  */
 
 @SuppressWarnings("WeakerAccess")
-public class YoutubeChannelExtractor extends ChannelExtractor {
+public class YoutubeChannelExtractor extends ChannelExtractor<YoutubeService> {
     private static final String CHANNEL_FEED_BASE = "https://www.youtube.com/feeds/videos.xml?channel_id=";
     private static final String CHANNEL_URL_PARAMETERS = "/videos?view=0&flow=list&sort=dd&live_view=10000";
+
+    private final TimeAgoParser timeAgoParser = getService().getTimeAgoParser();
 
     private Document doc;
     /**
@@ -60,7 +64,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
      */
     private boolean fetchingNextStreams;
 
-    public YoutubeChannelExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public YoutubeChannelExtractor(YoutubeService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
 
         fetchingNextStreams = nextStreamsUrl != null && !nextStreamsUrl.isEmpty();
@@ -226,7 +230,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         final String uploaderUrl = getCleanUrl();
         for (final Element li : element.children()) {
             if (li.select("div[class=\"feed-item-dismissable\"]").first() != null) {
-                collector.commit(new YoutubeStreamInfoItemExtractor(li) {
+                collector.commit(new YoutubeStreamInfoItemExtractor(li, timeAgoParser) {
                     @Override
                     public String getUrl() throws ParsingException {
                         try {

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractor.java
@@ -16,6 +16,7 @@ import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
@@ -25,6 +26,8 @@ import javax.annotation.Nonnull;
 
 @SuppressWarnings("WeakerAccess")
 public class YoutubePlaylistExtractor extends PlaylistExtractor<YoutubeService> {
+
+    private final TimeAgoParser timeAgoParser = getService().getTimeAgoParser();
 
     private Document doc;
     /**
@@ -206,7 +209,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor<YoutubeService> 
                 continue;
             }
 
-            collector.commit(new YoutubeStreamInfoItemExtractor(li, null) {
+            collector.commit(new YoutubeStreamInfoItemExtractor(li, timeAgoParser) {
                 public Element uploaderLink;
 
                 @Override

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractor.java
@@ -3,12 +3,12 @@ package org.schabi.newpipe.extractor.services.youtube;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.schabi.newpipe.extractor.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.UrlIdHandler;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -19,11 +19,12 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+
 @SuppressWarnings("WeakerAccess")
-public class YoutubePlaylistExtractor extends PlaylistExtractor {
+public class YoutubePlaylistExtractor extends PlaylistExtractor<YoutubeService> {
 
     private Document doc;
     /**
@@ -31,7 +32,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
      */
     private Document nextStreamsAjax;
 
-    public YoutubePlaylistExtractor(StreamingService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
+    public YoutubePlaylistExtractor(YoutubeService service, String url, String nextStreamsUrl) throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl);
     }
 
@@ -205,7 +206,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                 continue;
             }
 
-            collector.commit(new YoutubeStreamInfoItemExtractor(li) {
+            collector.commit(new YoutubeStreamInfoItemExtractor(li, null) {
                 public Element uploaderLink;
 
                 @Override
@@ -269,7 +270,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                 }
 
                 @Override
-                public String getUploadDate() throws ParsingException {
+                public String getTextualUploadDate() throws ParsingException {
                     return "";
                 }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
@@ -107,7 +107,7 @@ public class YoutubeSearchEngine extends SearchEngine {
 
                 // video item type
             } else if ((el = item.select("div[class*=\"yt-lockup-video\"]").first()) != null) {
-                collector.commit(new YoutubeStreamInfoItemExtractor(el));
+                collector.commit(new YoutubeStreamInfoItemExtractor(el, null));
             } else if ((el = item.select("div[class*=\"yt-lockup-channel\"]").first()) != null) {
                 collector.commit(new YoutubeChannelInfoItemExtractor(el));
             } else if ((el = item.select("div[class*=\"yt-lockup-playlist\"]").first()) != null &&

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
@@ -8,6 +8,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.search.InfoItemSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchEngine;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -38,8 +39,11 @@ public class YoutubeSearchEngine extends SearchEngine {
     private static final String TAG = YoutubeSearchEngine.class.toString();
     public static final String CHARSET_UTF_8 = "UTF-8";
 
-    public YoutubeSearchEngine(int serviceId) {
+    private final TimeAgoParser timeAgoParser;
+
+    public YoutubeSearchEngine(int serviceId, TimeAgoParser timeAgoParser) {
         super(serviceId);
+        this.timeAgoParser = timeAgoParser;
     }
 
     @Override
@@ -107,7 +111,7 @@ public class YoutubeSearchEngine extends SearchEngine {
 
                 // video item type
             } else if ((el = item.select("div[class*=\"yt-lockup-video\"]").first()) != null) {
-                collector.commit(new YoutubeStreamInfoItemExtractor(el, null));
+                collector.commit(new YoutubeStreamInfoItemExtractor(el, timeAgoParser));
             } else if ((el = item.select("div[class*=\"yt-lockup-channel\"]").first()) != null) {
                 collector.commit(new YoutubeChannelInfoItemExtractor(el));
             } else if ((el = item.select("div[class*=\"yt-lockup-playlist\"]").first()) != null &&

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -13,6 +13,8 @@ import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 
 import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
 
 
 /*
@@ -37,13 +39,15 @@ import java.io.IOException;
 
 public class YoutubeService extends StreamingService {
 
+    private Map<TimeAgoParser.TimeAgoUnit, String[]> timeAgoParserPhrases;
+
     public YoutubeService(int id, String name) {
         super(id, name);
     }
 
     @Override
     public SearchEngine getSearchEngine() {
-        return new YoutubeSearchEngine(getServiceId());
+        return new YoutubeSearchEngine(getServiceId(), getTimeAgoParser());
     }
 
     @Override
@@ -105,11 +109,35 @@ public class YoutubeService extends StreamingService {
     }
 
     /**
+     * Sets the phrases used to parse upload date in the format '2 days ago'.
+     * @param secondsPhrases How to recognize seconds
+     * @param minutesPhrases How to recognize minutes
+     * @param hoursPhrases   How to recognize hours
+     * @param daysPhrases    How to recognize days
+     * @param weeksPhrases   How to recognize weeks
+     * @param monthsPhrases  How to recognize months
+     * @param yearsPhrases   How to recognize years
+     */
+    public void setTimeAgoParserPhrases(String[] secondsPhrases, String[] minutesPhrases,
+                                        String[] hoursPhrases, String[] daysPhrases,
+                                        String[] weeksPhrases, String[] monthsPhrases,
+                                        String[] yearsPhrases) {
+        timeAgoParserPhrases = new EnumMap<>(TimeAgoParser.TimeAgoUnit.class);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.SECONDS, secondsPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.MINUTES, minutesPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.HOURS, hoursPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.DAYS, daysPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.WEEKS, weeksPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.MONTHS, monthsPhrases);
+        timeAgoParserPhrases.put(TimeAgoParser.TimeAgoUnit.YEARS, yearsPhrases);
+
+    }
+
+    /**
      * @return A helper to parse upload dates in the format '2 days ago'.
-     *
-     * TODO Introduce support for multiple languages.
      */
     TimeAgoParser getTimeAgoParser() {
-        return new TimeAgoParser(TimeAgoParser.DEFAULT_AGO_PHRASES);
+        return new TimeAgoParser(timeAgoParserPhrases == null ?
+                TimeAgoParser.DEFAULT_AGO_PHRASES : timeAgoParserPhrases);
     }
 }

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.kiosk.KioskList;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 
 import java.io.IOException;
 
@@ -101,5 +102,14 @@ public class YoutubeService extends StreamingService {
         }
 
         return list;
+    }
+
+    /**
+     * @return A helper to parse upload dates in the format '2 days ago'.
+     *
+     * TODO Introduce support for multiple languages.
+     */
+    TimeAgoParser getTimeAgoParser() {
+        return new TimeAgoParser(TimeAgoParser.DEFAULT_AGO_PHRASES);
     }
 }

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -4,6 +4,7 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -12,22 +13,32 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 import org.schabi.newpipe.extractor.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.Subtitles;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
-import org.schabi.newpipe.extractor.stream.*;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.Stream;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.SubtitlesFormat;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /*
  * Created by Christian Schabesberger on 06.08.15.
@@ -49,7 +60,7 @@ import java.util.regex.Pattern;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class YoutubeStreamExtractor extends StreamExtractor {
+public class YoutubeStreamExtractor extends StreamExtractor<YoutubeService> {
     private static final String TAG = YoutubeStreamExtractor.class.getSimpleName();
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -84,7 +95,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     private boolean isAgeRestricted;
 
-    public YoutubeStreamExtractor(StreamingService service, String url) throws IOException, ExtractionException {
+    public YoutubeStreamExtractor(YoutubeService service, String url) throws IOException, ExtractionException {
         super(service, url);
     }
 
@@ -801,7 +812,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      * This is encapsulated in a StreamInfoItem object, which is a subset of the fields in a full StreamInfo.
      */
     private StreamInfoItemExtractor extractVideoPreviewInfo(final Element li) {
-        return new YoutubeStreamInfoItemExtractor(li) {
+        return new YoutubeStreamInfoItemExtractor(li, null) {
 
             @Override
             public String getUrl() throws ParsingException {
@@ -828,7 +839,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             }
 
             @Override
-            public String getUploadDate() throws ParsingException {
+            public String getTextualUploadDate() throws ParsingException {
                 return "";
             }
 

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.SubtitlesFormat;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -86,6 +87,8 @@ public class YoutubeStreamExtractor extends StreamExtractor<YoutubeService> {
     }
 
     /*//////////////////////////////////////////////////////////////////////////*/
+
+    private final TimeAgoParser timeAgoParser = getService().getTimeAgoParser();
 
     private Document doc;
     @Nullable
@@ -812,7 +815,7 @@ public class YoutubeStreamExtractor extends StreamExtractor<YoutubeService> {
      * This is encapsulated in a StreamInfoItem object, which is a subset of the fields in a full StreamInfo.
      */
     private StreamInfoItemExtractor extractVideoPreviewInfo(final Element li) {
-        return new YoutubeStreamInfoItemExtractor(li, null) {
+        return new YoutubeStreamInfoItemExtractor(li, timeAgoParser) {
 
             @Override
             public String getUrl() throws ParsingException {

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractor.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 
 import java.io.IOException;
 
@@ -38,7 +39,7 @@ import javax.annotation.Nonnull;
 
 public class YoutubeTrendingExtractor extends KioskExtractor<YoutubeService> {
 
-
+    private final TimeAgoParser timeAgoParser = getService().getTimeAgoParser();
 
     private Document doc;
 
@@ -91,7 +92,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<YoutubeService> {
         for(Element ul : uls) {
             for(final Element li : ul.children()) {
                 final Element el = li.select("div[class*=\"yt-lockup-dismissable\"]").first();
-                collector.commit(new YoutubeStreamInfoItemExtractor(li, null) {
+                collector.commit(new YoutubeStreamInfoItemExtractor(li, timeAgoParser) {
                     @Override
                     public String getUrl() throws ParsingException {
                         try {

--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeTrendingExtractor.java
@@ -24,20 +24,25 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.schabi.newpipe.extractor.*;
+import org.schabi.newpipe.extractor.Downloader;
+import org.schabi.newpipe.extractor.ListExtractor;
+import org.schabi.newpipe.extractor.UrlIdHandler;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
-public class YoutubeTrendingExtractor extends KioskExtractor {
+import javax.annotation.Nonnull;
+
+public class YoutubeTrendingExtractor extends KioskExtractor<YoutubeService> {
+
+
 
     private Document doc;
 
-    public YoutubeTrendingExtractor(StreamingService service, String url, String nextStreamsUrl, String kioskId)
+    public YoutubeTrendingExtractor(YoutubeService service, String url, String nextStreamsUrl, String kioskId)
             throws IOException, ExtractionException {
         super(service, url, nextStreamsUrl, kioskId);
     }
@@ -86,7 +91,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor {
         for(Element ul : uls) {
             for(final Element li : ul.children()) {
                 final Element el = li.select("div[class*=\"yt-lockup-dismissable\"]").first();
-                collector.commit(new YoutubeStreamInfoItemExtractor(li) {
+                collector.commit(new YoutubeStreamInfoItemExtractor(li, null) {
                     @Override
                     public String getUrl() throws ParsingException {
                         try {

--- a/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -36,11 +36,11 @@ import java.util.List;
 /**
  * Scrapes information from a video streaming service (eg, YouTube).
  */
-public abstract class StreamExtractor extends Extractor {
+public abstract class StreamExtractor<S extends StreamingService> extends Extractor<S> {
 
     public static final int NO_AGE_LIMIT = 0;
 
-    public StreamExtractor(StreamingService service, String url) throws IOException, ExtractionException {
+    public StreamExtractor(S service, String url) throws IOException, ExtractionException {
         super(service, url);
     }
 

--- a/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
+++ b/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
@@ -22,6 +22,8 @@ package org.schabi.newpipe.extractor.stream;
 
 import org.schabi.newpipe.extractor.InfoItem;
 
+import java.util.Calendar;
+
 /**
  * Info object for previews of unopened videos, eg search results, related videos
  */
@@ -29,7 +31,8 @@ public class StreamInfoItem extends InfoItem {
     public final StreamType stream_type;
 
     public String uploader_name;
-    public String upload_date;
+    private String textualUploadDate;
+    private Calendar uploadDate;
     public long view_count = -1;
     public long duration = -1;
 
@@ -56,8 +59,12 @@ public class StreamInfoItem extends InfoItem {
         return uploader_name;
     }
 
-    public String getUploadDate() {
-        return upload_date;
+    /**
+     * @return The original textual upload date as returned by the streaming service.
+     * @see #getUploadDate()
+     */
+    public String getTextualUploadDate() {
+        return textualUploadDate;
     }
 
     public long getViewCount() {
@@ -76,12 +83,24 @@ public class StreamInfoItem extends InfoItem {
         this.uploader_name = uploader_name;
     }
 
-    public void setUploadDate(String upload_date) {
-        this.upload_date = upload_date;
+    public void setTextualUploadDate(String upload_date) {
+        this.textualUploadDate = upload_date;
     }
 
     public void setViewCount(long view_count) {
         this.view_count = view_count;
+    }
+
+    /**
+     * @return The (approximated) date and time this item was uploaded or {@code null}.
+     * @see #getTextualUploadDate()
+     */
+    public Calendar getUploadDate() {
+        return uploadDate;
+    }
+
+    void setUploadDate(Calendar uploadDate) {
+        this.uploadDate = uploadDate;
     }
 
     @Override
@@ -89,7 +108,7 @@ public class StreamInfoItem extends InfoItem {
         return "StreamInfoItem{" +
                 "stream_type=" + stream_type +
                 ", uploader_name='" + uploader_name + '\'' +
-                ", upload_date='" + upload_date + '\'' +
+                ", textualUploadDate='" + textualUploadDate + '\'' +
                 ", view_count=" + view_count +
                 ", duration=" + duration +
                 ", uploaderUrl='" + uploaderUrl + '\'' +

--- a/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemCollector.java
+++ b/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemCollector.java
@@ -61,8 +61,13 @@ public class StreamInfoItemCollector extends InfoItemCollector<StreamInfoItem, S
             addError(e);
         }
         try {
-            resultItem.setUploadDate(extractor.getUploadDate());
+            resultItem.setTextualUploadDate(extractor.getTextualUploadDate());
         } catch (Exception e) {
+            addError(e);
+        }
+        try {
+            resultItem.setUploadDate(extractor.getUploadDate());
+        } catch (ParsingException e) {
             addError(e);
         }
         try {

--- a/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
@@ -3,6 +3,8 @@ package org.schabi.newpipe.extractor.stream;
 import org.schabi.newpipe.extractor.InfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
+import java.util.Calendar;
+
 /*
  * Created by Christian Schabesberger on 28.02.16.
  *
@@ -64,10 +66,28 @@ public interface StreamInfoItemExtractor extends InfoItemExtractor {
     String getUploaderUrl() throws ParsingException;
 
     /**
-     * Extract the uploader name
-     * @return the uploader name
-     * @throws ParsingException thrown if there is an error in the extraction
+     * Extract the textual upload date of this item.
+     * The original textual date provided by the service may be used if it is short;
+     * otherwise the format "yyyy-MM-dd" or an locale specific version is preferred.
+     *
+     * @return The original textual upload date.
+     * @throws ParsingException if there is an error in the extraction
+     * @see #getUploadDate()
      */
-    String getUploadDate() throws ParsingException;
+    String getTextualUploadDate() throws ParsingException;
+
+    /**
+     * Extracts the upload date and time of this item and parses it.
+     * <p>
+     *     If the service doesn't provide an exact time, an approximation can be returned.
+     *     If the service doesn't provide any date at all, then {@code null} should be returned.
+     * </p>
+     *
+     * @return The (approximated) date and time this item was uploaded or {@code null}.
+     * @throws ParsingException if there is an error in the extraction
+     *                          or the extracted date couldn't be parsed.
+     * @see #getTextualUploadDate()
+     */
+    Calendar getUploadDate() throws ParsingException;
 
 }

--- a/src/main/java/org/schabi/newpipe/extractor/stream/TimeAgoParser.java
+++ b/src/main/java/org/schabi/newpipe/extractor/stream/TimeAgoParser.java
@@ -1,0 +1,141 @@
+package org.schabi.newpipe.extractor.stream;
+
+/*
+ * Created by wojcik.online on 2018-01-25.
+ */
+
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+
+import java.util.Calendar;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * A helper class that is meant to be used by services that need to parse upload dates in the
+ * format '2 days ago' or similar.
+ */
+public class TimeAgoParser {
+
+    /**
+     * A set of english phrases that are contained in the time units.
+     * (e.g. '7 minutes ago' contains 'min')
+     */
+    public static Map<TimeAgoUnit, String> DEFAULT_AGO_PHRASES = new EnumMap<>(TimeAgoUnit.class);
+
+    private final Map<TimeAgoUnit, String> agoPhrases;
+
+    private final Calendar consistentNow;
+
+    /**
+     * Creates a helper to parse upload dates in the format '2 days ago'.
+     * <p>
+     *     Instantiate a new {@link TimeAgoParser} every time you extract a new batch of items.
+     * </p>
+     * @param agoPhrases A set of phrases how to recognize the time units in a given language.
+     */
+    public TimeAgoParser(Map<TimeAgoUnit, String> agoPhrases) {
+        this.agoPhrases = agoPhrases;
+        consistentNow = Calendar.getInstance();
+    }
+
+    public Calendar parse(String textualDate) throws ParsingException {
+        try {
+            int timeAgoValue = parseTimeAgoValue(textualDate);
+            TimeAgoUnit timeAgoUnit = parseTimeAgoUnit(textualDate);
+
+            return getCalendar(timeAgoValue, timeAgoUnit);
+        } catch (NumberFormatException e) {
+            // If there is no valid number in the textual date, assume it is 'moments ago'.
+            return getCalendar(0, TimeAgoUnit.SECONDS);
+        }
+    }
+
+    private int parseTimeAgoValue(String textualDate) throws NumberFormatException {
+        String timeValueStr = textualDate.replaceAll("\\D+", "");
+        return Integer.parseInt(timeValueStr);
+    }
+
+    private TimeAgoUnit parseTimeAgoUnit(String textualDate) throws ParsingException {
+        for (TimeAgoUnit timeAgoUnit : agoPhrases.keySet()) {
+            if (textualDate.contains(agoPhrases.get(timeAgoUnit))) {
+                return timeAgoUnit;
+            }
+        }
+
+        throw new ParsingException("Unable to parse the date: " + textualDate);
+    }
+
+    private Calendar getCalendar(int timeAgoValue, TimeAgoUnit timeAgoUnit) {
+        Calendar calendarTime = getNow();
+
+        switch (timeAgoUnit) {
+            case SECONDS:
+                calendarTime.add(Calendar.SECOND, -timeAgoValue);
+                break;
+
+            case MINUTES:
+                calendarTime.add(Calendar.MINUTE, -timeAgoValue);
+                break;
+
+            case HOURS:
+                calendarTime.add(Calendar.HOUR_OF_DAY, -timeAgoValue);
+                break;
+
+            case DAYS:
+                calendarTime.add(Calendar.DAY_OF_MONTH, -timeAgoValue);
+                resetTimeOfDay(calendarTime);
+                break;
+
+            case WEEKS:
+                calendarTime.add(Calendar.WEEK_OF_MONTH, -timeAgoValue);
+                calendarTime.set(Calendar.DAY_OF_WEEK, calendarTime.getFirstDayOfWeek());
+                resetTimeOfDay(calendarTime);
+                break;
+
+            case MONTHS:
+                calendarTime.add(Calendar.MONTH, -timeAgoValue);
+                calendarTime.set(Calendar.DAY_OF_MONTH, 1);
+                resetTimeOfDay(calendarTime);
+                break;
+
+            case YEARS:
+                calendarTime.add(Calendar.YEAR, -timeAgoValue);
+                calendarTime.set(Calendar.MONTH, 1);
+                calendarTime.set(Calendar.DAY_OF_MONTH, 1);
+                resetTimeOfDay(calendarTime);
+                break;
+        }
+
+        return calendarTime;
+    }
+
+    private Calendar getNow() {
+        return (Calendar) consistentNow.clone();
+    }
+
+    private void resetTimeOfDay(Calendar calendarTime) {
+        calendarTime.set(Calendar.HOUR_OF_DAY, 0);
+        calendarTime.set(Calendar.MINUTE, 0);
+        calendarTime.set(Calendar.SECOND, 0);
+    }
+
+    static {
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.SECONDS, "sec");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.MINUTES, "min");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.HOURS, "hour");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.DAYS, "day");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.WEEKS, "week");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.MONTHS, "month");
+        DEFAULT_AGO_PHRASES.put(TimeAgoUnit.YEARS, "year");
+    }
+
+    enum TimeAgoUnit {
+        SECONDS,
+        MINUTES,
+        HOURS,
+        DAYS,
+        WEEKS,
+        MONTHS,
+        YEARS,
+    }
+}

--- a/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/BaseSoundcloudSearchTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/BaseSoundcloudSearchTest.java
@@ -28,7 +28,7 @@ public abstract class BaseSoundcloudSearchTest {
                 // test stream item
                 StreamInfoItem streamInfoItem = (StreamInfoItem) infoItem;
                 assertIsSecureUrl(streamInfoItem.getUploaderUrl());
-                assertFalse(streamInfoItem.getUploadDate().isEmpty());
+                assertFalse(streamInfoItem.getTextualUploadDate().isEmpty());
                 assertFalse(streamInfoItem.getUploaderName().isEmpty());
                 assertEquals(StreamType.AUDIO_STREAM, streamInfoItem.getStreamType());
             } else if(infoItem instanceof ChannelInfoItem) {

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/BaseYoutubeSearchTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/BaseYoutubeSearchTest.java
@@ -28,7 +28,7 @@ public abstract class BaseYoutubeSearchTest {
                 // test stream item
                 StreamInfoItem streamInfoItem = (StreamInfoItem) infoItem;
                 assertIsSecureUrl(streamInfoItem.getUploaderUrl());
-                assertFalse(streamInfoItem.getUploadDate().isEmpty());
+                assertFalse(streamInfoItem.getTextualUploadDate().isEmpty());
                 assertFalse(streamInfoItem.getUploaderName().isEmpty());
             } else if(infoItem instanceof ChannelInfoItem) {
                 // Nothing special to check?

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -87,7 +87,7 @@ public class YoutubePlaylistExtractorTest {
         for(StreamInfoItem item: streams) {
             assertEquals("Service id doesn't match", YouTube.getId(), item.getServiceId());
             assertNotNull("Stream type not set: " + item, item.getStreamType());
-            //assertNotEmpty("Upload date not set: " + item, item.getUploadDate());
+            //assertNotEmpty("Upload date not set: " + item, item.getTextualUploadDate());
             assertNotEmpty("Uploader name not set: " + item, item.getUploaderName());
             assertNotEmpty("Uploader url not set: " + item, item.getUploaderUrl());
         }

--- a/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineAllTest.java
+++ b/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngineAllTest.java
@@ -9,6 +9,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.search.SearchEngine;
 import org.schabi.newpipe.extractor.search.SearchResult;
+import org.schabi.newpipe.extractor.stream.TimeAgoParser;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -45,7 +46,8 @@ public class YoutubeSearchEngineAllTest extends BaseYoutubeSearchTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         NewPipe.init(Downloader.getInstance());
-        YoutubeSearchEngine engine = new YoutubeSearchEngine(1);
+        YoutubeSearchEngine engine = new YoutubeSearchEngine(1,
+                new TimeAgoParser(TimeAgoParser.DEFAULT_AGO_PHRASES));
 
         result = engine.search("pewdiepie", 0, "de", SearchEngine.Filter.ANY)
                 .getSearchResult();


### PR DESCRIPTION
The class `StreamInfoItem` gets a new field with the parsed upload date. It is the responsibility of the `StreamingService` to parse the date.

Services using RSS feeds or an API should have no problem with this. For YouTube a relative date in the format '*2 days ago*' must be parsed.
For this a simple approach is used where every time unit (minute / day / week / ...) gets a list of phrases. If the date from YouTube contains a phrase, it is assumed that the corresponding time unit was meant. (e.g '*2 minutes ago*' contains '*min*') The phrases are provided by the front end.

Linked to: Sort the items in the "What's New" feed by the parsed upload date.

### Still to be done (optionally)

 - [ ] **1.** 
   Parse the dates for every `Info` / `InfoItem`. This is not really necessary because the dates would not be used, but it might be useful in the future.
    And for the sake of consistency it could be implemented, now. Only drawback: computational overhead.

 - [ ] **2.**
    Get the exact upload dates from another source. The YouTube Channel RSS feed might be a good idea, but apparently it is not always available. Perhaps the `YoutubeService` could try to use the RSS feed and only upon failure fall back to the HTML page.
   The overhead should be negligible because most channel have a RSS feed. Which URLs should be used in that case?

