### PR TITLE
fix NPE when captionsArray is null

### DIFF
--- a/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
+++ b/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamExtractor.java
@@ -739,6 +739,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         // todo: use this to apply auto translation to different language from a source language
         final JsonArray autoCaptionsArray = renderer.getArray("translationLanguages", new JsonArray());
 
+        // captionsArray object may be null, e.g. https://www.youtube.com/watch?v=OyLafqSSJF8
+        if (captionsArray == null) return Collections.emptyList();
+		
         // This check is necessary since there may be cases where subtitles metadata do not contain caption track info
         // e.g. https://www.youtube.com/watch?v=-Vpwatutnko
         final int captionsSize = captionsArray.size();


### PR DESCRIPTION
I was trying to watch [this video](https://www.youtube.com/watch?v=OyLafqSSJF8), but it kept throwing NPE at this line. It would also throw NPE for other videos in the same [series](https://www.youtube.com/watch?v=4R0KwjwYrkE). Need to check if captionsArray is null before checking its size.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
