### PR TITLE
Improve thumbnail quality for Soundcloud service

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
@@ -24,7 +24,9 @@ public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtrac
 
     @Override
     public String getThumbnailUrl() {
-        return itemObject.getString("avatar_url", "");
+        String avatarUrl = itemObject.getString("avatar_url", "");
+        String avatarUrlBetterResolution = avatarUrl.replace("large.jpg", "crop.jpg");
+        return avatarUrlBetterResolution;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -71,13 +71,15 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
                     final String thumbnailUrl = item.getThumbnailUrl();
                     if (thumbnailUrl == null || thumbnailUrl.isEmpty()) continue;
 
-                    return thumbnailUrl;
+                    String thumbnailUrlBetterResolution = thumbnailUrl.replace("large.jpg", "crop.jpg");
+                    return thumbnailUrlBetterResolution;
                 }
             } catch (Exception ignored) {
             }
         }
 
-        return artworkUrl;
+        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
+        return artworkUrlBetterResolution;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
@@ -32,7 +32,10 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
         // Over-engineering at its finest
         if (itemObject.isString(ARTWORK_URL_KEY)) {
             final String artworkUrl = itemObject.getString(ARTWORK_URL_KEY, "");
-            if (!artworkUrl.isEmpty()) return artworkUrl;
+            if (!artworkUrl.isEmpty()) {
+                String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
+                return artworkUrlBetterResolution;
+            }
         }
 
         try {
@@ -42,8 +45,11 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
 
                 // First look for track artwork url
                 if (trackObject.isString(ARTWORK_URL_KEY)) {
-                    final String url = trackObject.getString(ARTWORK_URL_KEY, "");
-                    if (!url.isEmpty()) return url;
+                    String artworkUrl = trackObject.getString(ARTWORK_URL_KEY, "");
+                    if (!artworkUrl.isEmpty()) {
+                        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
+                        return artworkUrlBetterResolution;
+                    }
                 }
 
                 // Then look for track creator avatar url

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -57,7 +57,12 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
     @Nonnull
     @Override
     public String getThumbnailUrl() {
-        return track.getString("artwork_url", "");
+        String artworkUrl = track.getString("artwork_url", "");
+        if (artworkUrl.isEmpty()) {
+            artworkUrl = track.getObject("user").getString("avatar_url", "");
+        }
+        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
+        return artworkUrlBetterResolution;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -52,7 +52,12 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
 
     @Override
     public String getThumbnailUrl() {
-        return itemObject.getString("artwork_url");
+        String artworkUrl = itemObject.getString("artwork_url", "");
+        if (artworkUrl.isEmpty()) {
+            artworkUrl = itemObject.getObject("user").getString("avatar_url");
+        }
+        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
+        return artworkUrlBetterResolution;
     }
 
     @Override


### PR DESCRIPTION
The thumbnail URL provided when using the Soundcloud API defaults to 100x100 pixels image. It seems we could also fetch for better resolution thumbnails by replacing a small part in the URL. This stackoverflow post contains some valuable information on Soundcloud thumbnail quality: https://stackoverflow.com/a/13989369/.

I've added changes to the code to replace the part of the URL to fetch a 400x400 pixels thumbnail image. I didn't use the 500x500 pixels image because for some reason the part of the images were cut from the sides when displayed in NewPipe while 400x400 pixels image didn't have this problem.

Also, some Soundcloud tracks have the `artwork_url` key as null in the API response. Previously, the thumbnail for such tracks wouldn't show up in NewPipe. This PR will fallback to the `avatar_url` if `artwork_url` is `null` (this is what Soundcloud does when accessing it through a web browser, so these changes are consistent with that observed with a web browser).

----------

Some before-After NewPipe screenshots (click to zoom):
(At left: Before, At right: This PR)

<img src="https://user-images.githubusercontent.com/20314742/56771277-dae96500-67d3-11e9-81ac-a94220dadf1b.png" width="290"> <img src="https://user-images.githubusercontent.com/20314742/56771278-dae96500-67d3-11e9-9fc2-b60ba3b1f8ff.png" width="290">
<img src="https://user-images.githubusercontent.com/20314742/56771280-db81fb80-67d3-11e9-82ab-fd4fa19a4771.png" width="290"> <img src="https://user-images.githubusercontent.com/20314742/56771281-db81fb80-67d3-11e9-97fe-4b4951bf6166.png" width="290">
<img src="https://user-images.githubusercontent.com/20314742/56771282-dc1a9200-67d3-11e9-984a-60a48055b1fe.png" width="290"> <img src="https://user-images.githubusercontent.com/20314742/56771284-dc1a9200-67d3-11e9-8bd6-6bbeb54763cd.png" width="290">
----------

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [No breaking changes] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
