### PR TITLE
Improve yt_new

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -5,11 +5,9 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 
-import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
-import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
@@ -68,10 +66,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");
@@ -222,10 +218,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -2,8 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
@@ -19,14 +17,11 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 
 /*
@@ -62,22 +57,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = super.getUrl() + "/videos?pbj=1&view=0&flow=grid";
 
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(url);
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }
@@ -214,22 +194,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         fetchPage();
 
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(pageUrl);
 
         JsonObject sectionListContinuation = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("gridContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -53,6 +53,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     /*package-private*/ static final String CHANNEL_URL_BASE = "https://www.youtube.com/channel/";
 
     private JsonObject initialData;
+    private JsonObject videoTab;
 
     public YoutubeChannelExtractor(StreamingService service, ListLinkHandler linkHandler) {
         super(service, linkHandler);
@@ -276,6 +277,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     }
 
     private JsonObject getVideoTab() throws ParsingException {
+        if (this.videoTab != null) return this.videoTab;
+
         JsonArray tabs = initialData.getObject("contents").getObject("twoColumnBrowseResultsRenderer")
                 .getArray("tabs");
         JsonObject videoTab = null;
@@ -301,6 +304,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 return null;
         } catch (Exception ignored) {}
 
+        this.videoTab = videoTab;
         return videoTab;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -177,8 +177,12 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 throw new ParsingException("Could not get subscriber count", e);
             }
         } else {
-            // If the element is null, the channel have the subscriber count disabled
-            return -1;
+            // If there's no subscribe button, the channel has the subscriber count disabled
+            if (initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("subscribeButton") == null) {
+                return -1;
+            } else {
+                return 0;
+            }
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
@@ -50,8 +51,6 @@ import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeP
 
 @SuppressWarnings("WeakerAccess")
 public class YoutubeChannelExtractor extends ChannelExtractor {
-    /*package-private*/ static final String CHANNEL_URL_BASE = "https://www.youtube.com/channel/";
-
     private JsonObject initialData;
     private JsonObject videoTab;
 
@@ -96,7 +95,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     @Override
     public String getUrl() throws ParsingException {
         try {
-            return CHANNEL_URL_BASE + getId();
+            return YoutubeChannelLinkHandlerFactory.getInstance().getUrl("channel/" + getId());
         } catch (ParsingException e) {
             return super.getUrl();
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -61,7 +61,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
 
     @Override
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
-        final String url = super.getUrl() + "/videos?pbj=1";
+        final String url = super.getUrl() + "/videos?pbj=1&view=0&flow=grid";
 
         JsonArray ajaxJson;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -128,10 +128,6 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
             String url = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("avatar")
                     .getArray("thumbnails").getObject(0).getString("url");
 
-            // the first characters of the avatar URLs are different for each channel and some are not even valid URLs
-            if (url.startsWith("//")) {
-                url = url.substring(2);
-            }
             if (url.startsWith(HTTP)) {
                 url = Utils.replaceHttpWithHttps(url);
             } else if (!url.startsWith(HTTPS)) {
@@ -155,10 +151,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
             if (url == null || url.contains("s.ytimg.com") || url.contains("default_banner")) {
                 return null;
             }
-            // the first characters of the banner URLs are different for each channel and some are not even valid URLs
-            if (url.startsWith("//")) {
-                url = url.substring(2);
-            }
+
             if (url.startsWith(HTTP)) {
                 url = Utils.replaceHttpWithHttps(url);
             } else if (!url.startsWith(HTTPS)) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -57,7 +57,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = super.getUrl() + "/videos?pbj=1&view=0&flow=grid";
 
-        final JsonArray ajaxJson = getJsonResponse(url);
+        final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }
@@ -194,7 +194,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         fetchPage();
 
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        final JsonArray ajaxJson = getJsonResponse(pageUrl);
+        final JsonArray ajaxJson = getJsonResponse(pageUrl, getExtractorLocalization());
 
         JsonObject sectionListContinuation = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("gridContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -25,9 +25,8 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 /*
  * Created by Christian Schabesberger on 25.07.16.
@@ -128,13 +127,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
             String url = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("avatar")
                     .getArray("thumbnails").getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get avatar", e);
         }
@@ -152,13 +145,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 return null;
             }
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get banner", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
@@ -97,7 +98,11 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public String getDescription() throws ParsingException {
         try {
-            return channelInfoItem.getObject("descriptionSnippet").getArray("runs").getObject(0).getString("text");
+            StringBuilder description = new StringBuilder();
+            JsonArray descriptionArray = channelInfoItem.getObject("descriptionSnippet").getArray("runs");
+            for (Object descriptionPart : descriptionArray)
+                description.append(((JsonObject) descriptionPart).getString("text"));
+            return description.toString();
         } catch (Exception e) {
             throw new ParsingException("Could not get description", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -7,9 +7,8 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 /*
  * Created by Christian Schabesberger on 12.02.17.
@@ -43,13 +42,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
         try {
             String url = channelInfoItem.getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
-import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
@@ -8,6 +7,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
 import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
@@ -59,7 +59,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public String getName() throws ParsingException {
         try {
-            return channelInfoItem.getObject("title").getString("simpleText");
+            return getTextFromObject(channelInfoItem.getObject("title"));
         } catch (Exception e) {
             throw new ParsingException("Could not get name", e);
         }
@@ -68,7 +68,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public String getUrl() throws ParsingException {
         try {
-            String id = "channel/" + channelInfoItem.getString("channelId"); // Does prepending 'channel/' always work?
+            String id = "channel/" + channelInfoItem.getString("channelId");
             return YoutubeChannelLinkHandlerFactory.getInstance().getUrl(id);
         } catch (Exception e) {
             throw new ParsingException("Could not get url", e);
@@ -78,7 +78,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public long getSubscriberCount() throws ParsingException {
         try {
-            String subscribers = channelInfoItem.getObject("subscriberCountText").getString("simpleText").split(" ")[0];
+            String subscribers = getTextFromObject(channelInfoItem.getObject("subscriberCountText"));
             return Utils.mixedNumberWordToLong(subscribers);
         } catch (Exception e) {
             throw new ParsingException("Could not get subscriber count", e);
@@ -88,8 +88,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public long getStreamCount() throws ParsingException {
         try {
-            return Long.parseLong(Utils.removeNonDigitCharacters(channelInfoItem.getObject("videoCountText")
-                    .getArray("runs").getObject(0).getString("text")));
+            return Long.parseLong(Utils.removeNonDigitCharacters(getTextFromObject(channelInfoItem.getObject("videoCountText"))));
         } catch (Exception e) {
             throw new ParsingException("Could not get stream count", e);
         }
@@ -98,11 +97,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public String getDescription() throws ParsingException {
         try {
-            StringBuilder description = new StringBuilder();
-            JsonArray descriptionArray = channelInfoItem.getObject("descriptionSnippet").getArray("runs");
-            for (Object descriptionPart : descriptionArray)
-                description.append(((JsonObject) descriptionPart).getString("text"));
-            return description.toString();
+            return getTextFromObject(channelInfoItem.getObject("descriptionSnippet"));
         } catch (Exception e) {
             throw new ParsingException("Could not get description", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -42,14 +42,13 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     public String getThumbnailUrl() throws ParsingException {
         try {
             String url = channelInfoItem.getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
-            if (url.startsWith("//")) {
-                url = url.substring(2);
-            }
+
             if (url.startsWith(HTTP)) {
                 url = Utils.replaceHttpWithHttps(url);
             } else if (!url.startsWith(HTTPS)) {
                 url = HTTPS + url;
             }
+
             return url;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -2,8 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -12,20 +10,16 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
 
@@ -42,22 +36,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(url);
 
         initialData = ajaxJson.getObject(1).getObject("response");
         playlistInfo = getPlaylistInfo();
@@ -207,22 +186,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         }
 
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(pageUrl);
 
         JsonObject sectionListContinuation = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("playlistVideoListContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -36,7 +36,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        final JsonArray ajaxJson = getJsonResponse(url);
+        final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
 
         initialData = ajaxJson.getObject(1).getObject("response");
         playlistInfo = getPlaylistInfo();
@@ -186,7 +186,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         }
 
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        final JsonArray ajaxJson = getJsonResponse(pageUrl);
+        final JsonArray ajaxJson = getJsonResponse(pageUrl, getExtractorLocalization());
 
         JsonObject sectionListContinuation = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("playlistVideoListContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -108,15 +108,14 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
 
         if (url == null) {
             try {
-                return initialData.getObject("microformat").getObject("microformatDataRenderer").getObject("thumbnail")
+                url = initialData.getObject("microformat").getObject("microformatDataRenderer").getObject("thumbnail")
                         .getArray("thumbnails").getObject(0).getString("url");
             } catch (Exception ignored) {}
+
+            if (url == null) throw new ParsingException("Could not get playlist thumbnail");
         }
 
-        if (url != null && !url.isEmpty()) {
-            return fixThumbnailUrl(url);
-        }
-        throw new ParsingException("Could not get playlist thumbnail");
+        return fixThumbnailUrl(url);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -43,10 +43,8 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");
@@ -202,10 +200,8 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -28,7 +28,6 @@ import javax.annotation.Nonnull;
 @SuppressWarnings("WeakerAccess")
 public class YoutubePlaylistExtractor extends PlaylistExtractor {
     private JsonObject initialData;
-    private JsonObject uploaderInfo;
     private JsonObject playlistInfo;
 
     public YoutubePlaylistExtractor(StreamingService service, ListLinkHandler linkHandler) {
@@ -57,7 +56,6 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         }
 
         initialData = ajaxJson.getObject(1).getObject("response");
-        uploaderInfo = getUploaderInfo();
         playlistInfo = getPlaylistInfo();
     }
 
@@ -140,7 +138,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     public String getUploaderUrl() throws ParsingException {
         try {
             return YoutubeChannelExtractor.CHANNEL_URL_BASE +
-                    uploaderInfo.getObject("navigationEndpoint").getObject("browseEndpoint").getString("browseId");
+                    getUploaderInfo().getObject("navigationEndpoint").getObject("browseEndpoint").getString("browseId");
         } catch (Exception e) {
             throw new ParsingException("Could not get playlist uploader url", e);
         }
@@ -149,7 +147,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     @Override
     public String getUploaderName() throws ParsingException {
         try {
-            return uploaderInfo.getObject("title").getArray("runs").getObject(0).getString("text");
+            return getUploaderInfo().getObject("title").getArray("runs").getObject(0).getString("text");
         } catch (Exception e) {
             throw new ParsingException("Could not get playlist uploader name", e);
         }
@@ -158,7 +156,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     @Override
     public String getUploaderAvatarUrl() throws ParsingException {
         try {
-            return uploaderInfo.getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
+            return getUploaderInfo().getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
         } catch (Exception e) {
             throw new ParsingException("Could not get playlist uploader avatar", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -25,10 +25,9 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 @SuppressWarnings("WeakerAccess")
 public class YoutubePlaylistExtractor extends PlaylistExtractor {
@@ -136,13 +135,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         }
 
         if (url != null && !url.isEmpty()) {
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         }
         throw new ParsingException("Could not get playlist thumbnail");
     }
@@ -176,13 +169,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         try {
             String url = getUploaderInfo().getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get playlist uploader avatar", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -8,6 +8,8 @@ import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylist
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtractor {
     private JsonObject playlistInfoItem;
@@ -19,8 +21,16 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     @Override
     public String getThumbnailUrl() throws ParsingException {
         try {
-            return playlistInfoItem.getArray("thumbnails").getObject(0).getArray("thumbnails")
-                    .getObject(0).getString("url");
+            String url = playlistInfoItem.getArray("thumbnails").getObject(0)
+                    .getArray("thumbnails").getObject(0).getString("url");
+
+            if (url.startsWith(HTTP)) {
+                url = Utils.replaceHttpWithHttps(url);
+            } else if (!url.startsWith(HTTPS)) {
+                url = HTTPS + url;
+            }
+
+            return url;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -7,9 +7,8 @@ import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtractor {
     private JsonObject playlistInfoItem;
@@ -24,13 +23,7 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
             String url = playlistInfoItem.getArray("thumbnails").getObject(0)
                     .getArray("thumbnails").getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -7,6 +7,8 @@ import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
+
 public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtractor {
     private JsonObject playlistInfoItem;
 
@@ -27,7 +29,7 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     @Override
     public String getName() throws ParsingException {
         try {
-            return playlistInfoItem.getObject("title").getString("simpleText");
+            return getTextFromObject(playlistInfoItem.getObject("title"));
         } catch (Exception e) {
             throw new ParsingException("Could not get name", e);
         }
@@ -46,7 +48,7 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     @Override
     public String getUploaderName() throws ParsingException {
         try {
-            return playlistInfoItem.getObject("longBylineText").getArray("runs").getObject(0).getString("text");
+            return getTextFromObject(playlistInfoItem.getObject("longBylineText"));
         } catch (Exception e) {
             throw new ParsingException("Could not get uploader name", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -51,7 +51,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        final JsonArray ajaxJson = getJsonResponse(url);
+        final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }
@@ -104,7 +104,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         }
 
         InfoItemsSearchCollector collector = getInfoItemSearchCollector();
-        final JsonArray ajaxJson = getJsonResponse(pageUrl);
+        final JsonArray ajaxJson = getJsonResponse(pageUrl, getExtractorLocalization());
 
         JsonObject itemSectionRenderer = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("itemSectionContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -101,11 +101,13 @@ public class YoutubeSearchExtractor extends SearchExtractor {
     @Override
     public InfoItemsPage<InfoItem> getInitialPage() throws ExtractionException {
         InfoItemsSearchCollector collector = getInfoItemSearchCollector();
-        JsonArray videos = initialData.getObject("contents").getObject("twoColumnSearchResultsRenderer")
-                .getObject("primaryContents").getObject("sectionListRenderer").getArray("contents")
-                .getObject(0).getObject("itemSectionRenderer").getArray("contents");
+        JsonArray sections = initialData.getObject("contents").getObject("twoColumnSearchResultsRenderer")
+                .getObject("primaryContents").getObject("sectionListRenderer").getArray("contents");
 
-        collectStreamsFrom(collector, videos);
+        for (Object section : sections) {
+            collectStreamsFrom(collector, ((JsonObject) section).getObject("itemSectionRenderer").getArray("contents"));
+        }
+
         return new InfoItemsPage<>(collector, getNextPageUrl());
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -5,11 +5,9 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 
-import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
-import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
@@ -61,10 +59,8 @@ public class YoutubeSearchExtractor extends SearchExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");
@@ -130,10 +126,8 @@ public class YoutubeSearchExtractor extends SearchExtractor {
 
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        // Use the hardcoded client version first to get JSON with a structure we know
-        // TODO: Use YoutubeParsingHelper.getClientVersion() as fallback
         headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.HARDCODED_CLIENT_VERSION));
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
         final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("Could not parse json data for next streams");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
+
 /*
  * Created by Christian Schabesberger on 22.07.2018
  *
@@ -91,8 +93,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         if (showingResultsForRenderer == null) {
             return "";
         } else {
-            return showingResultsForRenderer.getObject("correctedQuery").getArray("runs")
-                    .getObject(0).getString("text");
+            return getTextFromObject(showingResultsForRenderer.getObject("correctedQuery"));
         }
     }
 
@@ -155,8 +156,8 @@ public class YoutubeSearchExtractor extends SearchExtractor {
 
         for (Object item : videos) {
             if (((JsonObject) item).getObject("backgroundPromoRenderer") != null) {
-                throw new NothingFoundException(((JsonObject) item).getObject("backgroundPromoRenderer")
-                        .getObject("bodyText").getArray("runs").getObject(0).getString("text"));
+                throw new NothingFoundException(getTextFromObject(((JsonObject) item)
+                        .getObject("backgroundPromoRenderer").getObject("bodyText")));
             } else if (((JsonObject) item).getObject("videoRenderer") != null) {
                 collector.commit(new YoutubeStreamInfoItemExtractor(((JsonObject) item).getObject("videoRenderer"), timeAgoParser));
             } else if (((JsonObject) item).getObject("channelRenderer") != null) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -2,8 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -14,16 +12,12 @@ import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 
 /*
@@ -57,22 +51,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(url);
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }
@@ -125,23 +104,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         }
 
         InfoItemsSearchCollector collector = getInfoItemSearchCollector();
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(pageUrl, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
-
+        final JsonArray ajaxJson = getJsonResponse(pageUrl);
 
         JsonObject itemSectionRenderer = ajaxJson.getObject(1).getObject("response")
                 .getObject("continuationContents").getObject("itemSectionContinuation");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -229,7 +229,25 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                             descriptionBuilder.append("<a href=\"").append(internUrl).append("\">").append(text).append("</a>");
                             htmlConversionRequired = true;
                         }
-                        continue;
+                    } else if (textHolder.getObject("navigationEndpoint").getObject("browseEndpoint") != null) {
+                        descriptionBuilder.append("<a href=\"https://www.youtube.com").append(
+                                textHolder.getObject("navigationEndpoint").getObject("browseEndpoint")
+                                        .getString("canonicalBaseUrl")).append("\">").append(text).append("</a>");
+                        htmlConversionRequired = true;
+                    } else if (textHolder.getObject("navigationEndpoint").getObject("watchEndpoint") != null) {
+                        if (textHolder.getObject("navigationEndpoint").getObject("watchEndpoint").getString("playlistId") != null) {
+                            descriptionBuilder.append("<a href=\"https://www.youtube.com/watch?v=").append(
+                                    textHolder.getObject("navigationEndpoint").getObject("watchEndpoint")
+                                            .getString("videoId")).append("&amp;list=")
+                                    .append(textHolder.getObject("navigationEndpoint")
+                                            .getObject("watchEndpoint").getString("playlistId"))
+                                    .append("\">").append(text).append("</a>");
+                        } else {
+                            descriptionBuilder.append("<a href=\"https://www.youtube.com/watch?v=").append(
+                                    textHolder.getObject("navigationEndpoint").getObject("watchEndpoint")
+                                            .getString("videoId")).append("\">").append(text).append("</a>");
+                        }
+                        htmlConversionRequired = true;
                     }
                     continue;
                 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -95,6 +95,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private final Map<String, String> videoInfoPage = new HashMap<>();
     private JsonObject playerResponse;
     private JsonObject initialData;
+    private JsonObject videoPrimaryInfoRenderer;
+    private JsonObject videoSecondaryInfoRenderer;
 
     @Nonnull
     private List<SubtitlesInfo> subtitlesInfos = new ArrayList<>();
@@ -843,6 +845,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     //////////////////////////////////////////////////////////////////////////*/
 
     private JsonObject getVideoPrimaryInfoRenderer() throws ParsingException {
+        if (this.videoPrimaryInfoRenderer != null) return this.videoPrimaryInfoRenderer;
+
         JsonArray contents = initialData.getObject("contents").getObject("twoColumnWatchNextResults")
                 .getObject("results").getObject("results").getArray("contents");
         JsonObject videoPrimaryInfoRenderer = null;
@@ -858,10 +862,13 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             throw new ParsingException("Could not find videoPrimaryInfoRenderer");
         }
 
+        this.videoPrimaryInfoRenderer = videoPrimaryInfoRenderer;
         return videoPrimaryInfoRenderer;
     }
 
     private JsonObject getVideoSecondaryInfoRenderer() throws ParsingException {
+        if (this.videoSecondaryInfoRenderer != null) return this.videoSecondaryInfoRenderer;
+
         JsonArray contents = initialData.getObject("contents").getObject("twoColumnWatchNextResults")
                 .getObject("results").getObject("results").getArray("contents");
         JsonObject videoSecondaryInfoRenderer = null;
@@ -877,6 +884,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             throw new ParsingException("Could not find videoSecondaryInfoRenderer");
         }
 
+        this.videoSecondaryInfoRenderer = videoSecondaryInfoRenderer;
         return videoSecondaryInfoRenderer;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -21,6 +21,7 @@ import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.localization.TimeAgoPatternsManager;
 import org.schabi.newpipe.extractor.services.youtube.ItagItem;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Description;
@@ -328,7 +329,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         } catch (Exception ignored) {}
         try {
             String uploaderId = playerResponse.getObject("videoDetails").getString("channelId");
-            if (uploaderId != null) return "https://www.youtube.com/channel/" + uploaderId;
+            if (uploaderId != null)
+                return YoutubeChannelLinkHandlerFactory.getInstance().getUrl("channel/" + uploaderId);
         } catch (Exception ignored) {}
         throw new ParsingException("Could not get uploader url");
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -235,18 +235,18 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                                         .getString("canonicalBaseUrl")).append("\">").append(text).append("</a>");
                         htmlConversionRequired = true;
                     } else if (textHolder.getObject("navigationEndpoint").getObject("watchEndpoint") != null) {
+                        descriptionBuilder.append("<a href=\"https://www.youtube.com/watch?v=").append(
+                                textHolder.getObject("navigationEndpoint").getObject("watchEndpoint")
+                                        .getString("videoId"));
                         if (textHolder.getObject("navigationEndpoint").getObject("watchEndpoint").getString("playlistId") != null) {
-                            descriptionBuilder.append("<a href=\"https://www.youtube.com/watch?v=").append(
-                                    textHolder.getObject("navigationEndpoint").getObject("watchEndpoint")
-                                            .getString("videoId")).append("&amp;list=")
-                                    .append(textHolder.getObject("navigationEndpoint")
-                                            .getObject("watchEndpoint").getString("playlistId"))
-                                    .append("\">").append(text).append("</a>");
-                        } else {
-                            descriptionBuilder.append("<a href=\"https://www.youtube.com/watch?v=").append(
-                                    textHolder.getObject("navigationEndpoint").getObject("watchEndpoint")
-                                            .getString("videoId")).append("\">").append(text).append("</a>");
+                            descriptionBuilder.append("&amp;list=").append(textHolder.getObject("navigationEndpoint")
+                                            .getObject("watchEndpoint").getString("playlistId"));
                         }
+                        if (textHolder.getObject("navigationEndpoint").getObject("watchEndpoint").has("startTimeSeconds")) {
+                            descriptionBuilder.append("&amp;t=").append(textHolder.getObject("navigationEndpoint")
+                                    .getObject("watchEndpoint").getInt("startTimeSeconds"));
+                        }
+                        descriptionBuilder.append("\">").append(text).append("</a>");
                         htmlConversionRequired = true;
                     }
                     continue;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -187,8 +187,15 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         try {
             JsonArray thumbnails = playerResponse.getObject("videoDetails").getObject("thumbnail").getArray("thumbnails");
             // the last thumbnail is the one with the highest resolution
-            return thumbnails.getObject(thumbnails.size() - 1).getString("url");
+            String url = thumbnails.getObject(thumbnails.size() - 1).getString("url");
 
+            if (url.startsWith(HTTP)) {
+                url = Utils.replaceHttpWithHttps(url);
+            } else if (!url.startsWith(HTTPS)) {
+                url = HTTPS + url;
+            }
+
+            return url;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url");
         }
@@ -362,10 +369,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             String url = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
                     .getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
 
-            // the first characters of the avatar URLs are different for each channel and some are not even valid URLs
-            if (url.startsWith("//")) {
-                url = url.substring(2);
-            }
             if (url.startsWith(HTTP)) {
                 url = Utils.replaceHttpWithHttps(url);
             } else if (!url.startsWith(HTTPS)) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -97,6 +97,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private JsonObject initialData;
     private JsonObject videoPrimaryInfoRenderer;
     private JsonObject videoSecondaryInfoRenderer;
+    private int ageLimit;
 
     @Nonnull
     private List<SubtitlesInfo> subtitlesInfos = new ArrayList<>();
@@ -216,12 +217,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Override
     public int getAgeLimit() {
         if (initialData == null || initialData.isEmpty()) throw new IllegalStateException("initialData is not parsed yet");
-        if (initialData.getObject("contents").getObject("twoColumnWatchNextResults")
-                .getObject("secondaryResults") == null) {
-            return 18;
-        } else {
-            return NO_AGE_LIMIT;
-        }
+
+        return ageLimit;
     }
 
     @Override
@@ -600,6 +597,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         if (initialAjaxJson.getObject(2).getObject("response") != null) { // age-restricted videos
             initialData = initialAjaxJson.getObject(2).getObject("response");
+            ageLimit = 18;
 
             final EmbeddedInfo info = getEmbeddedInfo();
             final String videoInfoUrl = getVideoInfoUrl(getId(), info.sts);
@@ -608,6 +606,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             playerUrl = info.url;
         } else {
             initialData = initialAjaxJson.getObject(3).getObject("response");
+            ageLimit = NO_AGE_LIMIT;
 
             playerArgs = getPlayerArgs(initialAjaxJson.getObject(2).getObject("player"));
             playerUrl = getPlayerUrl(initialAjaxJson.getObject(2).getObject("player"));

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -54,9 +54,9 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
 
 /*
  * Created by Christian Schabesberger on 06.08.15.
@@ -189,13 +189,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             // the last thumbnail is the one with the highest resolution
             String url = thumbnails.getObject(thumbnails.size() - 1).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url");
         }
@@ -369,13 +363,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             String url = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
                     .getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get uploader avatar url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -580,7 +580,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        initialAjaxJson = getJsonResponse(url);
+        initialAjaxJson = getJsonResponse(url, getExtractorLocalization());
 
         final String playerUrl;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -114,7 +114,12 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         assertPageFetched();
         String title = null;
         try {
-            title = getVideoPrimaryInfoRenderer().getObject("title").getArray("runs").getObject(0).getString("text");
+            StringBuilder titleBuilder = new StringBuilder();
+            JsonArray titleArray = getVideoPrimaryInfoRenderer().getObject("title").getArray("runs");
+            for (Object titlePart : titleArray) {
+                titleBuilder.append(((JsonObject) titlePart).getString("text"));
+            }
+            title = titleBuilder.toString();
         } catch (Exception ignored) {}
         if (title == null) {
             try {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -116,16 +116,20 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public String getName() throws ParsingException {
         assertPageFetched();
         String title = null;
+
         try {
             title = getTextFromObject(getVideoPrimaryInfoRenderer().getObject("title"));
         } catch (Exception ignored) {}
+
         if (title == null) {
             try {
                 title = playerResponse.getObject("videoDetails").getString("title");
             } catch (Exception ignored) {}
+
+            if (title == null) throw new ParsingException("Could not get name");
         }
-        if (title != null) return title;
-        throw new ParsingException("Could not get name");
+
+        return title;
     }
 
     @Override
@@ -259,17 +263,21 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public long getViewCount() throws ParsingException {
         assertPageFetched();
         String views = null;
+
         try {
             views = getTextFromObject(getVideoPrimaryInfoRenderer().getObject("viewCount")
                     .getObject("videoViewCountRenderer").getObject("viewCount"));
         } catch (Exception ignored) {}
+
         if (views == null) {
             try {
                 views = playerResponse.getObject("videoDetails").getString("viewCount");
             } catch (Exception ignored) {}
+
+            if (views == null) throw new ParsingException("Could not get view count");
         }
-        if (views != null) return Long.parseLong(Utils.removeNonDigitCharacters(views));
-        throw new ParsingException("Could not get view count");
+
+        return Long.parseLong(Utils.removeNonDigitCharacters(views));
     }
 
     @Override
@@ -340,17 +348,21 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public String getUploaderName() throws ParsingException {
         assertPageFetched();
         String uploaderName = null;
+
         try {
             uploaderName = getTextFromObject(getVideoSecondaryInfoRenderer().getObject("owner")
                     .getObject("videoOwnerRenderer").getObject("title"));
         } catch (Exception ignored) {}
+
         if (uploaderName == null) {
             try {
                 uploaderName = playerResponse.getObject("videoDetails").getString("author");
             } catch (Exception ignored) {}
+
+            if (uploaderName == null) throw new ParsingException("Could not get uploader name");
         }
-        if (uploaderName != null) return uploaderName;
-        throw new ParsingException("Could not get uploader name");
+
+        return uploaderName;
     }
 
     @Nonnull
@@ -910,9 +922,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
                         urlAndItags.put(streamUrl, itagItem);
                     }
-                } catch (UnsupportedEncodingException ignored) {
-
-                }
+                } catch (UnsupportedEncodingException ignored) {}
             }
         }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
@@ -53,6 +52,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
 
@@ -580,20 +580,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         final String url = getUrl() + "&pbj=1";
 
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            initialAjaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        initialAjaxJson = getJsonResponse(url);
 
         final String playerUrl;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -504,9 +504,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Override
     public StreamInfoItem getNextStream() throws ExtractionException {
         assertPageFetched();
-        if (getAgeLimit() == 18) {
-            return null;
-        }
+
+        if (getAgeLimit() != NO_AGE_LIMIT) return null;
+
         try {
             final JsonObject videoInfo = initialData.getObject("contents").getObject("twoColumnWatchNextResults")
                     .getObject("secondaryResults").getObject("secondaryResults").getArray("results")
@@ -525,9 +525,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Override
     public StreamInfoItemsCollector getRelatedStreams() throws ExtractionException {
         assertPageFetched();
-        if (getAgeLimit() == 18) {
-            return null;
-        }
+
+        if (getAgeLimit() != NO_AGE_LIMIT) return null;
+
         try {
             StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
             JsonArray results = initialData.getObject("contents").getObject("twoColumnWatchNextResults")
@@ -773,7 +773,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Nonnull
     private List<SubtitlesInfo> getAvailableSubtitlesInfo() {
         // If the video is age restricted getPlayerConfig will fail
-        if (getAgeLimit() == 18) return Collections.emptyList();
+        if (getAgeLimit() != NO_AGE_LIMIT) return Collections.emptyList();
 
         final JsonObject captions;
         if (!playerResponse.has("captions")) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -116,9 +116,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         try {
             StringBuilder titleBuilder = new StringBuilder();
             JsonArray titleArray = getVideoPrimaryInfoRenderer().getObject("title").getArray("runs");
-            for (Object titlePart : titleArray) {
+            for (Object titlePart : titleArray)
                 titleBuilder.append(((JsonObject) titlePart).getString("text"));
-            }
             title = titleBuilder.toString();
         } catch (Exception ignored) {}
         if (title == null) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -260,7 +260,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Override
     public int getAgeLimit() {
-        assertPageFetched();
+        if (initialData == null || initialData.isEmpty()) throw new IllegalStateException("initialData is not parsed yet");
         if (initialData.getObject("contents").getObject("twoColumnWatchNextResults")
                 .getObject("secondaryResults") == null) {
             return 18;
@@ -672,6 +672,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         doc = YoutubeParsingHelper.parseAndCheckPage(verifiedUrl, response);
 
         final String playerUrl;
+        initialData = YoutubeParsingHelper.getInitialData(pageHtml);
         // Check if the video is age restricted
         if (getAgeLimit() == 18) {
             final EmbeddedInfo info = getEmbeddedInfo();
@@ -685,7 +686,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             playerUrl = getPlayerUrl(ytPlayerConfig);
         }
         playerResponse = getPlayerResponse();
-        initialData = YoutubeParsingHelper.getInitialData(pageHtml);
 
         if (decryptionCode.isEmpty()) {
             decryptionCode = loadDecryptionCode(playerUrl);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -435,27 +435,12 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Override
     public String getUploaderAvatarUrl() throws ParsingException {
         assertPageFetched();
-
-        String uploaderAvatarUrl = null;
         try {
-            uploaderAvatarUrl = initialData.getObject("contents").getObject("twoColumnWatchNextResults").getObject("secondaryResults")
-                    .getObject("secondaryResults").getArray("results").getObject(0).getObject("compactAutoplayRenderer")
-                    .getArray("contents").getObject(0).getObject("compactVideoRenderer").getObject("channelThumbnail")
-                    .getArray("thumbnails").getObject(0).getString("url");
-            if (uploaderAvatarUrl != null && !uploaderAvatarUrl.isEmpty()) {
-                return uploaderAvatarUrl;
-            }
-        } catch (Exception ignored) {}
-
-        try {
-            uploaderAvatarUrl = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
+            return getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
                     .getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
-        } catch (Exception ignored) {}
-
-        if (uploaderAvatarUrl == null) {
-            throw new ParsingException("Could not get uploader avatar url");
+        } catch (Exception e) {
+            throw new ParsingException("Could not get uploader avatar url", e);
         }
-        return uploaderAvatarUrl;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -159,7 +159,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             if (id == null || id.isEmpty()) {
                 throw new IllegalArgumentException("is empty");
             }
-            return YoutubeChannelLinkHandlerFactory.getInstance().getUrl(id);
+            return YoutubeChannelLinkHandlerFactory.getInstance().getUrl("channel/" + id);
         } catch (Exception e) {
             throw new ParsingException("Could not get uploader url");
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -16,6 +16,8 @@ import javax.annotation.Nullable;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 /*
  * Copyright (C) Christian Schabesberger 2016 <chris.schabesberger@mailbox.org>
@@ -196,8 +198,16 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     public String getThumbnailUrl() throws ParsingException {
         try {
             // TODO: Don't simply get the first item, but look at all thumbnails and their resolution
-            return videoInfo.getObject("thumbnail").getArray("thumbnails")
+            String url = videoInfo.getObject("thumbnail").getArray("thumbnails")
                     .getObject(0).getString("url");
+
+            if (url.startsWith(HTTP)) {
+                url = Utils.replaceHttpWithHttps(url);
+            } else if (!url.startsWith(HTTPS)) {
+                url = HTTPS + url;
+            }
+
+            return url;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -195,8 +195,10 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                 return -1;
             }
             String viewCount = getTextFromObject(videoInfo.getObject("viewCountText"));
-            if (viewCount.equals("Recommended for you")) return -1;
+
             return Long.parseLong(Utils.removeNonDigitCharacters(viewCount));
+        } catch (NumberFormatException e) {
+            return -1;
         } catch (Exception e) {
             throw new ParsingException("Could not get view count", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -14,10 +14,9 @@ import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 /*
  * Copyright (C) Christian Schabesberger 2016 <chris.schabesberger@mailbox.org>
@@ -201,13 +200,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             String url = videoInfo.getObject("thumbnail").getArray("thumbnails")
                     .getObject(0).getString("url");
 
-            if (url.startsWith(HTTP)) {
-                url = Utils.replaceHttpWithHttps(url);
-            } else if (!url.startsWith(HTTPS)) {
-                url = HTTPS + url;
-            }
-
-            return url;
+            return fixThumbnailUrl(url);
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -108,17 +108,21 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() {
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        JsonArray firstPageElements = initialData.getObject("contents").getObject("twoColumnBrowseResultsRenderer")
-                .getArray("tabs").getObject(0).getObject("tabRenderer").getObject("content")
-                .getObject("sectionListRenderer").getArray("contents").getObject(0).getObject("itemSectionRenderer")
-                .getArray("contents").getObject(0).getObject("shelfRenderer").getObject("content")
-                .getObject("expandedShelfContentsRenderer").getArray("items");
-
         final TimeAgoParser timeAgoParser = getTimeAgoParser();
+        JsonArray itemSectionRenderers = initialData.getObject("contents").getObject("twoColumnBrowseResultsRenderer")
+                .getArray("tabs").getObject(0).getObject("tabRenderer").getObject("content")
+                .getObject("sectionListRenderer").getArray("contents");
 
-        for (Object ul : firstPageElements) {
-            final JsonObject videoInfo = ((JsonObject) ul).getObject("videoRenderer");
-            collector.commit(new YoutubeStreamInfoItemExtractor(videoInfo, timeAgoParser));
+        for (Object itemSectionRenderer : itemSectionRenderers) {
+            JsonObject expandedShelfContentsRenderer = ((JsonObject) itemSectionRenderer).getObject("itemSectionRenderer")
+                    .getArray("contents").getObject(0).getObject("shelfRenderer").getObject("content")
+                    .getObject("expandedShelfContentsRenderer");
+            if (expandedShelfContentsRenderer != null) {
+                for (Object ul : expandedShelfContentsRenderer.getArray("items")) {
+                    final JsonObject videoInfo = ((JsonObject) ul).getObject("videoRenderer");
+                    collector.commit(new YoutubeStreamInfoItemExtractor(videoInfo, timeAgoParser));
+                }
+            }
         }
         return new InfoItemsPage<>(collector, getNextPageUrl());
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -22,8 +22,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -32,18 +30,14 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
 
 public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
@@ -60,22 +54,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
         final String url = getUrl() + "?pbj=1&gl="
                 + getExtractorContentCountry().getCountryCode();
 
-        JsonArray ajaxJson;
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
-        if (response.length() < 50) { // ensure to have a valid response
-            throw new ParsingException("Could not parse json data for next streams");
-        }
-
-        try {
-            ajaxJson = JsonParser.array().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json data for next streams", e);
-        }
+        final JsonArray ajaxJson = getJsonResponse(url);
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -44,6 +44,8 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
+
 public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     private JsonObject initialData;
 
@@ -93,8 +95,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     public String getName() throws ParsingException {
         String name;
         try {
-            name = initialData.getObject("header").getObject("feedTabbedHeaderRenderer").getObject("title")
-                    .getArray("runs").getObject(0).getString("text");
+            name = getTextFromObject(initialData.getObject("header").getObject("feedTabbedHeaderRenderer").getObject("title"));
         } catch (Exception e) {
             throw new ParsingException("Could not get Trending name", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -22,10 +22,11 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
-import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
@@ -36,6 +37,10 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 
@@ -50,11 +55,27 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
 
     @Override
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
-        final String url = getUrl() +
-                "?gl=" + getExtractorContentCountry().getCountryCode();
+        final String url = getUrl() + "?pbj=1&gl="
+                + getExtractorContentCountry().getCountryCode();
 
-        final Response response = downloader.get(url, getExtractorLocalization());
-        initialData = YoutubeParsingHelper.getInitialData(response.responseBody());
+        JsonArray ajaxJson;
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
+        headers.put("X-YouTube-Client-Version",
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
+        final String response = getDownloader().get(url, headers, getExtractorLocalization()).responseBody();
+        if (response.length() < 50) { // ensure to have a valid response
+            throw new ParsingException("Could not parse json data for next streams");
+        }
+
+        try {
+            ajaxJson = JsonParser.array().from(response);
+        } catch (JsonParserException e) {
+            throw new ParsingException("Could not parse json data for next streams", e);
+        }
+
+        initialData = ajaxJson.getObject(1).getObject("response");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -54,7 +54,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
         final String url = getUrl() + "?pbj=1&gl="
                 + getExtractorContentCountry().getCountryCode();
 
-        final JsonArray ajaxJson = getJsonResponse(url);
+        final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
 
         initialData = ajaxJson.getObject(1).getObject("response");
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelLinkHandlerFactory.java
@@ -35,6 +35,14 @@ public class YoutubeChannelLinkHandlerFactory extends ListLinkHandlerFactory {
         return instance;
     }
 
+    /**
+     * Returns URL to channel from an ID
+     *
+     * @param id Channel ID including e.g. 'channel/'
+     * @param contentFilters
+     * @param searchFilter
+     * @return URL to channel
+     */
     @Override
     public String getUrl(String id, List<String> contentFilters, String searchFilter) {
         return "https://www.youtube.com/" + id;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
@@ -346,12 +347,12 @@ public class YoutubeParsingHelper {
         return thumbnailUrl;
     }
 
-    public static JsonArray getJsonResponse(String url) throws IOException, ExtractionException {
+    public static JsonArray getJsonResponse(String url, Localization localization) throws IOException, ExtractionException {
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
         headers.put("X-YouTube-Client-Version",
                 Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
-        final String response = getDownloader().get(url, headers).responseBody();
+        final String response = getDownloader().get(url, headers, localization).responseBody();
 
         if (response.length() < 50) { // ensure to have a valid response
             throw new ParsingException("JSON response is too short");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -9,11 +9,13 @@ import com.grack.nanojson.JsonParserException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -342,5 +344,23 @@ public class YoutubeParsingHelper {
         }
 
         return thumbnailUrl;
+    }
+
+    public static JsonArray getJsonResponse(String url) throws IOException, ExtractionException {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
+        headers.put("X-YouTube-Client-Version",
+                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
+        final String response = getDownloader().get(url, headers).responseBody();
+
+        if (response.length() < 50) { // ensure to have a valid response
+            throw new ParsingException("JSON response is too short");
+        }
+
+        try {
+            return JsonParser.array().from(response);
+        } catch (JsonParserException e) {
+            throw new ParsingException("Could not parse JSON", e);
+        }
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -178,7 +178,7 @@ public class YoutubeParsingHelper {
         }
     }
 
-    public static boolean isHardcodedClientVersionValid() {
+    public static boolean isHardcodedClientVersionValid() throws IOException {
         try {
             final String url = "https://www.youtube.com/results?search_query=test&pbj=1";
 
@@ -190,7 +190,7 @@ public class YoutubeParsingHelper {
             if (response.length() > 50) { // ensure to have a valid response
                 return true;
             }
-        } catch (Exception ignored) {}
+        } catch (ReCaptchaException ignored) {}
 
         return false;
     }
@@ -200,7 +200,7 @@ public class YoutubeParsingHelper {
      * @return
      * @throws ParsingException
      */
-    public static String getClientVersion() throws ParsingException {
+    public static String getClientVersion() throws ParsingException, IOException {
         if (clientVersion != null && !clientVersion.isEmpty()) return clientVersion;
 
         if (isHardcodedClientVersionValid()) {
@@ -350,8 +350,7 @@ public class YoutubeParsingHelper {
     public static JsonArray getJsonResponse(String url, Localization localization) throws IOException, ExtractionException {
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(YoutubeParsingHelper.getClientVersion()));
+        headers.put("X-YouTube-Client-Version", Collections.singletonList(getClientVersion()));
         final String response = getDownloader().get(url, headers, localization).responseBody();
 
         if (response.length() < 50) { // ensure to have a valid response

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -214,7 +214,7 @@ public class YoutubeParsingHelper {
                         }
                     }
                 } else if (s.getString("service").equals("ECATCHER")) {
-                    // fallback to get a shortened client version which does not contain the last do digits
+                    // fallback to get a shortened client version which does not contain the last two digits
                     JsonArray params = s.getArray("params");
                     for (Object param : params) {
                         JsonObject p = (JsonObject) param;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.utils.Parser;
+import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.schabi.newpipe.extractor.NewPipe.getDownloader;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 
 /*
  * Created by Christian Schabesberger on 02.03.16.
@@ -318,5 +321,19 @@ public class YoutubeParsingHelper {
 
     public static String getTextFromObject(JsonObject textObject) {
         return getTextFromObject(textObject, false);
+    }
+
+    public static String fixThumbnailUrl(String thumbnailUrl) {
+        if (thumbnailUrl.startsWith("//")) {
+            thumbnailUrl = thumbnailUrl.substring(2);
+        }
+
+        if (thumbnailUrl.startsWith(HTTP)) {
+            thumbnailUrl = Utils.replaceHttpWithHttps(thumbnailUrl);
+        } else if (!thumbnailUrl.startsWith(HTTPS)) {
+            thumbnailUrl = "https://" + thumbnailUrl;
+        }
+
+        return thumbnailUrl;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeParsingHelper.java
@@ -175,15 +175,7 @@ public class YoutubeParsingHelper {
         }
     }
 
-    /**
-     * Get the client version from a page
-     * @return
-     * @throws ParsingException
-     */
-    public static String getClientVersion() throws ParsingException {
-        if (clientVersion != null && !clientVersion.isEmpty()) return clientVersion;
-
-        // Test if hard-coded client version is valid
+    public static boolean isHardcodedClientVersionValid() {
         try {
             final String url = "https://www.youtube.com/results?search_query=test&pbj=1";
 
@@ -193,10 +185,25 @@ public class YoutubeParsingHelper {
                     Collections.singletonList(HARDCODED_CLIENT_VERSION));
             final String response = getDownloader().get(url, headers).responseBody();
             if (response.length() > 50) { // ensure to have a valid response
-                clientVersion = HARDCODED_CLIENT_VERSION;
-                return clientVersion;
+                return true;
             }
         } catch (Exception ignored) {}
+
+        return false;
+    }
+
+    /**
+     * Get the client version from a page
+     * @return
+     * @throws ParsingException
+     */
+    public static String getClientVersion() throws ParsingException {
+        if (clientVersion != null && !clientVersion.isEmpty()) return clientVersion;
+
+        if (isHardcodedClientVersionValid()) {
+            clientVersion = HARDCODED_CLIENT_VERSION;
+            return clientVersion;
+        }
 
         // Try extracting it from YouTube's website otherwise
         try {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
@@ -6,6 +6,8 @@ import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertTrue;
 
 public class YoutubeParsingHelperTest {
@@ -15,7 +17,7 @@ public class YoutubeParsingHelperTest {
     }
 
     @Test
-    public void testIsHardcodedClientVersionValid() {
+    public void testIsHardcodedClientVersionValid() throws IOException {
         assertTrue("Hardcoded client version is not valid anymore",
                 YoutubeParsingHelper.isHardcodedClientVersionValid());
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
+
+import static org.junit.Assert.assertTrue;
+
+public class YoutubeParsingHelperTest {
+    @BeforeClass
+    public static void setUp() {
+        NewPipe.init(DownloaderTestImpl.getInstance());
+    }
+
+    @Test
+    public void testIsHardcodedClientVersionValid() {
+        assertTrue("Hardcoded client version is not valid anymore",
+                YoutubeParsingHelper.isHardcodedClientVersionValid());
+    }
+}

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -99,7 +99,7 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testUploaderUrl() throws Exception {
-            assertEquals("https://www.youtube.com/channel/UCs72iRpTEuwV3y6pdWYLgiw", extractor.getUploaderUrl());
+            assertEquals("https://www.youtube.com/user/andre0y0you", extractor.getUploaderUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorChannelOnlyTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorChannelOnlyTest.java
@@ -92,11 +92,16 @@ public class YoutubeSearchExtractorChannelOnlyTest extends YoutubeSearchExtracto
             if (item instanceof ChannelInfoItem) {
                 ChannelInfoItem channel = (ChannelInfoItem) item;
 
-                if (channel.getSubscriberCount() > 5e7 && channel.getName().equals("PewDiePie")) { // the real PewDiePie
+                if (channel.getSubscriberCount() > 1e8) { // the real PewDiePie
                     assertEquals("https://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw", item.getUrl());
-                } else {
-                    assertThat(item.getUrl(), CoreMatchers.startsWith("https://www.youtube.com/channel/"));
+                    break;
                 }
+            }
+        }
+
+        for (InfoItem item : itemsPage.getItems()) {
+            if (item instanceof ChannelInfoItem) {
+                assertThat(item.getUrl(), CoreMatchers.startsWith("https://www.youtube.com/channel/"));
             }
         }
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorChannelOnlyTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorChannelOnlyTest.java
@@ -12,10 +12,17 @@ import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSearchExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory;
 
-import java.util.regex.Pattern;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 public class YoutubeSearchExtractorChannelOnlyTest extends YoutubeSearchExtractorBaseTest {
@@ -47,18 +54,26 @@ public class YoutubeSearchExtractorChannelOnlyTest extends YoutubeSearchExtracto
             }
         }
         assertFalse("First and second page are equal", equals);
-
-        assertEquals("https://www.youtube.com/results?q=pewdiepie&sp=EgIQAlAU&gl=GB&page=3", secondPage.getNextPageUrl());
     }
 
     @Test
     public void testGetSecondPageUrl() throws Exception {
-        // check that ctoken, continuation and itct are longer than 5 characters
-        Pattern pattern = Pattern.compile(
-                "https:\\/\\/www.youtube.com\\/results\\?search_query=pewdiepie&sp=EgIQAg%253D%253D&gl=GB&pbj=1"
-                + "&ctoken=[\\w%]{5,}?&continuation=[\\w%]{5,}?&itct=[\\w]{5,}?"
-        );
-        assertTrue(pattern.matcher(extractor.getNextPageUrl()).find());
+        URL url = new URL(extractor.getNextPageUrl());
+
+        assertEquals(url.getHost(), "www.youtube.com");
+        assertEquals(url.getPath(), "/results");
+
+        Map<String, String> queryPairs = new LinkedHashMap<>();
+        for (String queryPair : url.getQuery().split("&")) {
+            int index = queryPair.indexOf("=");
+            queryPairs.put(URLDecoder.decode(queryPair.substring(0, index), "UTF-8"),
+                    URLDecoder.decode(queryPair.substring(index + 1), "UTF-8"));
+        }
+
+        assertEquals("pewdiepie", queryPairs.get("search_query"));
+        assertEquals(queryPairs.get("ctoken"), queryPairs.get("continuation"));
+        assertTrue(queryPairs.get("continuation").length() > 5);
+        assertTrue(queryPairs.get("itct").length() > 5);
     }
 
     @Ignore
@@ -77,7 +92,7 @@ public class YoutubeSearchExtractorChannelOnlyTest extends YoutubeSearchExtracto
             if (item instanceof ChannelInfoItem) {
                 ChannelInfoItem channel = (ChannelInfoItem) item;
 
-                if (channel.getSubscriberCount() > 5e7) { // the real PewDiePie
+                if (channel.getSubscriberCount() > 5e7 && channel.getName().equals("PewDiePie")) { // the real PewDiePie
                     assertEquals("https://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw", item.getUrl());
                 } else {
                     assertThat(item.getUrl(), CoreMatchers.startsWith("https://www.youtube.com/channel/"));

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorDefaultTest.java
@@ -10,6 +10,11 @@ import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSearchExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
@@ -48,13 +53,28 @@ public class YoutubeSearchExtractorDefaultTest extends YoutubeSearchExtractorBas
 
     @Test
     public void testGetUrl() throws Exception {
-        assertEquals("https://www.youtube.com/results?q=pewdiepie&gl=GB", extractor.getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=pewdiepie&gl=GB", extractor.getUrl());
     }
 
 
     @Test
     public void testGetSecondPageUrl() throws Exception {
-        assertEquals("https://www.youtube.com/results?q=pewdiepie&gl=GB&page=2", extractor.getNextPageUrl());
+        URL url = new URL(extractor.getNextPageUrl());
+
+        assertEquals(url.getHost(), "www.youtube.com");
+        assertEquals(url.getPath(), "/results");
+
+        Map<String, String> queryPairs = new LinkedHashMap<>();
+        for (String queryPair : url.getQuery().split("&")) {
+            int index = queryPair.indexOf("=");
+            queryPairs.put(URLDecoder.decode(queryPair.substring(0, index), "UTF-8"),
+                    URLDecoder.decode(queryPair.substring(index + 1), "UTF-8"));
+        }
+
+        assertEquals("pewdiepie", queryPairs.get("search_query"));
+        assertEquals(queryPairs.get("ctoken"), queryPairs.get("continuation"));
+        assertTrue(queryPairs.get("continuation").length() > 5);
+        assertTrue(queryPairs.get("itct").length() > 5);
     }
 
     @Test
@@ -101,14 +121,12 @@ public class YoutubeSearchExtractorDefaultTest extends YoutubeSearchExtractorBas
             }
         }
         assertFalse("First and second page are equal", equals);
-
-        assertEquals("https://www.youtube.com/results?q=pewdiepie&gl=GB&page=3", secondPage.getNextPageUrl());
     }
 
     @Test
-    public void testSuggestionNotNull() throws Exception {
+    public void testSuggestionNotNull() {
         //todo write a real test
-        assertTrue(extractor.getSearchSuggestion() != null);
+        assertNotNull(extractor.getSearchSuggestion());
     }
 
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchQHTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchQHTest.java
@@ -11,11 +11,11 @@ public class YoutubeSearchQHTest {
 
     @Test
     public void testRegularValues() throws Exception {
-        assertEquals("https://www.youtube.com/results?q=asdf", YouTube.getSearchQHFactory().fromQuery("asdf").getUrl());
-        assertEquals("https://www.youtube.com/results?q=hans", YouTube.getSearchQHFactory().fromQuery("hans").getUrl());
-        assertEquals("https://www.youtube.com/results?q=Poifj%26jaijf", YouTube.getSearchQHFactory().fromQuery("Poifj&jaijf").getUrl());
-        assertEquals("https://www.youtube.com/results?q=G%C3%BCl%C3%BCm", YouTube.getSearchQHFactory().fromQuery("Gülüm").getUrl());
-        assertEquals("https://www.youtube.com/results?q=%3Fj%24%29H%C2%A7B", YouTube.getSearchQHFactory().fromQuery("?j$)H§B").getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=asdf", YouTube.getSearchQHFactory().fromQuery("asdf").getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=hans", YouTube.getSearchQHFactory().fromQuery("hans").getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=Poifj%26jaijf", YouTube.getSearchQHFactory().fromQuery("Poifj&jaijf").getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=G%C3%BCl%C3%BCm", YouTube.getSearchQHFactory().fromQuery("Gülüm").getUrl());
+        assertEquals("https://www.youtube.com/results?search_query=%3Fj%24%29H%C2%A7B", YouTube.getSearchQHFactory().fromQuery("?j$)H§B").getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -245,7 +245,6 @@ public class YoutubeStreamExtractorDefaultTest {
 
         @Test
         public void testGetDescription() throws ParsingException {
-            System.out.println(extractor.getDescription().getContent());
             assertNotNull(extractor.getDescription());
             assertFalse(extractor.getDescription().getContent().isEmpty());
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -245,21 +245,18 @@ public class YoutubeStreamExtractorDefaultTest {
 
         @Test
         public void testGetDescription() throws ParsingException {
+            System.out.println(extractor.getDescription().getContent());
             assertNotNull(extractor.getDescription());
             assertFalse(extractor.getDescription().getContent().isEmpty());
         }
 
         @Test
         public void testGetFullLinksInDescription() throws ParsingException {
-            assertTrue(extractor.getDescription().getContent().contains("https://www.youtube.com/watch?v=X7FLCHVXpsA&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
-            assertTrue(extractor.getDescription().getContent().contains("https://www.youtube.com/watch?v=Lqv6G0pDNnw&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
-            assertTrue(extractor.getDescription().getContent().contains("https://www.youtube.com/watch?v=XxaRBPyrnBU&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
-            assertTrue(extractor.getDescription().getContent().contains("https://www.youtube.com/watch?v=U-9tUEOFKNU&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
-
-            assertFalse(extractor.getDescription().getContent().contains("https://youtu.be/X7FLCHVXpsA?list=PL7..."));
-            assertFalse(extractor.getDescription().getContent().contains("https://youtu.be/Lqv6G0pDNnw?list=PL7..."));
-            assertFalse(extractor.getDescription().getContent().contains("https://youtu.be/XxaRBPyrnBU?list=PL7..."));
-            assertFalse(extractor.getDescription().getContent().contains("https://youtu.be/U-9tUEOFKNU?list=PL7..."));
+            final String description = extractor.getDescription().getContent();
+            assertTrue(description.contains("https://www.youtube.com/watch?v=X7FLCHVXpsA&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
+            assertTrue(description.contains("https://www.youtube.com/watch?v=Lqv6G0pDNnw&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
+            assertTrue(description.contains("https://www.youtube.com/watch?v=XxaRBPyrnBU&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
+            assertTrue(description.contains("https://www.youtube.com/watch?v=U-9tUEOFKNU&amp;list=PL7u4lWXQ3wfI_7PgX0C-VTiwLeu0S4v34"));
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -10,17 +10,24 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor;
-import org.schabi.newpipe.extractor.stream.*;
+import org.schabi.newpipe.extractor.stream.Frameset;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.extractor.utils.Utils;
 
-import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
@@ -89,7 +96,6 @@ public class YoutubeStreamExtractorDefaultTest {
         @Test
         public void testGetFullLinksInDescription() throws ParsingException {
             assertTrue(extractor.getDescription().getContent().contains("http://adele.com"));
-            assertFalse(extractor.getDescription().getContent().contains("http://smarturl.it/SubscribeAdele?IQi..."));
         }
 
         @Test
@@ -142,12 +148,12 @@ public class YoutubeStreamExtractorDefaultTest {
         }
 
         @Test
-        public void testGetAudioStreams() throws IOException, ExtractionException {
+        public void testGetAudioStreams() throws ExtractionException {
             assertFalse(extractor.getAudioStreams().isEmpty());
         }
 
         @Test
-        public void testGetVideoStreams() throws IOException, ExtractionException {
+        public void testGetVideoStreams() throws ExtractionException {
             for (VideoStream s : extractor.getVideoStreams()) {
                 assertIsSecureUrl(s.url);
                 assertTrue(s.resolution.length() > 0);
@@ -169,7 +175,7 @@ public class YoutubeStreamExtractorDefaultTest {
         }
 
         @Test
-        public void testGetRelatedVideos() throws ExtractionException, IOException {
+        public void testGetRelatedVideos() throws ExtractionException {
             StreamInfoItemsCollector relatedVideos = extractor.getRelatedStreams();
             Utils.printErrors(relatedVideos.getErrors());
             assertFalse(relatedVideos.getItems().isEmpty());
@@ -177,13 +183,13 @@ public class YoutubeStreamExtractorDefaultTest {
         }
 
         @Test
-        public void testGetSubtitlesListDefault() throws IOException, ExtractionException {
+        public void testGetSubtitlesListDefault() {
             // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
             assertTrue(extractor.getSubtitlesDefault().isEmpty());
         }
 
         @Test
-        public void testGetSubtitlesList() throws IOException, ExtractionException {
+        public void testGetSubtitlesList() {
             // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
             assertTrue(extractor.getSubtitles(MediaFormat.TTML).isEmpty());
         }
@@ -223,10 +229,6 @@ public class YoutubeStreamExtractorDefaultTest {
             assertTrue(extractor.getDescription().getContent().contains("https://www.reddit.com/r/PewdiepieSubmissions/"));
             assertTrue(extractor.getDescription().getContent().contains("https://www.youtube.com/channel/UC3e8EMTOn4g6ZSKggHTnNng"));
             assertTrue(extractor.getDescription().getContent().contains("https://usa.clutchchairz.com/product/pewdiepie-edition-throttle-series/"));
-
-            assertFalse(extractor.getDescription().getContent().contains("https://www.reddit.com/r/PewdiepieSub..."));
-            assertFalse(extractor.getDescription().getContent().contains("https://www.youtube.com/channel/UC3e8..."));
-            assertFalse(extractor.getDescription().getContent().contains("https://usa.clutchchairz.com/product/..."));
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
@@ -13,9 +13,12 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.extractor.utils.Utils;
 
-import java.io.IOException;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
@@ -26,7 +29,7 @@ public class YoutubeStreamExtractorLivestreamTest {
     public static void setUp() throws Exception {
         NewPipe.init(DownloaderTestImpl.getInstance());
         extractor = (YoutubeStreamExtractor) YouTube
-                .getStreamExtractor("https://www.youtube.com/watch?v=EcEMX-63PKY");
+                .getStreamExtractor("https://www.youtube.com/watch?v=5qap5aO4i9A");
         extractor.fetchPage();
     }
 
@@ -49,8 +52,7 @@ public class YoutubeStreamExtractorLivestreamTest {
 
     @Test
     public void testGetFullLinksInDescription() throws ParsingException {
-        assertTrue(extractor.getDescription().getContent().contains("https://www.instagram.com/nathalie.baraton/"));
-        assertFalse(extractor.getDescription().getContent().contains("https://www.instagram.com/nathalie.ba..."));
+        assertTrue(extractor.getDescription().getContent().contains("https://bit.ly/chilledcow-playlists"));
     }
 
     @Test
@@ -119,7 +121,7 @@ public class YoutubeStreamExtractorLivestreamTest {
     }
 
     @Test
-    public void testGetRelatedVideos() throws ExtractionException, IOException {
+    public void testGetRelatedVideos() throws ExtractionException {
         StreamInfoItemsCollector relatedVideos = extractor.getRelatedStreams();
         Utils.printErrors(relatedVideos.getErrors());
         assertFalse(relatedVideos.getItems().isEmpty());
@@ -127,12 +129,12 @@ public class YoutubeStreamExtractorLivestreamTest {
     }
 
     @Test
-    public void testGetSubtitlesListDefault() throws IOException, ExtractionException {
+    public void testGetSubtitlesListDefault() {
         assertTrue(extractor.getSubtitlesDefault().isEmpty());
     }
 
     @Test
-    public void testGetSubtitlesList() throws IOException, ExtractionException {
+    public void testGetSubtitlesList() {
         assertTrue(extractor.getSubtitles(MediaFormat.TTML).isEmpty());
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Things I want to do in this PR:

- [x] Use pbj=1 in YoutubeSearchExtractor
- [x] Use pbj=1 in YoutubeChannelExtractor
- [x] Use pbj=1 in YoutubePlaylistExtractor
- [x] Use pbj=1 in YoutubeTrendingExtractor
- [x] Use pbj=1 in YoutubeStreamExtractor ~(not possible due to age restriction stuff?)~
- [x] Improve getClientVersion() so that it's similar to the clientId() for SoundCloud
~Use new YouTube site for extracting comments~
- [x] Fix existing tests
- [x] Fix TeamNewPipe/NewPipe#3145 (trending page not containing everything)
- [x] Correctly parse links in e.g. https://www.youtube.com/watch?v=cV5TjZCJkuA
- [x] Fix TeamNewPipe/NewPipe#3144 (pictures of certain channels)
- [x] Fix #264 (YouTube Music playlists)
- [x] Fix exception for channels without Videos tab
- [x] Fix getUploaderUrl() in YoutubeStreamInfoItemExtractor
- [x] Fix video titles with @ (and probably #)
- [x] Make one helping function for text (as YouTube often provides that either as a `simpleText` or a `runs` array with `text` in them; this would prevent issues like those video titles or channel descriptions)
- [x] Fix channel descriptions
- [x] Fix subscribers count for channels with 0 subscribers
- [x] Fix channels with multiple views on Videos tab
- [x] Fix thumbnail URLs starting with //
- [x] Fix TeamNewPipe/NewPipe#3153 (some search queries having 0 results)