### PR TITLE
add extractor for jedentageinset

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -12,6 +12,8 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemsCollector;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.services.soundcloud.channel.SoundcloudChannelInfoItemExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Parser.RegexException;
@@ -96,7 +98,7 @@ public class SoundcloudParsingHelper {
      *
      * @return the url resolved
      */
-    public static String resolveUrlWithEmbedPlayer(String apiUrl) throws IOException, ReCaptchaException, ParsingException {
+    public static String resolveUrlWithEmbedPlayer(String apiUrl) throws IOException, ReCaptchaException {
 
         String response = NewPipe.getDownloader().download("https://w.soundcloud.com/player/?url="
                 + URLEncoder.encode(apiUrl, "UTF-8"));
@@ -226,13 +228,13 @@ public class SoundcloudParsingHelper {
     }
 
     @Nonnull
-    static String getUploaderUrl(JsonObject object) {
+    public static String getUploaderUrl(JsonObject object) {
         String url = object.getObject("user").getString("permalink_url", "");
         return replaceHttpWithHttps(url);
     }
 
     @Nonnull
-    static String getAvatarUrl(JsonObject object) {
+    public static String getAvatarUrl(JsonObject object) {
         String url = object.getObject("user", new JsonObject()).getString("avatar_url", "");
         return replaceHttpWithHttps(url);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
@@ -18,6 +18,18 @@ import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.channel.SoundcloudChannelExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.channel.SoundcloudChannelLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.JedenTagEinSetExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.JedenTagEinSetLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.SoundcloudChartsExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.SoundcloudChartsLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.playlist.SoundcloudPlaylistExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.playlist.SoundcloudPlaylistLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamLinkHandlerFactory;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.utils.Localization;
@@ -83,8 +95,13 @@ public class SoundcloudService extends StreamingService {
                                                  String id,
                                                  Localization local)
                     throws ExtractionException {
-                return new SoundcloudChartsExtractor(SoundcloudService.this,
-                        new SoundcloudChartsLinkHandlerFactory().fromUrl(url), id, local);
+                if(new JedenTagEinSetLinkHandlerFactory().onAcceptUrl(url)) {
+                    return new JedenTagEinSetExtractor(SoundcloudService.this,
+                            new JedenTagEinSetLinkHandlerFactory().fromUrl(url), id, local);
+                } else {
+                    return new SoundcloudChartsExtractor(SoundcloudService.this,
+                            new SoundcloudChartsLinkHandlerFactory().fromUrl(url), id, local);
+                }
             }
         };
 
@@ -92,9 +109,11 @@ public class SoundcloudService extends StreamingService {
 
         // add kiosks here e.g.:
         final SoundcloudChartsLinkHandlerFactory h = new SoundcloudChartsLinkHandlerFactory();
+        final JedenTagEinSetLinkHandlerFactory jh = new JedenTagEinSetLinkHandlerFactory();
         try {
             list.addKioskEntry(chartsFactory, h, "Top 50");
             list.addKioskEntry(chartsFactory, h, "New & hot");
+            list.addKioskEntry(chartsFactory, jh, "jedentageinset");
             list.setDefaultKiosk("New & hot");
         } catch (Exception e) {
             throw new ExtractionException(e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.channel;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Localization;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelInfoItemExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.channel;
 
 import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/channel/SoundcloudChannelLinkHandlerFactory.java
@@ -1,20 +1,22 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.channel;
 
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.util.List;
 
-public class SoundcloudPlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
-    private static final SoundcloudPlaylistLinkHandlerFactory instance = new SoundcloudPlaylistLinkHandlerFactory();
+public class SoundcloudChannelLinkHandlerFactory extends ListLinkHandlerFactory {
+    private static final SoundcloudChannelLinkHandlerFactory instance = new SoundcloudChannelLinkHandlerFactory();
     private final String URL_PATTERN = "^https?://(www\\.|m\\.)?soundcloud.com/[0-9a-z_-]+" +
-            "/sets/[0-9a-z_-]+/?([#?].*)?$";
+            "(/((tracks|albums|sets|reposts|followers|following)/?)?)?([#?].*)?$";
 
-    public static SoundcloudPlaylistLinkHandlerFactory getInstance() {
+    public static SoundcloudChannelLinkHandlerFactory getInstance() {
         return instance;
     }
+
 
     @Override
     public String getId(String url) throws ParsingException {
@@ -23,21 +25,21 @@ public class SoundcloudPlaylistLinkHandlerFactory extends ListLinkHandlerFactory
         try {
             return SoundcloudParsingHelper.resolveIdWithEmbedPlayer(url);
         } catch (Exception e) {
-            throw new ParsingException("Could not get id of url: " + url + " " + e.getMessage(), e);
+            throw new ParsingException(e.getMessage(), e);
         }
     }
 
     @Override
     public String getUrl(String id, List<String> contentFilter, String sortFilter) throws ParsingException {
         try {
-            return SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/playlists/" + id);
+            return SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/" + id);
         } catch (Exception e) {
             throw new ParsingException(e.getMessage(), e);
         }
     }
 
     @Override
-    public boolean onAcceptUrl(final String url) throws ParsingException {
+    public boolean onAcceptUrl(final String url) {
         return Parser.isMatch(URL_PATTERN, url.toLowerCase());
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/JedenTagEinSetExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/JedenTagEinSetExtractor.java
@@ -1,0 +1,190 @@
+package org.schabi.newpipe.extractor.services.soundcloud.kiosk;
+
+import com.sun.org.apache.xerces.internal.xs.StringList;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.schabi.newpipe.extractor.Downloader;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.utils.Localization;
+import org.schabi.newpipe.extractor.utils.Parser;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.schabi.newpipe.extractor.stream.StreamType.AUDIO_STREAM;
+
+public class JedenTagEinSetExtractor extends KioskExtractor<StreamInfoItem> {
+    public JedenTagEinSetExtractor(StreamingService streamingService,
+                                   ListLinkHandler linkHandler,
+                                   String kioskId,
+                                   Localization localization) {
+        super(streamingService, linkHandler, kioskId, localization);
+    }
+
+    @Nonnull
+    @Override
+    public String getName() throws ParsingException {
+        return "jedentageinset";
+    }
+
+    @Nonnull
+    @Override
+    public InfoItemsPage<StreamInfoItem> getInitialPage() throws IOException, ExtractionException {
+        return getPage("https://www.jedentageinset.de/page/1");
+    }
+
+    @Override
+    public String getNextPageUrl() throws IOException, ExtractionException {
+        return "https://www.jedentageinset.de/page/2";
+    }
+
+    @Override
+    public InfoItemsPage<StreamInfoItem> getPage(String pageUrl) throws IOException, ExtractionException {
+        try {
+            final Downloader d = getDownloader();
+            final String rawPage = d.download("https://jedentageinset.de");
+            final Document page = Jsoup.parse(rawPage, JedenTagEinSetLinkHandlerFactory.URL);
+
+            final Elements homeBoxes = page.getElementById("posts_cont")
+                    .getElementsByClass("home_box");
+
+            //get links to the set pages
+            final List<String> setLinks = new ArrayList<>();
+            for (Element homeBox : homeBoxes) {
+                setLinks.add(homeBox
+                        .getElementsByClass("home_box_cont")
+                        .first()
+                        .getElementsByTag("a")
+                        .first().attr("href"));
+            }
+
+            //get soundcloud api url from set links
+            final StreamInfoItemExtractor[] extractors = new StreamInfoItemExtractor[setLinks.size()];
+            final List<Throwable> errorList = Collections.synchronizedList(new ArrayList<Throwable>());
+            final List<Thread> threadHandles = new ArrayList<>(setLinks.size());
+
+            for (int i = 0; i < setLinks.size(); i++) {
+                final String setLink = setLinks.get(i);
+                final int index = i;
+                final Element homeBox = homeBoxes.get(i);
+                final Thread t = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            final Document setPage = Jsoup.parse(d.download(setLink), setLink);
+                            final URL frameUrl = new URL(setPage.getElementsByTag("iframe")
+                                    .last().attr("src"));
+
+                            final String apiUrl = Parser.compatParseMap(frameUrl.getQuery()).get("url");
+                            final String streamUrl = SoundcloudParsingHelper.resolveUrlWithEmbedPlayer(apiUrl);
+                            final String uploadDate = setPage.getElementsByClass("post_date")
+                                    .first().getElementsByTag("span").first().html();
+                            final String name = setPage.getElementsByClass("single_title")
+                                    .first().html();
+                            final String thumbnail = homeBox.getElementsByClass("attachment-home-box-image")
+                                    .first().attr("src");
+
+                            extractors[index] = new StreamInfoItemExtractor() {
+                                @Override
+                                public StreamType getStreamType() throws ParsingException {
+                                    return AUDIO_STREAM;
+                                }
+
+                                @Override
+                                public boolean isAd() throws ParsingException {
+                                    return false;
+                                }
+
+                                @Override
+                                public long getDuration() throws ParsingException {
+                                    return -1;
+                                }
+
+                                @Override
+                                public long getViewCount() throws ParsingException {
+                                    return -1;
+                                }
+
+                                @Override
+                                public String getUploaderName() throws ParsingException {
+                                    return null;
+                                }
+
+                                @Override
+                                public String getUploaderUrl() throws ParsingException {
+                                    return null;
+                                }
+
+                                @Override
+                                public String getUploadDate() throws ParsingException {
+                                    return uploadDate;
+                                }
+
+                                @Override
+                                public String getName() throws ParsingException {
+                                    return name;
+                                }
+
+                                @Override
+                                public String getUrl() throws ParsingException {
+                                    return streamUrl;
+                                }
+
+                                @Override
+                                public String getThumbnailUrl() throws ParsingException {
+                                    return thumbnail;
+                                }
+                            };
+
+                        } catch (Exception e) {
+                            errorList.add(e);
+                        }
+                    }
+                });
+                t.start();
+                threadHandles.add(t);
+            }
+
+            for (Thread t : threadHandles) {
+                t.join();
+            }
+
+            StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
+            for(StreamInfoItemExtractor e : extractors) {
+                collector.commit(e);
+            }
+
+            List<StreamInfoItem> infoItems = collector.getStreamInfoItemList();
+            errorList.addAll(collector.getErrors());
+
+            final int nextPageNum =
+                    Integer.valueOf(
+                            pageUrl.replace("https://www.jedentageinset.de/page/", "")) + 1;
+
+
+
+            return new InfoItemsPage<>(infoItems, "https://www.jedentageinset.de/page/" + nextPageNum, errorList);
+        } catch (Exception e) {
+            throw new ExtractionException(e);
+        }
+    }
+
+    @Override
+    public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/JedenTagEinSetLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/JedenTagEinSetLinkHandlerFactory.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.extractor.services.soundcloud.kiosk;
+
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
+import org.schabi.newpipe.extractor.utils.Parser;
+
+import java.util.List;
+
+public class JedenTagEinSetLinkHandlerFactory extends ListLinkHandlerFactory {
+    public static final String URL = "https://jedentageinset.de";
+
+    @Override
+    public String getId(String url) {
+        return "jedentageinset";
+    }
+
+    @Override
+    public String getUrl(String id, List<String> contentFilter, String sortFilter) {
+        return URL;
+    }
+
+    @Override
+    public boolean onAcceptUrl(final String url) {
+        return url.startsWith(URL);
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/SoundcloudChartsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/SoundcloudChartsExtractor.java
@@ -1,10 +1,11 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.kiosk;
 
 import org.schabi.newpipe.extractor.Downloader;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Localization;
@@ -60,12 +61,6 @@ public class SoundcloudChartsExtractor extends KioskExtractor<StreamInfoItem> {
         } else {
             apiUrl += "&kind=trending";
         }
-
-        /*List<String> supportedCountries = Arrays.asList("AU", "CA", "FR", "DE", "IE", "NL", "NZ", "GB", "US");
-        String contentCountry = getContentCountry();
-        if (supportedCountries.contains(contentCountry)) {
-            apiUrl += "&region=soundcloud:regions:" + contentCountry;
-        }*/
 
         nextPageUrl = SoundcloudParsingHelper.getStreamsFromApi(collector, apiUrl, true);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/SoundcloudChartsLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/kiosk/SoundcloudChartsLinkHandlerFactory.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.kiosk;
 
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Parser;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.playlist;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
@@ -9,6 +9,7 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Localization;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistInfoItemExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.playlist;
 
 import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/playlist/SoundcloudPlaylistLinkHandlerFactory.java
@@ -1,21 +1,21 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.playlist;
 
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.util.List;
 
-public class SoundcloudChannelLinkHandlerFactory extends ListLinkHandlerFactory {
-    private static final SoundcloudChannelLinkHandlerFactory instance = new SoundcloudChannelLinkHandlerFactory();
+public class SoundcloudPlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
+    private static final SoundcloudPlaylistLinkHandlerFactory instance = new SoundcloudPlaylistLinkHandlerFactory();
     private final String URL_PATTERN = "^https?://(www\\.|m\\.)?soundcloud.com/[0-9a-z_-]+" +
-            "(/((tracks|albums|sets|reposts|followers|following)/?)?)?([#?].*)?$";
+            "/sets/[0-9a-z_-]+/?([#?].*)?$";
 
-    public static SoundcloudChannelLinkHandlerFactory getInstance() {
+    public static SoundcloudPlaylistLinkHandlerFactory getInstance() {
         return instance;
     }
-
 
     @Override
     public String getId(String url) throws ParsingException {
@@ -24,21 +24,21 @@ public class SoundcloudChannelLinkHandlerFactory extends ListLinkHandlerFactory 
         try {
             return SoundcloudParsingHelper.resolveIdWithEmbedPlayer(url);
         } catch (Exception e) {
-            throw new ParsingException(e.getMessage(), e);
+            throw new ParsingException("Could not get id of url: " + url + " " + e.getMessage(), e);
         }
     }
 
     @Override
     public String getUrl(String id, List<String> contentFilter, String sortFilter) throws ParsingException {
         try {
-            return SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/" + id);
+            return SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/playlists/" + id);
         } catch (Exception e) {
             throw new ParsingException(e.getMessage(), e);
         }
     }
 
     @Override
-    public boolean onAcceptUrl(final String url) {
+    public boolean onAcceptUrl(final String url) throws ParsingException {
         return Parser.isMatch(URL_PATTERN, url.toLowerCase());
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.search;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -10,6 +10,9 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
+import org.schabi.newpipe.extractor.services.soundcloud.channel.SoundcloudChannelInfoItemExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.playlist.SoundcloudPlaylistInfoItemExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.utils.Localization;
 import org.schabi.newpipe.extractor.utils.Parser;
 
@@ -19,7 +22,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory.ITEMS_PER_PAGE;
+import static org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchQueryHandlerFactory.ITEMS_PER_PAGE;
 
 public class SoundcloudSearchExtractor extends SearchExtractor {
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQueryHandlerFactory.java
@@ -1,8 +1,9 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.search;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamExtractor.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.streams;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
@@ -8,6 +8,7 @@ import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.*;
 import org.schabi.newpipe.extractor.utils.Localization;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamInfoItemExtractor.java
@@ -1,7 +1,8 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.streams;
 
 import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/streams/SoundcloudStreamLinkHandlerFactory.java
@@ -1,7 +1,8 @@
-package org.schabi.newpipe.extractor.services.soundcloud;
+package org.schabi.newpipe.extractor.services.soundcloud.streams;
 
 import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/JedenTagEinSetKioskTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/JedenTagEinSetKioskTest.java
@@ -1,0 +1,87 @@
+package org.schabi.newpipe.extractor.services.soundcloud;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.schabi.newpipe.Downloader;
+import org.schabi.newpipe.extractor.ListExtractor;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.utils.Localization;
+import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
+
+public class JedenTagEinSetKioskTest {
+    static KioskExtractor extractor;
+    static ListExtractor.InfoItemsPage<StreamInfoItem> initPage;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        NewPipe.init(Downloader.getInstance(), new Localization("GB", "en"));
+        extractor = SoundCloud
+                .getKioskList()
+                .getExtractorById("jedentageinset", null);
+        extractor.fetchPage();
+        initPage = extractor.getInitialPage();
+    }
+
+    @Test
+    public void getUrlFromApiUrl() throws Exception {
+        assertEquals("https://soundcloud.com/egpodcast/eg744-tiefschwarz",
+            SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/tracks/651375380"));
+    }
+
+    @Test
+    public void getFirstPageSize() throws Exception {
+        assertEquals(6, initPage.getItems().size());
+    }
+
+    @Test
+    public void getName() {
+        assertFalse(initPage.getItems().get(0).getName(),
+                initPage.getItems().get(0).getName().isEmpty());
+    }
+
+    @Test
+    public void getUrl() {
+        for(StreamInfoItem si : initPage.getItems()) {
+            assertTrue(si.getUrl(),
+                    si.getUrl().startsWith("https"));
+            assertTrue(si.getUrl(),
+                    si.getUrl().contains("soundcloud"));
+        }
+    }
+
+    @Test
+    public void getThumbnail() {
+        for(StreamInfoItem si : initPage.getItems()) {
+            assertTrue(si.getThumbnailUrl(),
+                    si.getThumbnailUrl().startsWith("https://www.jedentageinset.de"));
+            assertTrue(si.getThumbnailUrl(),
+                    si.getThumbnailUrl().endsWith("jpg"));
+        }
+    }
+
+    @Test
+    public void getUploadDate() {
+        for(StreamInfoItem si : initPage.getItems()) {
+            assertFalse(si.getUploadDate(), si.getUploadDate().isEmpty());
+        }
+    }
+
+    @Test
+    public void getNextPageUrl() {
+        assertEquals("https://www.jedentageinset.de/page/2",
+                initPage.getNextPageUrl());
+    }
+
+    @Test
+    public void getSecondPage() throws Exception {
+        ListExtractor.InfoItemsPage<StreamInfoItem> secondPage =
+                extractor.getPage("https://www.jedentageinset.de/page/2");
+
+        assertEquals(6, secondPage.getItems().size());
+        assertEquals("https://www.jedentageinset.de/page/3", secondPage.getNextPageUrl());
+
+    }
+}

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/JedenTagEinSetKioskTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/JedenTagEinSetKioskTest.java
@@ -14,6 +14,7 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 public class JedenTagEinSetKioskTest {
     static KioskExtractor extractor;
     static ListExtractor.InfoItemsPage<StreamInfoItem> initPage;
+    static ListExtractor.InfoItemsPage<StreamInfoItem> secondPage;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -23,6 +24,7 @@ public class JedenTagEinSetKioskTest {
                 .getExtractorById("jedentageinset", null);
         extractor.fetchPage();
         initPage = extractor.getInitialPage();
+        secondPage = extractor.getPage("https://www.jedentageinset.de/page/2");
     }
 
     @Test
@@ -70,18 +72,43 @@ public class JedenTagEinSetKioskTest {
     }
 
     @Test
-    public void getNextPageUrl() {
+    public void testGetNextPageUrl() {
         assertEquals("https://www.jedentageinset.de/page/2",
                 initPage.getNextPageUrl());
     }
 
     @Test
-    public void getSecondPage() throws Exception {
-        ListExtractor.InfoItemsPage<StreamInfoItem> secondPage =
-                extractor.getPage("https://www.jedentageinset.de/page/2");
+    public void testForErrors() {
+        assertTrue(initPage.getErrors().toString(), initPage.getErrors().size() == 0);
+    }
 
+    @Test
+    public void testSecondPageEqualsFirstPage() {
+        for(int i = 0; i < secondPage.getItems().size(); i++) {
+            assertFalse("items from first page seem to exist in second: " +
+                            initPage.getItems().get(i).getUrl()
+                    , initPage.getItems().get(i).getUrl()
+                            .equals(secondPage.getItems().get(i).getUrl()));
+        }
+    }
+
+    @Test
+    public void testSecondPageItemCount() {
         assertEquals(6, secondPage.getItems().size());
-        assertEquals("https://www.jedentageinset.de/page/3", secondPage.getNextPageUrl());
+    }
 
+    @Test
+    public void testSecondPageHasErrors() {
+        if(!secondPage.getErrors().isEmpty()) {
+            for(Throwable e : secondPage.getErrors()) {
+                e.printStackTrace();
+                System.err.println("---------------");
+            }
+        }
+    }
+
+    @Test
+    public void testThirdPageUrl() {
+        assertEquals("https://www.jedentageinset.de/page/3", secondPage.getNextPageUrl());
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
+import org.schabi.newpipe.extractor.services.soundcloud.channel.SoundcloudChannelExtractor;
 import org.schabi.newpipe.extractor.utils.Localization;
 
 import static org.junit.Assert.*;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractorTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.SoundcloudChartsLinkHandlerFactory;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.utils.Localization;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsLinkHandlerFactoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.kiosk.SoundcloudChartsLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Localization;
 
 import static junit.framework.TestCase.assertFalse;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -9,6 +9,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
+import org.schabi.newpipe.extractor.services.soundcloud.playlist.SoundcloudPlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.utils.Localization;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -6,6 +6,7 @@ import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.stream.StreamType;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamLinkHandlerFactoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.soundcloud.streams.SoundcloudStreamLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Localization;
 
 import java.util.ArrayList;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorBaseTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorBaseTest.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.extractor.services.soundcloud.search;
 import org.junit.Test;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
-import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchExtractor;
 
 import static org.junit.Assert.assertTrue;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorChannelOnlyTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorChannelOnlyTest.java
@@ -7,8 +7,6 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
-import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchExtractor;
-import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Localization;
 
 import static java.util.Arrays.asList;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorDefaultTest.java
@@ -6,9 +6,6 @@ import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
-import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchExtractor;
-import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSearchExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.utils.Localization;
@@ -17,7 +14,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
-import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 /*
  * Created by Christian Schabesberger on 27.05.18

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQHTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQHTest.java
@@ -9,9 +9,9 @@ import org.schabi.newpipe.extractor.utils.Localization;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory.PLAYLISTS;
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory.TRACKS;
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudSearchQueryHandlerFactory.USERS;
+import static org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchQueryHandlerFactory.PLAYLISTS;
+import static org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchQueryHandlerFactory.TRACKS;
+import static org.schabi.newpipe.extractor.services.soundcloud.search.SoundcloudSearchQueryHandlerFactory.USERS;
 
 public class SoundcloudSearchQHTest {
 


### PR DESCRIPTION
This will add support for [jedentageinset.de](https://jedentageinset.de) to the extractor.
jedentag ein set is a list of techno sets which is maintained by some fine duds from my city. Since the do everything based on soundcloud i thought it was a cool idea to add it as available kiosk to the soundcloud service.