### PR TITLE
Adds parsing support for invidious.us links

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelLinkHandlerFactory.java
@@ -46,7 +46,7 @@ public class YoutubeChannelLinkHandlerFactory extends ListLinkHandlerFactory {
             URL urlObj = Utils.stringToURL(url);
             String path = urlObj.getPath();
 
-            if (!(YoutubeParsingHelper.isYoutubeURL(urlObj) || urlObj.getHost().equalsIgnoreCase("hooktube.com"))) {
+            if (!(YoutubeParsingHelper.isYoutubeURL(urlObj) || urlObj.getHost().equalsIgnoreCase("hooktube.com") || urlObj.getHost().equalsIgnoreCase("invidio.us"))) {
                 throw new ParsingException("the URL given is not a Youtube-URL");
             }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -63,7 +63,8 @@ public class YoutubeParsingHelper {
         String host = url.getHost();
         return host.equalsIgnoreCase("youtube.com") || host.equalsIgnoreCase("www.youtube.com")
                 || host.equalsIgnoreCase("m.youtube.com") || host.equalsIgnoreCase("www.youtube-nocookie.com")
-                || host.equalsIgnoreCase("youtu.be") || host.equalsIgnoreCase("hooktube.com");
+                || host.equalsIgnoreCase("youtu.be") || host.equalsIgnoreCase("hooktube.com")
+                || host.equalsIgnoreCase("invidio.us");
     }
 
     public static long parseDurationString(String input)

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeStreamLinkHandlerFactory.java
@@ -170,6 +170,20 @@ public class YoutubeStreamLinkHandlerFactory extends LinkHandlerFactory {
                 }
             }
 
+            case "INVIDIO.US": {
+                if (path.equals("watch")) {
+                    String viewQueryValue = Utils.getQueryValue(url, "v");
+                    if (viewQueryValue != null) {
+                        return assertIsID(viewQueryValue);
+                    }
+                }
+                if (path.startsWith("embed/")) {
+                    String id = path.substring("embed/".length());
+
+                    return assertIsID(id);
+                }
+            }
+
             break;
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelLinkHandlerFactoryTest.java
@@ -37,6 +37,8 @@ public class YoutubeChannelLinkHandlerFactoryTest {
 
         assertTrue(linkHandler.acceptUrl("https://hooktube.com/channel/UClq42foiSgl7sSpLupnugGA"));
         assertTrue(linkHandler.acceptUrl("https://hooktube.com/channel/UClq42foiSgl7sSpLupnugGA/videos?disable_polymer=1"));
+
+        assertTrue(linkHandler.acceptUrl("https://invidio.us/channel/UCl2mFZoRqjw_ELax4Yisf6w"));
     }
 
     @Test
@@ -53,5 +55,7 @@ public class YoutubeChannelLinkHandlerFactoryTest {
 
         assertEquals("channel/UClq42foiSgl7sSpLupnugGA", linkHandler.fromUrl("https://hooktube.com/channel/UClq42foiSgl7sSpLupnugGA").getId());
         assertEquals("channel/UClq42foiSgl7sSpLupnugGA", linkHandler.fromUrl("https://hooktube.com/channel/UClq42foiSgl7sSpLupnugGA/videos?disable_polymer=1").getId());
+
+        assertEquals("channel/UCl2mFZoRqjw_ELax4Yisf6w", linkHandler.fromUrl("https://invidio.us/channel/UCl2mFZoRqjw_ELax4Yisf6w").getId());
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamLinkHandlerFactoryTest.java
@@ -121,4 +121,20 @@ public class YoutubeStreamLinkHandlerFactoryTest {
         assertEquals("3msbfr6pBNE", linkHandler.fromUrl("hooktube.com/v/3msbfr6pBNE").getId());
         assertEquals("3msbfr6pBNE", linkHandler.fromUrl("hooktube.com/embed/3msbfr6pBNE").getId());
     }
+
+    @Test
+    public void testAcceptInvidiousUrl() throws ParsingException {
+        assertTrue(linkHandler.acceptUrl("https://invidio.us/watch?v=TglNG-yjabU"));
+        assertTrue(linkHandler.acceptUrl("https://invidio.us/watch?v=TglNG-yjabU&listen=1"));
+        assertTrue(linkHandler.acceptUrl("invidio.us/watch?v=3msbfr6pBNE"));
+        assertTrue(linkHandler.acceptUrl("invidio.us/embed/3msbfr6pBNE"));
+    }
+
+    @Test
+    public void testGetInvidiousIdfromUrl() throws ParsingException {
+        assertEquals("TglNG-yjabU", linkHandler.fromUrl("https://invidio.us/watch?v=TglNG-yjabU").getId());
+        assertEquals("TglNG-yjabU", linkHandler.fromUrl("https://invidio.us/watch?v=TglNG-yjabU&listen=1").getId());
+        assertEquals("3msbfr6pBNE", linkHandler.fromUrl("invidio.us/watch?v=3msbfr6pBNE").getId());
+        assertEquals("3msbfr6pBNE", linkHandler.fromUrl("invidio.us/embed/3msbfr6pBNE").getId());
+    }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Hi.

This pull request adds parsing support for [invidious.us](https://invidio.us/) links.

I found this [issue](https://github.com/TeamNewPipe/NewPipe/issues/1614) for beginners in the main New Pipe repo requesting this. 

As I found out, updates to this library are needed to implement that.

The implementation is quite trivial: I used the hooktube.com implementation as reference.
I also added relevant tests. 

I've prepared and tested the changes in the app and all seems to work fine.