### PR TITLE
Fix id extraction of youtube channels that have no "Subscribe" button

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -83,6 +83,11 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     @Override
     public String getId() throws ParsingException {
         try {
+            return doc.select("meta[itemprop=\"channelId\"]").first().attr("content");
+        } catch (Exception ignored) {}
+
+        // fallback method; does not work with channels that have no "Subscribe" button (e.g. EminemVEVO)
+        try {
             Element element = doc.getElementsByClass("yt-uix-subscription-button").first();
             if (element == null) element = doc.getElementsByClass("yt-uix-subscription-preferences-button").first();
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -66,14 +66,14 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
             if (match.matches()) {
                 return YoutubeChannelExtractor.CHANNEL_URL_BASE + match.group(1);
             }
-        } catch(Throwable ignored) {}
+        } catch(Exception ignored) {}
 
         try {
             // fallback method just in case youtube changes things; it should never run and tests will fail
             // provides an url with "/user/NAME", that is inconsistent with stream and channel extractor
             return el.select("a[class*=\"yt-uix-tile-link\"]").first()
                     .attr("abs:href");
-        } catch (Throwable e) {
+        } catch (Exception e) {
             throw new ParsingException("Could not get channel url", e);
         }
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -56,19 +56,25 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
 
     @Override
     public String getUrl() throws ParsingException {
-        String buttonTrackingUrl = el.select("button[class*=\"yt-uix-button\"]").first()
-                .attr("abs:data-href");
+        try {
+            String buttonTrackingUrl = el.select("button[class*=\"yt-uix-button\"]").first()
+                    .attr("abs:data-href");
 
-        Pattern channelIdPattern = Pattern.compile("(?:.*?)\\%252Fchannel\\%252F([A-Za-z0-9\\-\\_]+)(?:.*)");
-        Matcher match = channelIdPattern.matcher(buttonTrackingUrl);
+            Pattern channelIdPattern = Pattern.compile("(?:.*?)\\%252Fchannel\\%252F([A-Za-z0-9\\-\\_]+)(?:.*)");
+            Matcher match = channelIdPattern.matcher(buttonTrackingUrl);
 
-        if (match.matches()) {
-            return YoutubeChannelExtractor.CHANNEL_URL_BASE + match.group(1);
-        } else {
+            if (match.matches()) {
+                return YoutubeChannelExtractor.CHANNEL_URL_BASE + match.group(1);
+            }
+        } catch(Throwable ignored) {}
+
+        try {
             // fallback method just in case youtube changes things; it should never run and tests will fail
             // provides an url with "/user/NAME", that is inconsistent with stream and channel extractor
             return el.select("a[class*=\"yt-uix-tile-link\"]").first()
                     .attr("abs:href");
+        } catch (Throwable e) {
+            throw new ParsingException("Could not get channel url", e);
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -68,9 +68,9 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
             }
         } catch(Exception ignored) {}
 
+        // fallback method for channels without "Subscribe" button (or just in case yt changes things)
+        // provides an url with "/user/NAME", inconsistent with stream and channel extractor: tests will fail
         try {
-            // fallback method just in case youtube changes things; it should never run and tests will fail
-            // provides an url with "/user/NAME", that is inconsistent with stream and channel extractor
             return el.select("a[class*=\"yt-uix-tile-link\"]").first()
                     .attr("abs:href");
         } catch (Exception e) {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -390,6 +390,100 @@ public class YoutubeChannelExtractorTest {
         }
     }
 
+    // this channel has no "Subscribe" button
+    public static class EminemVEVO implements BaseChannelExtractorTest {
+        private static YoutubeChannelExtractor extractor;
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(Downloader.getInstance(), new Localization("GB", "en"));
+            extractor = (YoutubeChannelExtractor) YouTube
+                    .getChannelExtractor("https://www.youtube.com/user/EminemVEVO/");
+            extractor.fetchPage();
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // Extractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testServiceId() {
+            assertEquals(YouTube.getServiceId(), extractor.getServiceId());
+        }
+
+        @Test
+        public void testName() throws Exception {
+            assertEquals("EminemVEVO", extractor.getName());
+        }
+
+        @Test
+        public void testId() throws Exception {
+            assertEquals("UC20vb-R_px4CguHzzBPhoyQ", extractor.getId());
+        }
+
+        @Test
+        public void testUrl() throws ParsingException {
+            assertEquals("https://www.youtube.com/channel/UC20vb-R_px4CguHzzBPhoyQ", extractor.getUrl());
+        }
+
+        @Test
+        public void testOriginalUrl() throws ParsingException {
+            assertEquals("https://www.youtube.com/user/EminemVEVO/", extractor.getOriginalUrl());
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // ListExtractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testRelatedItems() throws Exception {
+            defaultTestRelatedItems(extractor, YouTube.getServiceId());
+        }
+
+        @Test
+        public void testMoreRelatedItems() throws Exception {
+            defaultTestMoreItems(extractor, YouTube.getServiceId());
+        }
+
+         /*//////////////////////////////////////////////////////////////////////////
+         // ChannelExtractor
+         //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testDescription() throws Exception {
+            final String description = extractor.getDescription();
+            assertTrue(description, description.contains("Eminem on Vevo"));
+        }
+
+        @Test
+        public void testAvatarUrl() throws Exception {
+            String avatarUrl = extractor.getAvatarUrl();
+            assertIsSecureUrl(avatarUrl);
+            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+        }
+
+        @Test
+        public void testBannerUrl() throws Exception {
+            String bannerUrl = extractor.getBannerUrl();
+            assertIsSecureUrl(bannerUrl);
+            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+        }
+
+        @Test
+        public void testFeedUrl() throws Exception {
+            assertEquals("https://www.youtube.com/feeds/videos.xml?channel_id=UC20vb-R_px4CguHzzBPhoyQ", extractor.getFeedUrl());
+        }
+
+        @Test
+        public void testSubscriberCount() throws Exception {
+            // there is no "Subscribe" button
+            long subscribers = extractor.getSubscriberCount();
+            assertEquals("Wrong subscriber count", -1, subscribers);
+        }
+    }
+
+
+
     public static class RandomChannel implements BaseChannelExtractorTest {
         private static YoutubeChannelExtractor extractor;
 
@@ -481,8 +575,9 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testSubscriberCount() throws Exception {
-            assertTrue("Wrong subscriber count", extractor.getSubscriberCount() >= 50);
+            long subscribers = extractor.getSubscriberCount();
+            assertTrue("Wrong subscriber count: " + subscribers, subscribers >= 50);
         }
     }
-};
+}
 


### PR DESCRIPTION
- [yes] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [yes] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [no need] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

In 0.17.1 searching for "eminemvevo" led to a crash: in #184 I changed the way to get the channel url from channel info items, but I left a fallback to the old inconsistent method. But I forgot to correctly handle exceptions so the fallback was not called in case of failure. ;-) The channel "EminemVEVO" apparently has no ".../channel/..." url in search results.

Some youtube channels (such as EminemVEVO) have no "Subscribe" button, so the id could not be extracted leading to a ParsingException. Now the id is extracted in a different way.

Fixes TeamNewPipe/NewPipe#1477