### PR TITLE
Extractor for youtube mix (auto-generated playlist)

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -28,6 +28,7 @@ import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.youtube.extractors.*;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeCommentsLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory;
@@ -101,7 +102,11 @@ public class YoutubeService extends StreamingService {
 
     @Override
     public PlaylistExtractor getPlaylistExtractor(ListLinkHandler linkHandler) {
-        return new YoutubePlaylistExtractor(this, linkHandler);
+        if (YoutubeParsingHelper.isYoutubeMixId(linkHandler.getId())) {
+            return new YoutubeMixPlaylistExtractor(this, linkHandler);
+        } else {
+            return new YoutubePlaylistExtractor(this, linkHandler);
+        }
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -18,6 +18,10 @@ import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingH
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
+/**
+ * A YoutubePlaylistExtractor for a mix (auto-generated playlist).
+ * It handles urls in the format of "youtube.com/watch?v=videoId&list=playlistId"
+ */
 public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
 
   private Document doc;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -1,0 +1,196 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.localization.TimeAgoParser;
+import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
+
+public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
+
+  private Document doc;
+
+  public YoutubeMixPlaylistExtractor(StreamingService service, ListLinkHandler linkHandler) {
+    super(service, linkHandler);
+  }
+
+  @Override
+  public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
+    final String url = getUrl();
+    final Response response = downloader.get(url, getExtractorLocalization());
+    doc = YoutubeParsingHelper.parseAndCheckPage(url, response);
+  }
+
+  @Nonnull
+  @Override
+  public String getName() throws ParsingException {
+    try {
+      return doc.select("div[class=\"playlist-info\"] h3[class=\"playlist-title\"]").first().text();
+    } catch (Exception e) {
+      throw new ParsingException("Could not get playlist name", e);
+    }
+  }
+
+  @Override
+  public String getThumbnailUrl() throws ParsingException {
+    try {
+      return doc.select("ol[class*=\"playlist-videos-list\"] li").first().attr("data-thumbnail-url");
+    } catch (Exception e) {
+      throw new ParsingException("Could not get playlist thumbnail", e);
+    }
+  }
+
+  @Override
+  public String getBannerUrl() {
+    return "";
+  }
+
+  @Override
+  public String getUploaderUrl() {
+    //Youtube mix are auto-generated
+    return "";
+  }
+
+  @Override
+  public String getUploaderName() {
+    //Youtube mix are auto-generated
+    return "";
+  }
+
+  @Override
+  public String getUploaderAvatarUrl() {
+    //Youtube mix are auto-generated
+    return "";
+  }
+
+  @Override
+  public long getStreamCount() {
+    // Auto-generated playlist always start with 25 videos and are endless
+    // But the html doesn't have a continuation url
+    return doc.select("ol[class*=\"playlist-videos-list\"] li").size();
+  }
+
+  @Nonnull
+  @Override
+  public InfoItemsPage<StreamInfoItem> getInitialPage() {
+    StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
+    Element ol = doc.select("ol[class*=\"playlist-videos-list\"]").first();
+    collectStreamsFrom(collector, ol);
+    return new InfoItemsPage<>(collector, getNextPageUrl());
+  }
+
+  @Override
+  public String getNextPageUrl() {
+    return "";
+  }
+
+  @Override
+  public InfoItemsPage<StreamInfoItem> getPage(final String pageUrl) {
+    //Continuations are not implemented
+    return null;
+  }
+
+  private void collectStreamsFrom(
+      @Nonnull StreamInfoItemsCollector collector,
+      @Nullable Element element) {
+    collector.reset();
+
+    if (element == null) {
+      return;
+    }
+
+    final LinkHandlerFactory streamLinkHandlerFactory = getService().getStreamLHFactory();
+    final TimeAgoParser timeAgoParser = getTimeAgoParser();
+
+    for (final Element li : element.children()) {
+
+      collector.commit(new YoutubeStreamInfoItemExtractor(li, timeAgoParser) {
+
+        @Override
+        public boolean isAd() {
+          return false;
+        }
+
+        @Override
+        public String getUrl() throws ParsingException {
+          try {
+            return streamLinkHandlerFactory.fromId(li.attr("data-video-id")).getUrl();
+          } catch (Exception e) {
+            throw new ParsingException("Could not get web page url for the video", e);
+          }
+        }
+
+        @Override
+        public String getName() throws ParsingException {
+          try {
+            return li.attr("data-video-title");
+          } catch (Exception e) {
+            throw new ParsingException("Could not get name", e);
+          }
+        }
+
+        @Override
+        public long getDuration() throws ParsingException {
+          //Not present in doc
+          return 0;
+        }
+
+        @Override
+        public String getUploaderName() throws ParsingException {
+          try {
+            return li.select(
+                "div[class=\"playlist-video-description\"]"
+                    + "span[class=\"video-uploader-byline\"]")
+                .first()
+                .text();
+          } catch (Exception e) {
+            throw new ParsingException("Could not get uploader", e);
+          }
+        }
+
+        @Override
+        public String getUploaderUrl() {
+          //Not present in doc
+          return "";
+        }
+
+        @Override
+        public String getTextualUploadDate() {
+          //Not present in doc
+          return "";
+        }
+
+        @Override
+        public long getViewCount() {
+          return -1;
+        }
+
+        @Override
+        public String getThumbnailUrl() throws ParsingException {
+          try {
+            return "https://i.ytimg.com/vi/" + streamLinkHandlerFactory.fromUrl(getUrl()).getId()
+                + "/hqdefault.jpg";
+          } catch (Exception e) {
+            throw new ParsingException("Could not get thumbnail url", e);
+          }
+        }
+      });
+    }
+  }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -143,4 +143,8 @@ public class YoutubeParsingHelper {
         uploadDate.setTime(date);
         return uploadDate;
     }
+
+    public static boolean isYoutubeMixId(String playlistId) {
+        return playlistId.startsWith("RD");
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -144,6 +144,12 @@ public class YoutubeParsingHelper {
         return uploadDate;
     }
 
+    /**
+     * Checks if the given playlist id is a mix (auto-generated playlist)
+     * Ids from a mix start with "RD"
+     * @param playlistId
+     * @return Whether given id belongs to a mix
+     */
     public static boolean isYoutubeMixId(String playlistId) {
         return playlistId.startsWith("RD");
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
@@ -1,6 +1,9 @@
 package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 
+import java.net.MalformedURLException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
 
@@ -59,5 +62,23 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public ListLinkHandler fromUrl(String url) throws ParsingException {
+        try {
+            URL urlObj = Utils.stringToURL(url);
+            String listID = Utils.getQueryValue(urlObj, "list");
+            if (listID != null && YoutubeParsingHelper.isYoutubeMixId(listID)) {
+                String videoID = Utils.getQueryValue(urlObj, "v");
+                String newUrl = "https://www.youtube.com/watch?v=" + videoID + "&list=" + listID;
+                return new ListLinkHandler(new LinkHandler(url, newUrl, listID), getContentFilter(url),
+                    getSortFilter(url));
+            }
+        } catch (MalformedURLException exception) {
+            throw new ParsingException("Error could not parse url :" + exception.getMessage(),
+                exception);
+        }
+        return super.fromUrl(url);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
@@ -68,9 +68,6 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
      * If it is a mix (auto-generated playlist) url, return a Linkhandler where the url is like
      * youtube.com/watch?v=videoId&list=playlistId
      * <p>Otherwise use super</p>
-     * @param url
-     * @return
-     * @throws ParsingException
      */
     @Override
     public ListLinkHandler fromUrl(String url) throws ParsingException {
@@ -79,6 +76,9 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
             String listID = Utils.getQueryValue(urlObj, "list");
             if (listID != null && YoutubeParsingHelper.isYoutubeMixId(listID)) {
                 String videoID = Utils.getQueryValue(urlObj, "v");
+                if (videoID == null) {
+                    videoID = listID.substring(2);
+                }
                 String newUrl = "https://www.youtube.com/watch?v=" + videoID + "&list=" + listID;
                 return new ListLinkHandler(new LinkHandler(url, newUrl, listID), getContentFilter(url),
                     getSortFilter(url));

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
@@ -64,6 +64,14 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
         return true;
     }
 
+    /**
+     * If it is a mix (auto-generated playlist) url, return a Linkhandler where the url is like
+     * youtube.com/watch?v=videoId&list=playlistId
+     * <p>Otherwise use super</p>
+     * @param url
+     * @return
+     * @throws ParsingException
+     */
     @Override
     public ListLinkHandler fromUrl(String url) throws ParsingException {
         try {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

closes  TeamNewPipe/NewPipe#2895

## Problem
As describes in the issue in the NewPipe repo, when sharing a youtube mix to newpipe, it crashes. Reason for that is that the linkhandler receives (1)"https://www.youtube.com/watch?v=QXCE3Betyug&list=RDQXCE3Betyug" and converts it to (2)"https://www.youtube.com/playlist?list=RDQXCE3Betyug", which loads a basicly empty page.

## Changes
- The LinkHandler doesn't convert mix urls.
- New PlaylistExtractor to extract playlist information from the url (1).
- The YoutubeService uses the new extractor if it is a mix.

## Testing
I tested the changes on my android 10 and 7.1 devices and a 5.0 emulator, by:
- sharing a link from my browser to NewPipe
- saving the playlist and opening it from the bookmarks fragment
- playling the playlist (didn't play on 5.0 emulator, but i can't play ANY video here)

This doesn't require changes in the app, besides updating the extractor dependency.

[app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/4153412/app-debug.zip)

## What's missing
- Mixes are generated based on the user. Meaning if I open the site once while logged in and once while in incognito mode, it gives me different playlists.
- Mixes on youtube are endless but i couldn't find a link for the continuation
- A lot of other fields are not present in the html, so i just return empty strings or 0

## Notes
- In the mix url (1) above you can see the playlist id is just the video id with "RD" at the start.
All mix urls that i found so far are like that, where the playlist id is "RD" + video id of the first video. I assume RD stands for radio (Playlist ids start with "PL" instead)