### PR TITLE
Sanitize youtube comment

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
+import org.schabi.newpipe.extractor.utils.Utils;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -62,7 +63,9 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     @Override
     public String getCommentText() throws ParsingException {
         try {
-            return YoutubeCommentsExtractor.getYoutubeText(JsonUtils.getObject(json, "contentText"));
+            String commentText = YoutubeCommentsExtractor.getYoutubeText(JsonUtils.getObject(json, "contentText"));
+            // youtube adds U+FEFF in some comments. eg. https://www.youtube.com/watch?v=Nj4F63E59io<feff>
+            return Utils.removeUTF8BOM(commentText);
         } catch (Exception e) {
             throw new ParsingException("Could not get comment text", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -1,12 +1,12 @@
 package org.schabi.newpipe.extractor.utils;
 
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
-
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.List;
+
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
 public class Utils {
 
@@ -119,5 +119,15 @@ public class Utils {
 
             throw e;
         }
+    }
+    
+    public static String removeUTF8BOM(String s) {
+        if (s.startsWith("\uFEFF")) {
+            s = s.substring(1);
+        }
+        if (s.endsWith("\uFEFF")) {
+            s = s.substring(0,  s.length()-1);
+        }
+        return s;
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
Youtube adds `Unicode Character 'ZERO WIDTH NO-BREAK SPACE' (U+FEFF)` (http://www.fileformat.info/info/unicode/char/FEFF/index.htm) in some comments which makes links not detectable. This PR removes such characters.
