### PR TITLE
Fix casual search error when playlists are in results

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -49,10 +49,11 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     @Override
     public String getUrl() throws ParsingException {
         try {
-            final Element div = el.select("div[class=\"yt-lockup-meta\"]").first();
+            final Element a = el.select("div[class=\"yt-lockup-meta\"]")
+                    .select("ul[class=\"yt-lockup-meta-info\"]")
+                    .select("li").select("a").first();
 
-            if(div != null) {
-                final Element a = div.select("a").first();
+            if(a != null) {
                 return a.attr("abs:href");
             }
 


### PR DESCRIPTION
- [y] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [y] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [no need] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Sometimes there were two divs with class "yt-lockup-meta" in the search item's html, so the extractor couldn't get the correct one.
(the failing test is unrelated)

Fixes TeamNewPipe/NewPipe#2371