### PR TITLE
Fix 'java.lang.IllegalArgumentException

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -61,7 +61,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     @Override
     public String getUrl() throws ParsingException {
         try {
-            Element el = item.select("div[class*=\"yt-lockup-video\"").first();
+            Element el = item.select("div[class*=\"yt-lockup-video\"]").first();
             Element dl = el.select("h3").first().select("a").first();
             return dl.attr("abs:href");
         } catch (Exception e) {
@@ -72,7 +72,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     @Override
     public String getName() throws ParsingException {
         try {
-            Element el = item.select("div[class*=\"yt-lockup-video\"").first();
+            Element el = item.select("div[class*=\"yt-lockup-video\"]").first();
             Element dl = el.select("h3").first().select("a").first();
             return dl.text();
         } catch (Exception e) {


### PR DESCRIPTION
```
java.lang.IllegalArgumentException: Did not find balanced marker at 'class*="yt-lockup-video"'
    at org.jsoup.helper.Validate.fail(Validate.java:110)
    at org.jsoup.parser.TokenQueue.chompBalanced(TokenQueue.java:294)
    at org.jsoup.select.QueryParser.byAttribute(QueryParser.java:240)
    at org.jsoup.select.QueryParser.findElements(QueryParser.java:156)
    at org.jsoup.select.QueryParser.parse(QueryParser.java:71)
    at org.jsoup.select.QueryParser.parse(QueryParser.java:42)
    at org.jsoup.select.Selector.select(Selector.java:91)
    at org.jsoup.nodes.Element.select(Element.java:372)
    at org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamInfoItemExtractor.getUrl(YoutubeStreamInfoItemExtractor.java:64)
    at org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector.extract(StreamInfoItemsCollector.java:45)
    at org.schabi.newpipe.extractor.search.InfoItemsSearchCollector.extract(InfoItemsSearchCollector.java:63)
    at org.schabi.newpipe.extractor.search.InfoItemsSearchCollector.extract(InfoItemsSearchCollector.java:47)
    at org.schabi.newpipe.extractor.InfoItemsCollector.commit(InfoItemsCollector.java:87)
    at org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSearchExtractor.collectItems(YoutubeSearchExtractor.java:134)
```
  
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
