### PR TITLE
fix switching on null causing NPE

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -662,7 +662,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             }
         }
 
-        return errorReason != null ? errorReason.toString() : null;
+        return errorReason != null ? errorReason.toString() : "";
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See: https://github.com/TeamNewPipe/NewPipeExtractor/issues/197
Suggested workaround: https://github.com/TeamNewPipe/NewPipeExtractor/issues/197#issuecomment-535096912
Tested by recompiling NewPipe with the changes and playing some video, but I could not find a video which triggered the NPE. The video that triggered the NPE before does now work with the unmodified version aswell.
@CWftw I did not notice that you have forked too: https://github.com/CWftw/NewPipeExtractor maybe you should make the PR.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
