### PR TITLE
Fix SoundCloud client_id extraction and update SoundCloud client_id

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -31,7 +31,7 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 public class SoundcloudParsingHelper {
-    private static final String HARDCODED_CLIENT_ID = "LHzSAKe8eP9Yy3FgBugfBapRPLncO6Ng"; // Updated on 22/10/19
+    private static final String HARDCODED_CLIENT_ID = "bkcJLoXNaiFlsLaKBQXOxO5FhW0NJVnu"; // Updated on 29/11/19
     private static String clientId;
     
     private SoundcloudParsingHelper() {
@@ -73,10 +73,15 @@ public class SoundcloudParsingHelper {
         throw new ExtractionException("Couldn't extract client id");
     }
 
-    static boolean checkIfHardcodedClientIdIsValid(Downloader dl) throws IOException, ReCaptchaException {
+    static boolean checkIfHardcodedClientIdIsValid(Downloader dl) {
         final String apiUrl = "https://api.soundcloud.com/connect?client_id=" + HARDCODED_CLIENT_ID;
-        // Should return 200 to indicate that the client id is valid, a 401 is returned otherwise.
-        return dl.head(apiUrl).responseCode() == 200;
+        try {
+            // Should return 200 to indicate that the client id is valid, a 401 is returned otherwise.
+            return dl.head(apiUrl).responseCode() == 200;
+        } catch (Exception ignored) {
+            // No need to throw an exception here. If something went wrong, the client_id is wrong
+            return false;
+        }
     }
 
     static Calendar parseDate(String textualUploadDate) throws ParsingException {


### PR DESCRIPTION
Don't throw exception when hard coded client_id is wrong.
Addresses TeamNewPipe/NewPipe#2823

There is still one problem left: the audioStreamTest fails with a 401 response. Can someone please look into this?

CC @mauriciocolli @Stypox @theScrabi 

