### PR TITLE
[Youtube Live Streams] fixed extracting live HLS URL

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -5,7 +5,6 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 import org.jsoup.Jsoup;
-import org.jsoup.helper.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -398,7 +397,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                             .getString("hlsManifestUrl", "");
                 }
             }
-            
+
             return hlsvp;
         } catch (Exception e) {
             throw new ParsingException("Could not get hls manifest url", e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -5,6 +5,7 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 import org.jsoup.Jsoup;
+import org.jsoup.helper.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -386,13 +387,18 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public String getHlsUrl() throws ParsingException {
         assertPageFetched();
         try {
-            String hlsvp;
-            if (playerArgs != null && playerArgs.isString("hlsvp")) {
-                hlsvp = playerArgs.getString("hlsvp", "");
-            } else {
-                return "";
+            String hlsvp = "";
+            if (playerArgs != null) {
+                if( playerArgs.isString("hlsvp") ) {
+                    hlsvp = playerArgs.getString("hlsvp", "");
+                }else {
+                    hlsvp = JsonParser.object()
+                            .from(playerArgs.getString("player_response", "{}"))
+                            .getObject("streamingData", new JsonObject())
+                            .getString("hlsManifestUrl", "");
+                }
             }
-
+            
             return hlsvp;
         } catch (Exception e) {
             throw new ParsingException("Could not get hls manifest url", e);


### PR DESCRIPTION
Closes https://github.com/TeamNewPipe/NewPipe/issues/1996

Fix taken from https://github.com/rg3/youtube-dl/commit/c3e543893bfba7faa7c13e53fbe6b60f936b81f1