### PR TITLE
Fix OkHttp

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -678,7 +678,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             String helperPattern = "(var "
                     + helperObjectName.replace("$", "\\$") + "=\\{.+?\\}\\};)";
-            helperObject = Parser.matchGroup1(helperPattern, playerCode);
+            helperObject = Parser.matchGroup1(helperPattern, playerCode.replace("\n", ""));
 
 
             callerFunc = callerFunc.replace("%%", decryptionFuncName);


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

This commit fixes OkHttp support. All unit tests still pass with HttpsUrlConnection. Should I replace the test `Downloader.java` with OkHttp support or should there be 2 test variants (1 with HttpsUrlConnection and 1 with OkHttp)? I'll also create a PR to NewPipe to add OkHttp support and use the new NewPipeExtractor API.