### PR TITLE
Fix invalid yt url: signature tag name is not always "signature"

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -888,7 +888,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         String streamUrl = tags.get("url");
                         // if video has a signature: decrypt it and add it to the url
                         if (tags.get("s") != null) {
-                            streamUrl = streamUrl + "&signature=" + decryptSignature(tags.get("s"), decryptionCode);
+                            streamUrl = streamUrl + "&" + tags.get("sp") + "=" + decryptSignature(tags.get("s"), decryptionCode);
                         }
                         urlAndItags.put(streamUrl, itagItem);
                     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -888,7 +888,13 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         String streamUrl = tags.get("url");
                         // if video has a signature: decrypt it and add it to the url
                         if (tags.get("s") != null) {
-                            streamUrl = streamUrl + "&" + tags.get("sp") + "=" + decryptSignature(tags.get("s"), decryptionCode);
+                            if (tags.get("sp") == null) {
+                                // fallback for urls not conaining the "sp" tag
+                                streamUrl = streamUrl + "&signature=" + decryptSignature(tags.get("s"), decryptionCode);
+                            }
+                            else {
+                                streamUrl = streamUrl + "&" + tags.get("sp") + "=" + decryptSignature(tags.get("s"), decryptionCode);
+                            }
                         }
                         urlAndItags.put(streamUrl, itagItem);
                     }


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [no breaking change] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Thanks to @omarroth for the suggestion. For more info see #155 #162 TeamNewPipe/NewPipe#2337

This should fix many problems users keep having in the last few weeks: some videos in NewPipe don't load, at random. Invalid urls of those videos are then cached, and the app won't load them anymore until the cache is wiped. So even after this pr is merged, users would still have to manually wipe metadata from the app.

I tested the changes in the NewPipe app and it worked normally with all the videos I tried. I also added a `Log` instruction to have the url printed in the android logcat, and I saw that both types* of YouTube links work (one of them wouldn't have worked previously).
###### * One type (the one that has always worked) has "id" as the first url tag and signature tag "signature", the other (that created problems with the signature) has "expire" as the first url tag and signature tag "sig". Or at least it seems to be like this, to me.

Please merge this as soon as possible, since this issue is affecting many people and is very annoying :-) .

Fixes #162
Fixes (partially) #155 
Fixes TeamNewPipe/NewPipe#2336
Fixes TeamNewPipe/NewPipe#2337
Fixes TeamNewPipe/NewPipe#2324
Fixes TeamNewPipe/NewPipe#2304
Fixes TeamNewPipe/NewPipe#2275
Probably also fixes TeamNewPipe/NewPipe#867
Probably also fixes TeamNewPipe/NewPipe#2297