### PR TITLE
Add url to ReCaptchaException

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/ReCaptchaException.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/ReCaptchaException.java
@@ -21,7 +21,14 @@ package org.schabi.newpipe.extractor.exceptions;
  */
 
 public class ReCaptchaException extends ExtractionException {
-    public ReCaptchaException(String message) {
+    private String url;
+
+    public ReCaptchaException(String message, String url) {
         super(message);
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -714,8 +714,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         } catch (IOException e) {
             throw new ParsingException(
                     "Could load decryption code form restricted video for the Youtube service.", e);
-        } catch (ReCaptchaException e) {
-            throw new ReCaptchaException("reCaptcha Challenge requested");
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/DashMpdParser.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/DashMpdParser.java
@@ -123,8 +123,6 @@ public class DashMpdParser {
             dashDoc = downloader.download(streamInfo.getDashMpdUrl());
         } catch (IOException ioe) {
             throw new DashMpdParsingException("Could not get dash mpd: " + streamInfo.getDashMpdUrl(), ioe);
-        } catch (ReCaptchaException e) {
-            throw new ReCaptchaException("reCaptcha Challenge needed");
         }
 
         try {

--- a/extractor/src/test/java/org/schabi/newpipe/Downloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/Downloader.java
@@ -129,7 +129,7 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
              * request See : https://github.com/rg3/youtube-dl/issues/5138
              */
             if (con.getResponseCode() == 429) {
-                throw new ReCaptchaException("reCaptcha Challenge requested");
+                throw new ReCaptchaException("reCaptcha Challenge requested", con.getURL().toString());
             }
 
             throw new IOException(con.getResponseCode() + " " + con.getResponseMessage(), e);


### PR DESCRIPTION
- [y] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [y] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [y] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Sometimes YouTube introduces recaptchas only on some pages. By adding an url to the ReCaptchaException the NewPipe app is able to use that url to load the page that originally caused the problem.

Corresponding NewPipe pr: TeamNewPipe/NewPipe#2527