### PR TITLE
Fix some formats not working in some YouTube videos

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -943,6 +943,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                             streamUrl = cipher.get("url") + "&" + cipher.get("sp") + "=" + decryptSignature(cipher.get("s"), decryptionCode);
                         }
 
+                        if (formatData.has("type") && formatData.getString("type").equals("FORMAT_STREAM_TYPE_OTF")) {
+                            streamUrl += "&sq=1";
+                        }
                         urlAndItags.put(streamUrl, itagItem);
                     }
                 } catch (UnsupportedEncodingException ignored) {


### PR DESCRIPTION
In TeamNewPipe/NewPipe#2525 the reporter provides a YouTube stream for which reliably some formats do not work (never). The urls provided by the extractor generate a 404 error code. After analyzing the requests made by the official youtube website I saw that by adding `&sq=N` (with N being a number in range [0,54]) to the end of the url the error 404 goes away. [The complete list of things added by YouTube is `&alr=yes&cpn=uc6VjfO-gQ_9g-Zo&cver=2.20191003.04.00&sq=23&rn=38&rbuf=116603`, but changing/removing any of them except `sq` has no consequence]
The problem is that the response data from the modified url is very small (<~200.000 bytes), so it is surely not a video, even though `Content-Type: video/webm` is in reponse headers.

The json format data of a non-working format is (my ip was replaced by XXX.XX.XXX.XXX):
```
{itag=247, qualityLabel=720p, width=1280, fps=30, projectionType=RECTANGULAR, bitrate=1505280, mimeType=video/webm; codecs="vp9", lastModified=1551012563152296, type=FORMAT_STREAM_TYPE_OTF, url=https://r3---sn-fpoq-8jxe.googlevideo.com/videoplayback?expire=1570154150&ei=RlKWXZSzK4Sn7gPUpr7ICw&ip=XXX.XX.XXX.XXX&id=o-AJlLYtVbN5rf_wCmfOlOiWZd8XrvVu09ARndUXGkqcNv&itag=247&aitags=133%2C134%2C135%2C136%2C160%2C242%2C243%2C244%2C247%2C278&source=yt_otf&requiressl=yes&mm=31%2C29&mn=sn-fpoq-8jxe%2Csn-hpa7kn7l&ms=au%2Crdu&mv=m&mvi=2&pl=16&initcwndbps=840000&mime=video%2Fwebm&otf=1&otfp=1&dur=0.000&lmt=1551012563152296&mt=1570132463&fvip=6&keepalive=yes&fexp=23842630&c=WEB&sparams=expire%2Cei%2Cip%2Cid%2Caitags%2Csource%2Crequiressl%2Cmime%2Cotf%2Cotfp%2Cdur%2Clmt&sig=ALgxI2wwRQIhAJGMTCrzrmdJYWMZin9ckJOAXj9xtgnFo-yv4jDD0ZN6AiBmc8Mvx8UXjtZZagTG2CuFtSW-9ey1qjMc1_8MNzHwgg%3D%3D&lsparams=mm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AHylml4wRgIhALNNz-nB9rsbQ0IOzRLpJ-fSi5XWhHr2qBfu6N1EHLCyAiEApX7F-8FW4K7IPJ2Or6AKKgAbEoPrb1VxLWNhGycMhc8%3D, height=720, quality=hd720}
```

I noticed that `type=FORMAT_STREAM_TYPE_OTF` is there for every non-working format, so this probably means something (I have no idea what, though). Also, in non-working formats there is less information that in working ones (e.g. `approxDurationMs`, `contentLength`, `indexRange` are missing).

This pr solves nothing currently, I hope @omarroth @TobiGr can help me ;-)