### PR TITLE
Fix time formatting for different countries

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -30,7 +30,17 @@ public class YoutubeParsingHelper {
 
     public static long parseDurationString(String input)
             throws ParsingException, NumberFormatException {
-        String[] splitInput = input.split(":");
+
+        String[] splitInput;
+
+        // If time separator : is not detected, try . instead
+        
+        if (input.contains(":")) {
+        splitInput = input.split(":");
+        } else {
+        splitInput = input.split("\\.");
+        }
+        
         String days = "0";
         String hours = "0";
         String minutes = "0";


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Tested to compile with NewPipe and to work on a real device, and to fix the issue.
this fixes https://github.com/TeamNewPipe/NewPipeExtractor/issues/110

This code change autodetects whether duration is formatted with : or . as in 5.45 or 5:45 instead of hardcoded to : which causes errors and lag when using NewPipe in countries with different timeformatting.

