### PR TITLE
Hotfixes for YouTube and improve unavailable cases

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -15,12 +15,16 @@ public class Response {
     private final Map<String, List<String>> responseHeaders;
     private final String responseBody;
 
-    public Response(int responseCode, String responseMessage, Map<String, List<String>> responseHeaders, @Nullable String responseBody) {
+    private final String latestUrl;
+
+    public Response(int responseCode, String responseMessage, Map<String, List<String>> responseHeaders,
+                    @Nullable String responseBody, @Nullable String latestUrl) {
         this.responseCode = responseCode;
         this.responseMessage = responseMessage;
         this.responseHeaders = responseHeaders != null ? responseHeaders : Collections.<String, List<String>>emptyMap();
 
         this.responseBody = responseBody == null ? "" : responseBody;
+        this.latestUrl = latestUrl;
     }
 
     public int responseCode() {
@@ -38,6 +42,16 @@ public class Response {
     @Nonnull
     public String responseBody() {
         return responseBody;
+    }
+
+    /**
+     * Used for detecting a possible redirection, limited to the latest one.
+     *
+     * @return latest url known right before this response object was created
+     */
+    @Nonnull
+    public String latestUrl() {
+        return latestUrl;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -68,7 +68,8 @@ public class Response {
     @Nullable
     public String getHeader(String name) {
         for (Map.Entry<String, List<String>> headerEntry : responseHeaders.entrySet()) {
-            if (headerEntry.getKey().equalsIgnoreCase(name)) {
+            final String key = headerEntry.getKey();
+            if (key != null && key.equalsIgnoreCase(name)) {
                 if (headerEntry.getValue().size() > 0) {
                     return headerEntry.getValue().get(0);
                 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -58,8 +58,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         final String url = super.getUrl() + "/videos?pbj=1&view=0&flow=grid";
 
         final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
-
         initialData = ajaxJson.getObject(1).getObject("response");
+        YoutubeParsingHelper.defaultAlertsCheck(initialData);
     }
 
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -39,6 +40,8 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         final JsonArray ajaxJson = getJsonResponse(url, getExtractorLocalization());
 
         initialData = ajaxJson.getObject(1).getObject("response");
+        YoutubeParsingHelper.defaultAlertsCheck(initialData);
+
         playlistInfo = getPlaylistInfo();
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -63,7 +63,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
     }
 
     @Override
-    public String getSearchSuggestion() {
+    public String getSearchSuggestion() throws ParsingException {
         JsonObject showingResultsForRenderer = initialData.getObject("contents")
                 .getObject("twoColumnSearchResultsRenderer").getObject("primaryContents")
                 .getObject("sectionListRenderer").getArray("contents").getObject(0)
@@ -114,7 +114,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         return new InfoItemsPage<>(collector, getNextPageUrlFrom(itemSectionRenderer.getArray("continuations")));
     }
 
-    private void collectStreamsFrom(InfoItemsSearchCollector collector, JsonArray videos) throws NothingFoundException {
+    private void collectStreamsFrom(InfoItemsSearchCollector collector, JsonArray videos) throws NothingFoundException, ParsingException {
         collector.reset();
 
         final TimeAgoParser timeAgoParser = getTimeAgoParser();

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
@@ -32,6 +33,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.SubtitlesStream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
@@ -618,6 +620,13 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         }
 
         playerResponse = getPlayerResponse();
+
+        final JsonObject playabilityStatus = playerResponse.getObject("playabilityStatus", JsonUtils.DEFAULT_EMPTY);
+        final String status = playabilityStatus.getString("status");
+        if (status != null && status.toLowerCase().equals("error")) {
+            final String reason = playabilityStatus.getString("reason");
+            throw new ContentNotAvailableException("Got error: \"" + reason + "\"");
+        }
 
         if (decryptionCode.isEmpty()) {
             decryptionCode = loadDecryptionCode(playerUrl);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -564,8 +564,12 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      */
     @Override
     public String getErrorMessage() {
-        return getTextFromObject(initialAjaxJson.getObject(2).getObject("playerResponse").getObject("playabilityStatus")
-                .getObject("errorScreen").getObject("playerErrorMessageRenderer").getObject("reason"));
+        try {
+            return getTextFromObject(initialAjaxJson.getObject(2).getObject("playerResponse").getObject("playabilityStatus")
+                    .getObject("errorScreen").getObject("playerErrorMessageRenderer").getObject("reason"));
+        } catch (ParsingException e) {
+            return null;
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -203,6 +203,12 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
             final String viewCount = getTextFromObject(viewCountObject);
 
+            if (viewCount.toLowerCase().contains("no views")) {
+                return 0;
+            } else if (viewCount.toLowerCase().contains("recommended")) {
+                return -1;
+            }
+
             return Long.parseLong(Utils.removeNonDigitCharacters(viewCount));
         } catch (Exception e) {
             throw new ParsingException("Could not get view count", e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
@@ -13,10 +12,11 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.*;
 
 /*
  * Copyright (C) Christian Schabesberger 2016 <chris.schabesberger@mailbox.org>
@@ -86,7 +86,9 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Override
     public long getDuration() throws ParsingException {
-        if (getStreamType() == StreamType.LIVE_STREAM) return -1;
+        if (getStreamType() == StreamType.LIVE_STREAM || isPremiere()) {
+            return -1;
+        }
 
         String duration = null;
 
@@ -165,7 +167,16 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Nullable
     @Override
-    public String getTextualUploadDate() {
+    public String getTextualUploadDate() throws ParsingException {
+        if (getStreamType().equals(StreamType.LIVE_STREAM)) {
+            return null;
+        }
+
+        if (isPremiere()) {
+            final Date date = getDateFromPremiere().getTime();
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm").format(date);
+        }
+
         try {
             return getTextFromObject(videoInfo.getObject("publishedTimeText"));
         } catch (Exception e) {
@@ -177,7 +188,15 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     @Nullable
     @Override
     public DateWrapper getUploadDate() throws ParsingException {
-        String textualUploadDate = getTextualUploadDate();
+        if (getStreamType().equals(StreamType.LIVE_STREAM)) {
+            return null;
+        }
+
+        if (isPremiere()) {
+            return new DateWrapper(getDateFromPremiere());
+        }
+
+        final String textualUploadDate = getTextualUploadDate();
         if (timeAgoParser != null && textualUploadDate != null && !textualUploadDate.isEmpty()) {
             try {
                 return timeAgoParser.parse(textualUploadDate);
@@ -236,7 +255,26 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                     return true;
                 }
             }
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
         return false;
+    }
+
+    private boolean isPremiere() {
+        return videoInfo.has("upcomingEventData");
+    }
+
+    private Calendar getDateFromPremiere() throws ParsingException {
+        final JsonObject upcomingEventData = videoInfo.getObject("upcomingEventData");
+        final String startTime = upcomingEventData.getString("startTime");
+
+        try {
+            final long startTimeTimestamp = Long.parseLong(startTime);
+            final Calendar calendar = Calendar.getInstance();
+            calendar.setTime(new Date(startTimeTimestamp * 1000L));
+            return calendar;
+        } catch (Exception e) {
+            throw new ParsingException("Could not parse date from premiere:  \"" + startTime + "\"");
+        }
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -194,11 +194,16 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             if (videoInfo.getObject("topStandaloneBadge") != null || isPremium()) {
                 return -1;
             }
-            String viewCount = getTextFromObject(videoInfo.getObject("viewCountText"));
+
+            final JsonObject viewCountObject = videoInfo.getObject("viewCountText");
+            if (viewCountObject == null) {
+                // This object is null when a video has its views hidden.
+                return -1;
+            }
+
+            final String viewCount = getTextFromObject(viewCountObject);
 
             return Long.parseLong(Utils.removeNonDigitCharacters(viewCount));
-        } catch (NumberFormatException e) {
-            return -1;
         } catch (Exception e) {
             throw new ParsingException("Could not get view count", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class JsonUtils {
+    public static final JsonObject DEFAULT_EMPTY = new JsonObject();
 
     private JsonUtils() {
     }

--- a/extractor/src/test/java/org/schabi/newpipe/DownloaderTestImpl.java
+++ b/extractor/src/test/java/org/schabi/newpipe/DownloaderTestImpl.java
@@ -102,16 +102,20 @@ public class DownloaderTestImpl extends Downloader {
 
             return new Response(responseCode, responseMessage, responseHeaders, response.toString());
         } catch (Exception e) {
+            final int responseCode = connection.getResponseCode();
+
             /*
              * HTTP 429 == Too Many Request
              * Receive from Youtube.com = ReCaptcha challenge request
              * See : https://github.com/rg3/youtube-dl/issues/5138
              */
-            if (connection.getResponseCode() == 429) {
+            if (responseCode == 429) {
                 throw new ReCaptchaException("reCaptcha Challenge requested", url);
+            } else if (responseCode != -1) {
+                return new Response(responseCode, connection.getResponseMessage(), connection.getHeaderFields(), null);
             }
 
-            throw new IOException(connection.getResponseCode() + " " + connection.getResponseMessage(), e);
+            throw new IOException("Error occurred while fetching the content", e);
         } finally {
             if (outputStream != null) outputStream.close();
             if (input != null) input.close();

--- a/extractor/src/test/java/org/schabi/newpipe/DownloaderTestImpl.java
+++ b/extractor/src/test/java/org/schabi/newpipe/DownloaderTestImpl.java
@@ -99,8 +99,9 @@ public class DownloaderTestImpl extends Downloader {
             final int responseCode = connection.getResponseCode();
             final String responseMessage = connection.getResponseMessage();
             final Map<String, List<String>> responseHeaders = connection.getHeaderFields();
+            final String latestUrl = connection.getURL().toString();
 
-            return new Response(responseCode, responseMessage, responseHeaders, response.toString());
+            return new Response(responseCode, responseMessage, responseHeaders, response.toString(), latestUrl);
         } catch (Exception e) {
             final int responseCode = connection.getResponseCode();
 
@@ -112,7 +113,8 @@ public class DownloaderTestImpl extends Downloader {
             if (responseCode == 429) {
                 throw new ReCaptchaException("reCaptcha Challenge requested", url);
             } else if (responseCode != -1) {
-                return new Response(responseCode, connection.getResponseMessage(), connection.getHeaderFields(), null);
+                final String latestUrl = connection.getURL().toString();
+                return new Response(responseCode, connection.getResponseMessage(), connection.getHeaderFields(), null, latestUrl);
             }
 
             throw new IOException("Error occurred while fetching the content", e);

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -6,6 +6,7 @@ import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeChannelExtractor;
@@ -19,6 +20,28 @@ import static org.schabi.newpipe.extractor.services.DefaultTests.*;
  * Test for {@link ChannelExtractor}
  */
 public class YoutubeChannelExtractorTest {
+
+    public static class NotAvailable {
+        @BeforeClass
+        public static void setUp() {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+        }
+
+        @Test(expected = ContentNotAvailableException.class)
+        public void deletedFetch() throws Exception {
+            final ChannelExtractor extractor =
+                    YouTube.getChannelExtractor("https://www.youtube.com/channel/UCAUc4iz6edWerIjlnL8OSSw");
+            extractor.fetchPage();
+        }
+
+        @Test(expected = ContentNotAvailableException.class)
+        public void nonExistentFetch() throws Exception {
+            final ChannelExtractor extractor =
+                    YouTube.getChannelExtractor("https://www.youtube.com/channel/DOESNT-EXIST");
+            extractor.fetchPage();
+        }
+    }
+
     public static class Gronkh implements BaseChannelExtractorTest {
         private static YoutubeChannelExtractor extractor;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper;
 
 import java.io.IOException;
@@ -17,7 +18,7 @@ public class YoutubeParsingHelperTest {
     }
 
     @Test
-    public void testIsHardcodedClientVersionValid() throws IOException {
+    public void testIsHardcodedClientVersionValid() throws IOException, ExtractionException {
         assertTrue("Hardcoded client version is not valid anymore",
                 YoutubeParsingHelper.isHardcodedClientVersionValid());
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
@@ -23,6 +24,28 @@ import static org.schabi.newpipe.extractor.services.DefaultTests.*;
  * Test for {@link YoutubePlaylistExtractor}
  */
 public class YoutubePlaylistExtractorTest {
+
+    public static class NotAvailable {
+        @BeforeClass
+        public static void setUp() {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+        }
+
+        @Test(expected = ContentNotAvailableException.class)
+        public void nonExistentFetch() throws Exception {
+            final PlaylistExtractor extractor =
+                    YouTube.getPlaylistExtractor("https://www.youtube.com/playlist?list=PL11111111111111111111111111111111");
+            extractor.fetchPage();
+        }
+
+        @Test(expected = ContentNotAvailableException.class)
+        public void invalidId() throws Exception {
+            final PlaylistExtractor extractor =
+                    YouTube.getPlaylistExtractor("https://www.youtube.com/playlist?list=INVALID_ID");
+            extractor.fetchPage();
+        }
+    }
+
     public static class TimelessPopHits implements BasePlaylistExtractorTest {
         private static YoutubePlaylistExtractor extractor;
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -99,7 +99,7 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testUploaderUrl() throws Exception {
-            assertEquals("https://www.youtube.com/user/andre0y0you", extractor.getUploaderUrl());
+            assertEquals("https://www.youtube.com/channel/UCs72iRpTEuwV3y6pdWYLgiw", extractor.getUploaderUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorDefaultTest.java
@@ -124,7 +124,7 @@ public class YoutubeSearchExtractorDefaultTest extends YoutubeSearchExtractorBas
     }
 
     @Test
-    public void testSuggestionNotNull() {
+    public void testSuggestionNotNull() throws Exception {
         //todo write a real test
         assertNotNull(extractor.getSearchSuggestion());
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.ExtractorAsserts;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor;
@@ -55,6 +56,27 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
  * Test for {@link StreamExtractor}
  */
 public class YoutubeStreamExtractorDefaultTest {
+
+    public static class NotAvailable {
+        @BeforeClass
+        public static void setUp() {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+        }
+
+        @Test(expected = ContentNotAvailableException.class)
+        public void nonExistentFetch() throws Exception {
+            final StreamExtractor extractor =
+                    YouTube.getStreamExtractor("https://www.youtube.com/watch?v=don-t-exist");
+            extractor.fetchPage();
+        }
+
+        @Test(expected = ParsingException.class)
+        public void invalidId() throws Exception {
+            final StreamExtractor extractor =
+                    YouTube.getStreamExtractor("https://www.youtube.com/watch?v=INVALID_ID_INVALID_ID");
+            extractor.fetchPage();
+        }
+    }
 
     /**
      * Test for {@link StreamExtractor}


### PR DESCRIPTION
Fix the issues that I mentioned in #262, and some more that I found along the way.

---

### YouTube

- Take into account videos that have their views hidden.
- Handle videos with no views or with "Recommended to you" text.
- Handle video premiere's date and duration.
- Avoid crashing by letting exceptions bubble up.
  - reCAPTCHAS, for example, were not reaching where they should, resulting in a crash instead of opening it for the user to solve.
  - Maybe there's a better way/approach to how the exceptions are handled in the extractor (e.g. communicate error to front end, error propagation), I'll take a look some time.
- Fix bug when url isn't present in the browseEndpoint object.
- Detect simple 404s in the standard fetch method.
- Detect deleted/nonexistent/invalid channels and playlists.
- Detect when a stream is deleted or doesn't exist.

### Downloader

- Make test downloader return a response instead of throwing an exception.
- Add latest url to the response to make detection of a redirect possible.
- Ignore null-keyed entries when iterating through the response headers.