### PR TITLE
Fixed youtube subscription import: ignore ones with invalid url and keep ones with empty title.

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
@@ -63,20 +63,10 @@ public class YoutubeSubscriptionExtractor extends SubscriptionExtractor {
             String title = outline.attr("title");
             String xmlUrl = outline.attr("abs:xmlUrl");
 
-            if (title.isEmpty()) {
-                continue;
-            }
-
-            if (xmlUrl.isEmpty()) {
-                throw new InvalidSourceException("document has invalid entries");
-            }
-
             try {
                 String id = Parser.matchGroup1(ID_PATTERN, xmlUrl);
                 result.add(new SubscriptionItem(service.getServiceId(), BASE_CHANNEL_URL + id, title));
-            } catch (Parser.RegexException e) {
-                throw new InvalidSourceException("document has invalid entries", e);
-            }
+            } catch (Parser.RegexException ignored) { /* ignore invalid subscriptions */ }
         }
 
         return result;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
@@ -63,7 +63,11 @@ public class YoutubeSubscriptionExtractor extends SubscriptionExtractor {
             String title = outline.attr("title");
             String xmlUrl = outline.attr("abs:xmlUrl");
 
-            if (title.isEmpty() || xmlUrl.isEmpty()) {
+            if (title.isEmpty()) {
+                continue;
+            }
+
+            if (xmlUrl.isEmpty()) {
                 throw new InvalidSourceException("document has invalid entries");
             }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSubscriptionExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSubscriptionExtractorTest.java
@@ -60,6 +60,23 @@ public class YoutubeSubscriptionExtractorTest {
     }
 
     @Test
+    public void testSubscriptionWithEmptyTitleInSource() throws Exception {
+        String channelName = "NAME OF CHANNEL";
+        String emptySource = "<opml version=\"1.1\"><body><outline text=\"YouTube Subscriptions\" title=\"YouTube Subscriptions\">" +
+
+                "<outline text=\"\" title=\"\" type=\"rss\" xmlUrl=\"https://www.youtube.com/feeds/videos.xml?channel_id=AA0AaAa0AaaaAAAAAA0aa0AA\" />" +
+
+                "<outline text=\"" + channelName + "\" title=\"" + channelName +
+                "\" type=\"rss\" xmlUrl=\"https://www.youtube.com/feeds/videos.xml?channel_id=AA0AaAa0AaaaAAAAAA0aa0AA\" />" +
+
+                "</outline></body></opml>";
+
+        List<SubscriptionItem> items = subscriptionExtractor.fromInputStream(new ByteArrayInputStream(emptySource.getBytes("UTF-8")));
+        assertTrue("List doesn't have exactly 1 item (had " + items.size() + ")", items.size() == 1);
+        assertTrue("Item does not have the right title \"" + channelName + "\" (had \"" + items.get(0).getName() + "\")", items.get(0).getName().equals(channelName));
+    }
+
+    @Test
     public void testInvalidSourceException() {
         List<String> invalidList = Arrays.asList(
                 "<xml><notvalid></notvalid></xml>",


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [no breaking change] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Now when the YoutubeSubscriptionExtractor parses the YouTube subscription_manager file, it ignores channels that have no title, instead of throwing an error: that file can sometimes natively contain channels with no title (i.e. deleted channels).

I tested the changes inside the NewPipe app against [the file](https://gist.githubusercontent.com/wolttam/d56586d2c677565071c4e935812d39c9/raw/dba803bc29f694afaf6bc51faaeffcdf2f5866bf/subscription_manager) provided in TeamNewPipe/NewPipe#2226. I also added a unit test.

I left untouched all the other "document has invalid entries" exceptions, since they are not involved in the empty-title issue. I think this is ok.

Fix TeamNewPipe/NewPipe#2226