### PR TITLE
Fix failing YouTube comments tests

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -27,18 +27,18 @@ public class YoutubeCommentsExtractorTest {
     public static void setUp() throws Exception {
         NewPipe.init(Downloader.getInstance(), new Localization("GB", "en"));
         extractor = (YoutubeCommentsExtractor) YouTube
-                .getCommentsExtractor("https://www.youtube.com/watch?v=rrgFN3AxGfs");
+                .getCommentsExtractor("https://www.youtube.com/watch?v=D00Au7k3i6o");
     }
 
     @Test
     public void testGetComments() throws IOException, ExtractionException {
-        boolean result = false;
+        boolean result;
         InfoItemsPage<CommentsInfoItem> comments = extractor.getInitialPage();
-        result = findInComments(comments, "i should really be in the top comment.lol");
+        result = findInComments(comments, "s1ck m3m3");
 
         while (comments.hasNextPage() && !result) {
             comments = extractor.getPage(comments.getNextPageUrl());
-            result = findInComments(comments, "i should really be in the top comment.lol");
+            result = findInComments(comments, "s1ck m3m3");
         }
 
         assertTrue(result);
@@ -47,14 +47,14 @@ public class YoutubeCommentsExtractorTest {
     @Test
     public void testGetCommentsFromCommentsInfo() throws IOException, ExtractionException {
         boolean result = false;
-        CommentsInfo commentsInfo = CommentsInfo.getInfo("https://www.youtube.com/watch?v=rrgFN3AxGfs");
-        assertTrue("what the fuck am i doing with my life.wmv".equals(commentsInfo.getName()));
-        result = findInComments(commentsInfo.getRelatedItems(), "i should really be in the top comment.lol");
+        CommentsInfo commentsInfo = CommentsInfo.getInfo("https://www.youtube.com/watch?v=D00Au7k3i6o");
+        assertTrue("what the fuck am i doing with my life".equals(commentsInfo.getName()));
+        result = findInComments(commentsInfo.getRelatedItems(), "s1ck m3m3");
 
         String nextPage = commentsInfo.getNextPageUrl();
         while (!StringUtil.isBlank(nextPage) && !result) {
             InfoItemsPage<CommentsInfoItem> moreItems = CommentsInfo.getMoreItems(YouTube, commentsInfo, nextPage);
-            result = findInComments(moreItems.getItems(), "i should really be in the top comment.lol");
+            result = findInComments(moreItems.getItems(), "s1ck m3m3");
             nextPage = moreItems.getNextPageUrl();
         }
 


### PR DESCRIPTION
The comment function has been disabled for the video on which we ran the test. We are testing the comments of a different video now.

There are a bunch of SoundCloud tests which are failing, but I am short on time. Maybe someone else wants to fix them.
