### PR TITLE
Quick fix for failing test

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchCountTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchCountTest.java
@@ -17,7 +17,7 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link YoutubeSearchExtractor}
  */
 public class YoutubeSearchCountTest {
-    public static class YoutubeChannelViewCountTest extends YoutubeSearchExtractorBaseTest {
+    public static class YoutubeChannelSubscriberCountTest extends YoutubeSearchExtractorBaseTest {
         @BeforeClass
         public static void setUpClass() throws Exception {
             NewPipe.init(Downloader.getInstance(), new Localization("GB", "en"));
@@ -28,10 +28,15 @@ public class YoutubeSearchCountTest {
         }
 
         @Test
-        public void testViewCount() {
+        public void testSubscriberCount() {
             ChannelInfoItem ci = (ChannelInfoItem) itemsPage.getItems().get(0);
-            assertTrue("Count does not fit: " + Long.toString(ci.getSubscriberCount()),
-                    69043316 < ci.getSubscriberCount() && ci.getSubscriberCount() < 103043316);
+            long subscriberCount = ci.getSubscriberCount();
+
+            // Only test if subscribers count is available in the search page
+            if (subscriberCount != -1) {
+                assertTrue("Count does not fit: " + Long.toString(subscriberCount),
+                        69043316 < subscriberCount && subscriberCount < 103043316);
+            }
         }
     }
 }


### PR DESCRIPTION
Tests should be refactored as soon as possible. I mean [look at their state](https://github.com/TeamNewPipe/NewPipeExtractor/blob/d14c45c948d3f0641cd41961dca93c7c860d3018/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java#L276..L277), it's sad, really.

For example, from time to time (read often) we get rate limited and receive a 500 status from SoundCloud, we should implement retry and back off in the downloader used in tests. They are very brittle in the current state, and yes, we should expect them to be because we don't control the source, but we can at least improve the situation.

This is just a temporary quick fix.