### PR TITLE
Fix TeamNewPipe/NewPipe#2615

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -952,7 +952,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 ItagItem itagItem = ItagItem.getItag(itag);
                 if (itagItem.itagType == itagTypeWanted) {
                     String streamUrl = formatData.getString("url");
-                    System.out.println(streamUrl);
                     urlAndItags.put(streamUrl, itagItem);
                 }
             }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -429,22 +429,15 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Override
     public String getHlsUrl() throws ParsingException {
         assertPageFetched();
-        try {
-            String hlsvp = "";
-            if (playerArgs != null) {
-                if( playerArgs.isString("hlsvp") ) {
-                    hlsvp = playerArgs.getString("hlsvp", "");
-                }else {
-                    hlsvp = JsonParser.object()
-                            .from(playerArgs.getString("player_response", "{}"))
-                            .getObject("streamingData", new JsonObject())
-                            .getString("hlsManifestUrl", "");
-                }
-            }
 
-            return hlsvp;
+        try {
+            return playerResponse.getObject("streamingData").getString("hlsManifestUrl");
         } catch (Exception e) {
-            throw new ParsingException("Could not get hls manifest url", e);
+            if (playerArgs != null && playerArgs.isString("hlsvp")) {
+                return playerArgs.getString("hlsvp");
+            } else {
+                throw new ParsingException("Could not get hls manifest url", e);
+            }
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -449,11 +449,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public List<AudioStream> getAudioStreams() throws IOException, ExtractionException {
+    public List<AudioStream> getAudioStreams() throws ExtractionException {
         assertPageFetched();
         List<AudioStream> audioStreams = new ArrayList<>();
         try {
-            for (Map.Entry<String, ItagItem> entry : getItags(ADAPTIVE_FMTS, ItagItem.ItagType.AUDIO).entrySet()) {
+            for (Map.Entry<String, ItagItem> entry : getItags(ADAPTIVE_FORMATS, ItagItem.ItagType.AUDIO).entrySet()) {
                 ItagItem itag = entry.getValue();
 
                 AudioStream audioStream = new AudioStream(entry.getKey(), itag.getMediaFormat(), itag.avgBitrate);
@@ -469,11 +469,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public List<VideoStream> getVideoStreams() throws IOException, ExtractionException {
+    public List<VideoStream> getVideoStreams() throws ExtractionException {
         assertPageFetched();
         List<VideoStream> videoStreams = new ArrayList<>();
         try {
-            for (Map.Entry<String, ItagItem> entry : getItags(ADAPTIVE_FMTS, ItagItem.ItagType.VIDEO).entrySet()) {
+            for (Map.Entry<String, ItagItem> entry : getItags(FORMATS, ItagItem.ItagType.VIDEO).entrySet()) {
                 ItagItem itag = entry.getValue();
 
                 VideoStream videoStream = new VideoStream(entry.getKey(), itag.getMediaFormat(), itag.resolutionString);
@@ -493,7 +493,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         assertPageFetched();
         List<VideoStream> videoOnlyStreams = new ArrayList<>();
         try {
-            for (Map.Entry<String, ItagItem> entry : getItags(ADAPTIVE_FMTS, ItagItem.ItagType.VIDEO_ONLY).entrySet()) {
+            for (Map.Entry<String, ItagItem> entry : getItags(ADAPTIVE_FORMATS, ItagItem.ItagType.VIDEO_ONLY).entrySet()) {
                 ItagItem itag = entry.getValue();
 
                 VideoStream videoStream = new VideoStream(entry.getKey(), itag.getMediaFormat(), itag.resolutionString, true);
@@ -530,7 +530,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         assertPageFetched();
         try {
             if (playerArgs != null && (playerArgs.has("ps") && playerArgs.get("ps").toString().equals("live") ||
-                    playerArgs.get(URL_ENCODED_FMT_STREAM_MAP).toString().isEmpty())) {
+                    playerResponse.getObject("streamingData").getArray(FORMATS).isEmpty())) {
                 return StreamType.LIVE_STREAM;
             }
         } catch (Exception e) {
@@ -606,8 +606,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     // Fetch page
     //////////////////////////////////////////////////////////////////////////*/
 
-    private static final String URL_ENCODED_FMT_STREAM_MAP = "url_encoded_fmt_stream_map";
-    private static final String ADAPTIVE_FMTS = "adaptiveFormats";
+    private static final String FORMATS = "formats";
+    private static final String ADAPTIVE_FORMATS = "adaptiveFormats";
     private static final String HTTPS = "https:";
     private static final String CONTENT = "content";
     private static final String DECRYPTION_FUNC_NAME = "decrypt";

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -929,10 +929,22 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             int itag = formatData.getInt("itag");
 
             if (ItagItem.isSupported(itag)) {
-                ItagItem itagItem = ItagItem.getItag(itag);
-                if (itagItem.itagType == itagTypeWanted) {
-                    String streamUrl = formatData.getString("url");
-                    urlAndItags.put(streamUrl, itagItem);
+                try {
+                    ItagItem itagItem = ItagItem.getItag(itag);
+                    if (itagItem.itagType == itagTypeWanted) {
+                        String streamUrl;
+                        if (formatData.has("url")) {
+                            streamUrl = formatData.getString("url");
+                        } else {
+                            // this url has an encrypted signature
+                            Map<String, String> cipher = Parser.compatParseMap(formatData.getString("cipher"));
+                            streamUrl = cipher.get("url") + "&" + cipher.get("sp") + "=" + decryptSignature(cipher.get("s"), decryptionCode);
+                        }
+
+                        urlAndItags.put(streamUrl, itagItem);
+                    }
+                } catch (UnsupportedEncodingException ignored) {
+
                 }
             }
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -254,20 +254,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public long getLength() throws ParsingException {
         assertPageFetched();
 
-        final JsonObject playerResponse;
-        try {
-            final String pr;
-            if(playerArgs != null) {
-                pr = playerArgs.getString("player_response");
-            } else {
-                pr = videoInfoPage.get("player_response");
-            }
-            playerResponse = JsonParser.object()
-                    .from(pr);
-        } catch (Exception e) {
-            throw new ParsingException("Could not get playerResponse", e);
-        }
-
         // try getting duration from playerargs
         try {
             String durationMs = playerResponse
@@ -859,19 +845,13 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         } catch (IOException | ExtractionException e) {
             throw new SubtitlesException("Unable to download player configs", e);
         }
-        final String playerResponse = playerConfig.getObject("args", new JsonObject())
-                .getString("player_response");
 
         final JsonObject captions;
-        try {
-            if (playerResponse == null || !JsonParser.object().from(playerResponse).has("captions")) {
-                // Captions does not exist
-                return Collections.emptyList();
-            }
-            captions = JsonParser.object().from(playerResponse).getObject("captions");
-        } catch (JsonParserException e) {
-            throw new SubtitlesException("Unable to parse subtitles listing", e);
+        if (!playerResponse.has("captions")) {
+            // Captions does not exist
+            return Collections.emptyList();
         }
+        captions = playerResponse.getObject("captions");
 
         final JsonObject renderer = captions.getObject("playerCaptionsTracklistRenderer", new JsonObject());
         final JsonArray captionsArray = renderer.getArray("captionTracks", new JsonArray());


### PR DESCRIPTION
~This is the fix, but there some things that could be improved. Now the key URL_ENCODED_FMT_STREAM_MAP (line 623) is unused and has been replaced by ADAPTIVE_FMTS in the only place it was used: getVideoStreams(). I don't know if this is ok.~
~Also, I have added a field to the YoutubeStreamExtractor, playerResponse, to avoid extracting it every time. But I didn't use the class field in all places possible since I do not have time just now.~
~Also, now stream urls seem to have no signature ("s" or "sig") anymore, I tried with a video and every provided url worked. Still I don't know if this is ok.~
Fixes TeamNewPipe/NewPipe#2615

This pr is probably ready, here is a debug apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/3602205/app-debug.zip)
**Please test** whether all the video & audio formats work (I don't have much time to test now)