### PR TITLE
Introduce Image class and provide all available images

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
@@ -2,7 +2,8 @@ package org.schabi.newpipe.extractor;
 
 public class Image {
     // Make it so that HIGH > LOW
-    public final static int LOW = -2;
+    public final static int LOW = -3;
+    public final static int MEDIUM = -2;
     public final static int HIGH = -1;
 
     private final String url;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
@@ -1,6 +1,10 @@
 package org.schabi.newpipe.extractor;
 
 public class Image {
+    // Make it so that HIGH > LOW
+    public final static int LOW = -2;
+    public final static int HIGH = -1;
+
     private final String url;
     private final int width;
     private final int height;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/Image.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.extractor;
+
+public class Image {
+    private final String url;
+    private final int width;
+    private final int height;
+
+    public Image(final String url, final int width, final int height) {
+        this.url = url;
+        this.width = width;
+        this.height = height;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
@@ -27,7 +27,7 @@ public abstract class InfoItem implements Serializable {
     private final int serviceId;
     private final String url;
     private final String name;
-    private String thumbnailUrl;
+    private Image thumbnail;
 
     public InfoItem(InfoType infoType, int serviceId, String url, String name) {
         this.infoType = infoType;
@@ -52,12 +52,12 @@ public abstract class InfoItem implements Serializable {
         return name;
     }
 
-    public void setThumbnailUrl(String thumbnailUrl) {
-        this.thumbnailUrl = thumbnailUrl;
+    public void setThumbnail(Image thumbnail) {
+        this.thumbnail = thumbnail;
     }
 
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
+    public Image getThumbnail() {
+        return thumbnail;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
@@ -21,13 +21,14 @@ package org.schabi.newpipe.extractor;
  */
 
 import java.io.Serializable;
+import java.util.List;
 
 public abstract class InfoItem implements Serializable {
     private final InfoType infoType;
     private final int serviceId;
     private final String url;
     private final String name;
-    private Image thumbnail;
+    private List<Image> thumbnails;
 
     public InfoItem(InfoType infoType, int serviceId, String url, String name) {
         this.infoType = infoType;
@@ -52,12 +53,12 @@ public abstract class InfoItem implements Serializable {
         return name;
     }
 
-    public void setThumbnail(Image thumbnail) {
-        this.thumbnail = thumbnail;
+    public void setThumbnails(List<Image> thumbnails) {
+        this.thumbnails = thumbnails;
     }
 
-    public Image getThumbnail() {
-        return thumbnail;
+    public List<Image> getThumbnails() {
+        return thumbnails;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemExtractor.java
@@ -2,8 +2,10 @@ package org.schabi.newpipe.extractor;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
+import java.util.List;
+
 public interface InfoItemExtractor {
     String getName() throws ParsingException;
     String getUrl() throws ParsingException;
-    Image getThumbnail() throws ParsingException;
+    List<Image> getThumbnails() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemExtractor.java
@@ -5,5 +5,5 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 public interface InfoItemExtractor {
     String getName() throws ParsingException;
     String getUrl() throws ParsingException;
-    String getThumbnailUrl() throws ParsingException;
+    Image getThumbnail() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.channel;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -32,8 +33,8 @@ public abstract class ChannelExtractor extends ListExtractor<StreamInfoItem> {
         super(service, linkHandler);
     }
 
-    public abstract String getAvatarUrl() throws ParsingException;
-    public abstract String getBannerUrl() throws ParsingException;
+    public abstract Image getAvatar() throws ParsingException;
+    public abstract Image getBanner() throws ParsingException;
     public abstract String getFeedUrl() throws ParsingException;
     public abstract long getSubscriberCount() throws ParsingException;
     public abstract String getDescription() throws ParsingException;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelExtractor.java
@@ -7,6 +7,8 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
+import java.util.List;
+
 /*
  * Created by Christian Schabesberger on 25.07.16.
  *
@@ -33,8 +35,8 @@ public abstract class ChannelExtractor extends ListExtractor<StreamInfoItem> {
         super(service, linkHandler);
     }
 
-    public abstract Image getAvatar() throws ParsingException;
-    public abstract Image getBanner() throws ParsingException;
+    public abstract List<Image> getAvatars() throws ParsingException;
+    public abstract List<Image> getBanners() throws ParsingException;
     public abstract String getFeedUrl() throws ParsingException;
     public abstract long getSubscriberCount() throws ParsingException;
     public abstract String getDescription() throws ParsingException;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.utils.ExtractorHelper;
 
 import java.io.IOException;
+import java.util.List;
 
 /*
  * Created by Christian Schabesberger on 31.07.16.
@@ -65,12 +66,12 @@ public class ChannelInfo extends ListInfo<StreamInfoItem> {
         final ChannelInfo info = new ChannelInfo(serviceId, id, url, originalUrl, name, extractor.getLinkHandler());
 
         try {
-            info.setAvatar(extractor.getAvatar());
+            info.setAvatars(extractor.getAvatars());
         } catch (Exception e) {
             info.addError(e);
         }
         try {
-            info.setBanner(extractor.getBanner());
+            info.setBanners(extractor.getBanners());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -98,27 +99,27 @@ public class ChannelInfo extends ListInfo<StreamInfoItem> {
         return info;
     }
 
-    private Image avatar;
-    private Image banner;
+    private List<Image> avatars;
+    private List<Image> banners;
     private String feedUrl;
     private long subscriberCount = -1;
     private String description;
     private String[] donationLinks;
 
-    public Image getAvatar() {
-        return avatar;
+    public List<Image> getAvatars() {
+        return avatars;
     }
 
-    public void setAvatar(Image avatar) {
-        this.avatar = avatar;
+    public void setAvatars(List<Image> avatars) {
+        this.avatars = avatars;
     }
 
-    public Image getBanner() {
-        return banner;
+    public List<Image> getBanners() {
+        return banners;
     }
 
-    public void setBanner(Image banner) {
-        this.banner = banner;
+    public void setBanners(List<Image> banners) {
+        this.banners = banners;
     }
 
     public String getFeedUrl() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfo.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.channel;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage;
 import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -64,12 +65,12 @@ public class ChannelInfo extends ListInfo<StreamInfoItem> {
         final ChannelInfo info = new ChannelInfo(serviceId, id, url, originalUrl, name, extractor.getLinkHandler());
 
         try {
-            info.setAvatarUrl(extractor.getAvatarUrl());
+            info.setAvatar(extractor.getAvatar());
         } catch (Exception e) {
             info.addError(e);
         }
         try {
-            info.setBannerUrl(extractor.getBannerUrl());
+            info.setBanner(extractor.getBanner());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -97,27 +98,27 @@ public class ChannelInfo extends ListInfo<StreamInfoItem> {
         return info;
     }
 
-    private String avatarUrl;
-    private String bannerUrl;
+    private Image avatar;
+    private Image banner;
     private String feedUrl;
     private long subscriberCount = -1;
     private String description;
     private String[] donationLinks;
 
-    public String getAvatarUrl() {
-        return avatarUrl;
+    public Image getAvatar() {
+        return avatar;
     }
 
-    public void setAvatarUrl(String avatarUrl) {
-        this.avatarUrl = avatarUrl;
+    public void setAvatar(Image avatar) {
+        this.avatar = avatar;
     }
 
-    public String getBannerUrl() {
-        return bannerUrl;
+    public Image getBanner() {
+        return banner;
     }
 
-    public void setBannerUrl(String bannerUrl) {
-        this.bannerUrl = bannerUrl;
+    public void setBanner(Image banner) {
+        this.banner = banner;
     }
 
     public String getFeedUrl() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemsCollector.java
@@ -50,7 +50,7 @@ public class ChannelInfoItemsCollector extends InfoItemsCollector<ChannelInfoIte
             addError(e);
         }
         try {
-            resultItem.setThumbnailUrl(extractor.getThumbnailUrl());
+            resultItem.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/channel/ChannelInfoItemsCollector.java
@@ -50,7 +50,7 @@ public class ChannelInfoItemsCollector extends InfoItemsCollector<ChannelInfoIte
             addError(e);
         }
         try {
-            resultItem.setThumbnail(extractor.getThumbnail());
+            resultItem.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -1,7 +1,10 @@
 package org.schabi.newpipe.extractor.comments;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -10,7 +13,7 @@ public class CommentsInfoItem extends InfoItem {
     private String commentId;
     private String commentText;
     private String authorName;
-    private String authorThumbnail;
+    private List<Image> authorThumbnails;
     private String authorEndpoint;
     private String textualPublishedTime;
     @Nullable private DateWrapper publishedTime;
@@ -44,12 +47,12 @@ public class CommentsInfoItem extends InfoItem {
         this.authorName = authorName;
     }
 
-    public String getAuthorThumbnail() {
-        return authorThumbnail;
+    public List<Image> getAuthorThumbnails() {
+        return authorThumbnails;
     }
 
-    public void setAuthorThumbnail(String authorThumbnail) {
-        this.authorThumbnail = authorThumbnail;
+    public void setAuthorThumbnails(List<Image> authorThumbnails) {
+        this.authorThumbnails = authorThumbnails;
     }
 
     public String getAuthorEndpoint() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -1,8 +1,11 @@
 package org.schabi.newpipe.extractor.comments;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
+
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -10,7 +13,7 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
     String getCommentId() throws ParsingException;
     String getCommentText() throws ParsingException;
     String getAuthorName() throws ParsingException;
-    String getAuthorThumbnail() throws ParsingException;
+    List<Image> getAuthorThumbnails() throws ParsingException;
     String getAuthorEndpoint() throws ParsingException;
     String getTextualPublishedTime() throws ParsingException;
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -40,7 +40,7 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
             addError(e);
         }
         try {
-            resultItem.setAuthorThumbnail(extractor.getAuthorThumbnail());
+            resultItem.setAuthorThumbnails(extractor.getAuthorThumbnails());
         } catch (Exception e) {
             addError(e);
         }
@@ -65,7 +65,7 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
             addError(e);
         }
         try {
-            resultItem.setThumbnail(extractor.getThumbnail());
+            resultItem.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -65,7 +65,7 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
             addError(e);
         }
         try {
-            resultItem.setThumbnailUrl(extractor.getThumbnailUrl());
+            resultItem.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -7,18 +7,20 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
+import java.util.List;
+
 public abstract class PlaylistExtractor extends ListExtractor<StreamInfoItem> {
 
     public PlaylistExtractor(StreamingService service, ListLinkHandler linkHandler) {
         super(service, linkHandler);
     }
 
-    public abstract Image getThumbnail() throws ParsingException;
-    public abstract Image getBanner() throws ParsingException;
+    public abstract List<Image> getThumbnails() throws ParsingException;
+    public abstract List<Image> getBanners() throws ParsingException;
 
     public abstract String getUploaderUrl() throws ParsingException;
     public abstract String getUploaderName() throws ParsingException;
-    public abstract Image getUploaderAvatar() throws ParsingException;
+    public abstract List<Image> getUploaderAvatars() throws ParsingException;
 
     public abstract long getStreamCount() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.playlist;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -12,12 +13,12 @@ public abstract class PlaylistExtractor extends ListExtractor<StreamInfoItem> {
         super(service, linkHandler);
     }
 
-    public abstract String getThumbnailUrl() throws ParsingException;
-    public abstract String getBannerUrl() throws ParsingException;
+    public abstract Image getThumbnail() throws ParsingException;
+    public abstract Image getBanner() throws ParsingException;
 
     public abstract String getUploaderUrl() throws ParsingException;
     public abstract String getUploaderName() throws ParsingException;
-    public abstract String getUploaderAvatarUrl() throws ParsingException;
+    public abstract Image getUploaderAvatar() throws ParsingException;
 
     public abstract long getStreamCount() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
@@ -63,7 +63,7 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
             info.addError(e);
         }
         try {
-            info.setThumbnail(extractor.getThumbnail());
+            info.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -80,13 +80,13 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
             uploaderParsingErrors.add(e);
         }
         try {
-            info.setUploaderAvatar(extractor.getUploaderAvatar());
+            info.setUploaderAvatars(extractor.getUploaderAvatars());
         } catch (Exception e) {
-            info.setUploaderAvatar(null);
+            info.setUploaderAvatars(null);
             uploaderParsingErrors.add(e);
         }
         try {
-            info.setBanner(extractor.getBanner());
+            info.setBanners(extractor.getBanners());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -103,27 +103,27 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
         return info;
     }
 
-    private Image thumbnail;
-    private Image banner;
+    private List<Image> thumbnails;
+    private List<Image> banners;
     private String uploaderUrl;
     private String uploaderName;
-    private Image uploaderAvatar;
+    private List<Image> uploaderAvatars;
     private long streamCount = 0;
 
-    public Image getThumbnail() {
-        return thumbnail;
+    public List<Image> getThumbnails() {
+        return thumbnails;
     }
 
-    public void setThumbnail(Image thumbnail) {
-        this.thumbnail = thumbnail;
+    public void setThumbnails(List<Image> thumbnails) {
+        this.thumbnails = thumbnails;
     }
 
-    public Image getBanner() {
-        return banner;
+    public List<Image> getBanners() {
+        return banners;
     }
 
-    public void setBanner(Image banner) {
-        this.banner = banner;
+    public void setBanners(List<Image> banners) {
+        this.banners = banners;
     }
 
     public String getUploaderUrl() {
@@ -142,12 +142,12 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
         this.uploaderName = uploaderName;
     }
 
-    public Image getUploaderAvatar() {
-        return uploaderAvatar;
+    public List<Image> getUploaderAvatars() {
+        return uploaderAvatars;
     }
 
-    public void setUploaderAvatar(Image uploaderAvatar) {
-        this.uploaderAvatar = uploaderAvatar;
+    public void setUploaderAvatars(List<Image> uploaderAvatars) {
+        this.uploaderAvatars = uploaderAvatars;
     }
 
     public long getStreamCount() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.playlist;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage;
 import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -62,7 +63,7 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
             info.addError(e);
         }
         try {
-            info.setThumbnailUrl(extractor.getThumbnailUrl());
+            info.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -79,13 +80,13 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
             uploaderParsingErrors.add(e);
         }
         try {
-            info.setUploaderAvatarUrl(extractor.getUploaderAvatarUrl());
+            info.setUploaderAvatar(extractor.getUploaderAvatar());
         } catch (Exception e) {
-            info.setUploaderAvatarUrl("");
+            info.setUploaderAvatar(null);
             uploaderParsingErrors.add(e);
         }
         try {
-            info.setBannerUrl(extractor.getBannerUrl());
+            info.setBanner(extractor.getBanner());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -102,27 +103,27 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
         return info;
     }
 
-    private String thumbnailUrl;
-    private String bannerUrl;
+    private Image thumbnail;
+    private Image banner;
     private String uploaderUrl;
     private String uploaderName;
-    private String uploaderAvatarUrl;
+    private Image uploaderAvatar;
     private long streamCount = 0;
 
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
+    public Image getThumbnail() {
+        return thumbnail;
     }
 
-    public void setThumbnailUrl(String thumbnailUrl) {
-        this.thumbnailUrl = thumbnailUrl;
+    public void setThumbnail(Image thumbnail) {
+        this.thumbnail = thumbnail;
     }
 
-    public String getBannerUrl() {
-        return bannerUrl;
+    public Image getBanner() {
+        return banner;
     }
 
-    public void setBannerUrl(String bannerUrl) {
-        this.bannerUrl = bannerUrl;
+    public void setBanner(Image banner) {
+        this.banner = banner;
     }
 
     public String getUploaderUrl() {
@@ -141,12 +142,12 @@ public class PlaylistInfo extends ListInfo<StreamInfoItem> {
         this.uploaderName = uploaderName;
     }
 
-    public String getUploaderAvatarUrl() {
-        return uploaderAvatarUrl;
+    public Image getUploaderAvatar() {
+        return uploaderAvatar;
     }
 
-    public void setUploaderAvatarUrl(String uploaderAvatarUrl) {
-        this.uploaderAvatarUrl = uploaderAvatarUrl;
+    public void setUploaderAvatar(Image uploaderAvatar) {
+        this.uploaderAvatar = uploaderAvatar;
     }
 
     public long getStreamCount() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
@@ -24,7 +24,7 @@ public class PlaylistInfoItemsCollector extends InfoItemsCollector<PlaylistInfoI
             addError(e);
         }
         try {
-            resultItem.setThumbnail(extractor.getThumbnail());
+            resultItem.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
@@ -24,7 +24,7 @@ public class PlaylistInfoItemsCollector extends InfoItemsCollector<PlaylistInfoI
             addError(e);
         }
         try {
-            resultItem.setThumbnailUrl(extractor.getThumbnailUrl());
+            resultItem.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -26,13 +28,13 @@ public class MediaCCCConferenceExtractor extends ChannelExtractor {
     }
 
     @Override
-    public String getAvatarUrl() throws ParsingException {
-        return conferenceData.getString("logo_url");
+    public Image getAvatar() throws ParsingException {
+        return new Image(conferenceData.getString("logo_url"), -1, -1);
     }
 
     @Override
-    public String getBannerUrl() throws ParsingException {
-        return conferenceData.getString("logo_url");
+    public Image getBanner() throws ParsingException {
+        return new Image(conferenceData.getString("logo_url"), -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
@@ -18,6 +18,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MediaCCCConferenceExtractor extends ChannelExtractor {
 
@@ -28,13 +30,17 @@ public class MediaCCCConferenceExtractor extends ChannelExtractor {
     }
 
     @Override
-    public Image getAvatar() throws ParsingException {
-        return new Image(conferenceData.getString("logo_url"), -1, -1);
+    public List<Image> getAvatars() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        return images;
     }
 
     @Override
-    public Image getBanner() throws ParsingException {
-        return new Image(conferenceData.getString("logo_url"), -1, -1);
+    public List<Image> getBanners() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
@@ -32,14 +32,14 @@ public class MediaCCCConferenceExtractor extends ChannelExtractor {
     @Override
     public List<Image> getAvatars() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        images.add(new Image(conferenceData.getString("logo_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 
     @Override
     public List<Image> getBanners() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        images.add(new Image(conferenceData.getString("logo_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
@@ -135,8 +135,8 @@ public class MediaCCCSearchExtractor extends SearchExtractor {
                     }
 
                     @Override
-                    public Image getThumbnail() throws ParsingException {
-                        return item.getThumbnail();
+                    public List<Image> getThumbnails() throws ParsingException {
+                        return item.getThumbnails();
                     }
                 });
             }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
@@ -133,8 +135,8 @@ public class MediaCCCSearchExtractor extends SearchExtractor {
                     }
 
                     @Override
-                    public String getThumbnailUrl() throws ParsingException {
-                        return item.getThumbnailUrl();
+                    public Image getThumbnail() throws ParsingException {
+                        return item.getThumbnail();
                     }
                 });
             }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -42,8 +44,8 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getThumbnailUrl() throws ParsingException {
-        return data.getString("thumb_url");
+    public Image getThumbnail() throws ParsingException {
+        return new Image(data.getString("thumb_url"), -1, -1);
     }
 
     @Nonnull
@@ -97,8 +99,8 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getUploaderAvatarUrl() throws ParsingException {
-        return conferenceData.getString("logo_url");
+    public Image getUploaderAvatar() throws ParsingException {
+        return new Image(conferenceData.getString("logo_url"), -1, -1);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
@@ -44,8 +44,10 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getThumbnail() throws ParsingException {
-        return new Image(data.getString("thumb_url"), -1, -1);
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(data.getString("thumb_url"), -1, -1));
+        return images;
     }
 
     @Nonnull
@@ -99,8 +101,10 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getUploaderAvatar() throws ParsingException {
-        return new Image(conferenceData.getString("logo_url"), -1, -1);
+    public List<Image> getUploaderAvatars() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        return images;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
@@ -46,7 +46,7 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
     @Override
     public List<Image> getThumbnails() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(data.getString("thumb_url"), -1, -1));
+        images.add(new Image(data.getString("thumb_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 
@@ -103,7 +103,7 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
     @Override
     public List<Image> getUploaderAvatars() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(conferenceData.getString("logo_url"), -1, -1));
+        images.add(new Image(conferenceData.getString("logo_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
@@ -45,7 +45,7 @@ public class MediaCCCConferenceInfoItemExtractor implements ChannelInfoItemExtra
     @Override
     public List<Image> getThumbnails() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(conference.getString("logo_url"), -1, -1));
+        images.add(new Image(conference.getString("logo_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
@@ -6,6 +6,9 @@ import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MediaCCCConferenceInfoItemExtractor implements ChannelInfoItemExtractor {
 
     JsonObject conference;
@@ -40,7 +43,9 @@ public class MediaCCCConferenceInfoItemExtractor implements ChannelInfoItemExtra
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
-        return new Image(conference.getString("logo_url"), -1, -1);
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(conference.getString("logo_url"), -1, -1));
+        return images;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCConferenceInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.media_ccc.extractors.infoItems;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
@@ -38,7 +40,7 @@ public class MediaCCCConferenceInfoItemExtractor implements ChannelInfoItemExtra
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
-        return conference.getString("logo_url");
+    public Image getThumbnail() throws ParsingException {
+        return new Image(conference.getString("logo_url"), -1, -1);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
@@ -9,6 +9,9 @@ import org.schabi.newpipe.extractor.services.media_ccc.extractors.MediaCCCParsin
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 public class MediaCCCStreamInfoItemExtractor implements StreamInfoItemExtractor {
@@ -74,7 +77,9 @@ public class MediaCCCStreamInfoItemExtractor implements StreamInfoItemExtractor 
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
-        return new Image(event.getString("thumb_url"), -1, -1);
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(event.getString("thumb_url"), -1, -1));
+        return images;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
@@ -79,7 +79,7 @@ public class MediaCCCStreamInfoItemExtractor implements StreamInfoItemExtractor 
     @Override
     public List<Image> getThumbnails() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(event.getString("thumb_url"), -1, -1));
+        images.add(new Image(event.getString("thumb_url"), Image.HIGH, Image.HIGH));
         return images;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/infoItems/MediaCCCStreamInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.media_ccc.extractors.infoItems;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.services.media_ccc.extractors.MediaCCCParsingHelper;
@@ -72,7 +74,7 @@ public class MediaCCCStreamInfoItemExtractor implements StreamInfoItemExtractor 
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
-        return event.getString("thumb_url");
+    public Image getThumbnail() throws ParsingException {
+        return new Image(event.getString("thumb_url"), -1, -1);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
@@ -53,7 +53,8 @@ public class PeertubeChannelExtractor extends ChannelExtractor {
             value = "/client/assets/images/default-avatar.png";
         }
 
-        images.add(new Image(baseUrl + value, -1, -1));
+        images.add(new Image(baseUrl + value, 120, 120)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L558
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
@@ -5,6 +5,7 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 import org.jsoup.helper.StringUtil;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -40,18 +41,18 @@ public class PeertubeChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public String getAvatarUrl() throws ParsingException {
+    public Image getAvatar() throws ParsingException {
         String value;
         try {
             value = JsonUtils.getString(json, "avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return baseUrl + value;
+        return new Image(baseUrl + value, -1, -1);
     }
 
     @Override
-    public String getBannerUrl() throws ParsingException {
+    public Image getBanner() throws ParsingException {
         return null;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
@@ -21,6 +21,8 @@ import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Parser.RegexException;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PeertubeChannelExtractor extends ChannelExtractor {
 
@@ -41,18 +43,22 @@ public class PeertubeChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public Image getAvatar() throws ParsingException {
+    public List<Image> getAvatars() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+
         String value;
         try {
             value = JsonUtils.getString(json, "avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return new Image(baseUrl + value, -1, -1);
+
+        images.add(new Image(baseUrl + value, -1, -1));
+        return images;
     }
 
     @Override
-    public Image getBanner() throws ParsingException {
+    public List<Image> getBanners() throws ParsingException {
         return null;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -43,7 +43,7 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             value = "/client/assets/images/default-avatar.png";
         }
 
-        images.add(new Image(baseUrl + value, -1, -1));
+        images.add(new Image(baseUrl + value, 120, 120)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L558
         return images;
     }
 
@@ -96,7 +96,7 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             value = "/client/assets/images/default-avatar.png";
         }
 
-        images.add(new Image(baseUrl + value, -1, -1));
+        images.add(new Image(baseUrl + value, 120, 120)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L558
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -11,6 +11,9 @@ import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtractor {
 
@@ -30,14 +33,18 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+
         String value;
         try {
             value = JsonUtils.getString(item, "account.avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return new Image(baseUrl + value, -1, -1);
+
+        images.add(new Image(baseUrl + value, -1, -1));
+        return images;
     }
 
     @Override
@@ -79,14 +86,18 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
     }
 
     @Override
-    public String getAuthorThumbnail() throws ParsingException {
+    public List<Image> getAuthorThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+
         String value;
         try {
             value = JsonUtils.getString(item, "account.avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return baseUrl + value;
+
+        images.add(new Image(baseUrl + value, -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.peertube.extractors;
 import com.grack.nanojson.JsonObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -29,14 +30,14 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         String value;
         try {
             value = JsonUtils.getString(item, "account.avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return baseUrl + value;
+        return new Image(baseUrl + value, -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.peertube.extractors;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -18,13 +19,13 @@ public class PeertubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public String getBannerUrl() throws ParsingException {
+    public Image getBanner() throws ParsingException {
         // TODO Auto-generated method stub
         return null;
     }
@@ -42,7 +43,7 @@ public class PeertubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getUploaderAvatarUrl() throws ParsingException {
+    public Image getUploaderAvatar() throws ParsingException {
         // TODO Auto-generated method stub
         return null;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
@@ -10,77 +10,69 @@ import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Nonnull;
 
 public class PeertubePlaylistExtractor extends PlaylistExtractor {
-
     public PeertubePlaylistExtractor(StreamingService service, ListLinkHandler linkHandler) {
         super(service, linkHandler);
-        // TODO Auto-generated constructor stub
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
-        // TODO Auto-generated method stub
+    public List<Image> getThumbnails() throws ParsingException {
         return null;
     }
 
     @Override
-    public Image getBanner() throws ParsingException {
-        // TODO Auto-generated method stub
+    public List<Image> getBanners() throws ParsingException {
         return null;
     }
 
     @Override
     public String getUploaderUrl() throws ParsingException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public String getUploaderName() throws ParsingException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public Image getUploaderAvatar() throws ParsingException {
-        // TODO Auto-generated method stub
+    public List<Image> getUploaderAvatars() throws ParsingException {
         return null;
     }
 
     @Override
     public long getStreamCount() throws ParsingException {
-        // TODO Auto-generated method stub
         return 0;
     }
 
+    @Nonnull
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws IOException, ExtractionException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public String getNextPageUrl() throws IOException, ExtractionException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public InfoItemsPage<StreamInfoItem> getPage(String pageUrl) throws IOException, ExtractionException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public void onFetchPage(Downloader downloader) throws IOException, ExtractionException {
+    public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
 
     }
 
+    @Nonnull
     @Override
     public String getName() throws ParsingException {
-        // TODO Auto-generated method stub
         return null;
     }
-
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
@@ -61,7 +61,10 @@ public class PeertubeStreamExtractor extends StreamExtractor {
     @Override
     public List<Image> getThumbnails() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(baseUrl + JsonUtils.getString(json, "previewPath"), -1, -1));
+
+        images.add(new Image(baseUrl + JsonUtils.getString(json, "thumbnailPath"), 223, 122)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L548
+        images.add(new Image(baseUrl + JsonUtils.getString(json, "previewPath"), 850, 480)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L553
+
         return images;
     }
 
@@ -150,7 +153,8 @@ public class PeertubeStreamExtractor extends StreamExtractor {
             value = "/client/assets/images/default-avatar.png";
         }
 
-        images.add(new Image(baseUrl + value, -1, -1));
+        images.add(new Image(baseUrl + value, 120, 120)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L558
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
@@ -5,6 +5,7 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
 import org.jsoup.helper.StringUtil;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -58,8 +59,8 @@ public class PeertubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
-        return baseUrl + JsonUtils.getString(json, "previewPath");
+    public Image getThumbnail() throws ParsingException {
+        return new Image(baseUrl + JsonUtils.getString(json, "previewPath"), -1, -1);
     }
 
     @Override
@@ -137,14 +138,14 @@ public class PeertubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public String getUploaderAvatarUrl() throws ParsingException {
+    public Image getUploaderAvatar() throws ParsingException {
         String value;
         try {
             value = JsonUtils.getString(json, "account.avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return baseUrl + value;
+        return new Image(baseUrl + value, -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
@@ -59,8 +59,10 @@ public class PeertubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
-        return new Image(baseUrl + JsonUtils.getString(json, "previewPath"), -1, -1);
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(baseUrl + JsonUtils.getString(json, "previewPath"), -1, -1));
+        return images;
     }
 
     @Override
@@ -138,14 +140,18 @@ public class PeertubeStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public Image getUploaderAvatar() throws ParsingException {
+    public List<Image> getUploaderAvatars() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+
         String value;
         try {
             value = JsonUtils.getString(json, "account.avatar.path");
         } catch (Exception e) {
             value = "/client/assets/images/default-avatar.png";
         }
-        return new Image(baseUrl + value, -1, -1);
+
+        images.add(new Image(baseUrl + value, -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
@@ -33,7 +33,10 @@ public class PeertubeStreamInfoItemExtractor implements StreamInfoItemExtractor 
     @Override
     public List<Image> getThumbnails() throws ParsingException {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(baseUrl + JsonUtils.getString(item, "thumbnailPath"), -1, -1));
+
+        images.add(new Image(baseUrl + JsonUtils.getString(item, "thumbnailPath"), 223, 122)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L548
+        images.add(new Image(baseUrl + JsonUtils.getString(item, "previewPath"), 850, 480)); // See https://github.com/Chocobozzz/PeerTube/blob/366caf8b71f3d82336b6ac243845c783ef673fc1/server/initializers/constants.ts#L553
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
@@ -11,6 +11,9 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class PeertubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
     protected final JsonObject item;
@@ -28,9 +31,10 @@ public class PeertubeStreamInfoItemExtractor implements StreamInfoItemExtractor 
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
-        String value = JsonUtils.getString(item, "thumbnailPath");
-        return new Image(baseUrl + value, -1, -1);
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(baseUrl + JsonUtils.getString(item, "thumbnailPath"), -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.peertube.extractors;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -26,9 +28,9 @@ public class PeertubeStreamInfoItemExtractor implements StreamInfoItemExtractor 
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         String value = JsonUtils.getString(item, "thumbnailPath");
-        return baseUrl + value;
+        return new Image(baseUrl + value, -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -56,16 +58,16 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public String getAvatarUrl() {
-        return user.getString("avatar_url");
+    public Image getAvatar() {
+        return new Image(user.getString("avatar_url"), -1, -1);
     }
 
     @Override
-    public String getBannerUrl() {
-        return user.getObject("visuals", new JsonObject())
+    public Image getBanner() {
+        return new Image(user.getObject("visuals", new JsonObject())
                 .getArray("visuals", new JsonArray())
                 .getObject(0, new JsonObject())
-                .getString("visual_url");
+                .getString("visual_url"), -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
@@ -62,17 +62,22 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     @Override
     public List<Image> getAvatars() {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(user.getString("avatar_url"), -1, -1));
+
+        images.add(new Image(user.getString("avatar_url"), Image.LOW, Image.LOW));
+        images.add(new Image(user.getString("avatar_url").replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
         return images;
     }
 
     @Override
     public List<Image> getBanners() {
         List<Image> images = new ArrayList<>();
+
         images.add(new Image(user.getObject("visuals", new JsonObject())
                 .getArray("visuals", new JsonArray())
                 .getObject(0, new JsonObject())
-                .getString("visual_url"), -1, -1));
+                .getString("visual_url"), Image.HIGH, Image.HIGH));
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
@@ -15,10 +15,11 @@ import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 @SuppressWarnings("WeakerAccess")
 public class SoundcloudChannelExtractor extends ChannelExtractor {
@@ -63,7 +64,8 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     public List<Image> getAvatars() {
         List<Image> images = new ArrayList<>();
 
-        images.add(new Image(user.getString("avatar_url"), Image.LOW, Image.LOW));
+        images.add(new Image(user.getString("avatar_url"), Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(user.getString("avatar_url").replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(user.getString("avatar_url").replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractor.java
@@ -17,6 +17,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class SoundcloudChannelExtractor extends ChannelExtractor {
@@ -58,16 +60,20 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public Image getAvatar() {
-        return new Image(user.getString("avatar_url"), -1, -1);
+    public List<Image> getAvatars() {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(user.getString("avatar_url"), -1, -1));
+        return images;
     }
 
     @Override
-    public Image getBanner() {
-        return new Image(user.getObject("visuals", new JsonObject())
+    public List<Image> getBanners() {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(user.getObject("visuals", new JsonObject())
                 .getArray("visuals", new JsonArray())
                 .getObject(0, new JsonObject())
-                .getString("visual_url"), -1, -1);
+                .getString("visual_url"), -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
@@ -23,10 +25,10 @@ public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtrac
     }
 
     @Override
-    public String getThumbnailUrl() {
+    public Image getThumbnail() {
         String avatarUrl = itemObject.getString("avatar_url", "");
         String avatarUrlBetterResolution = avatarUrl.replace("large.jpg", "crop.jpg");
-        return avatarUrlBetterResolution;
+        return new Image(avatarUrlBetterResolution, -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
@@ -5,6 +5,9 @@ import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtractor {
@@ -25,10 +28,12 @@ public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtrac
     }
 
     @Override
-    public Image getThumbnail() {
+    public List<Image> getThumbnails() {
+        List<Image> images = new ArrayList<>();
         String avatarUrl = itemObject.getString("avatar_url", "");
         String avatarUrlBetterResolution = avatarUrl.replace("large.jpg", "crop.jpg");
-        return new Image(avatarUrlBetterResolution, -1, -1);
+        images.add(new Image(avatarUrlBetterResolution, -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
@@ -33,7 +33,8 @@ public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtrac
 
         String avatarUrl = itemObject.getString("avatar_url", "");
 
-        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(avatarUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelInfoItemExtractor.java
@@ -30,9 +30,12 @@ public class SoundcloudChannelInfoItemExtractor implements ChannelInfoItemExtrac
     @Override
     public List<Image> getThumbnails() {
         List<Image> images = new ArrayList<>();
+
         String avatarUrl = itemObject.getString("avatar_url", "");
-        String avatarUrlBetterResolution = avatarUrl.replace("large.jpg", "crop.jpg");
-        images.add(new Image(avatarUrlBetterResolution, -1, -1));
+
+        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -81,8 +81,8 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
 
         List<Image> images = new ArrayList<>();
 
-        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;
     }
@@ -105,7 +105,12 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     @Override
     public List<Image> getUploaderAvatars() {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(SoundcloudParsingHelper.getAvatarUrl(playlist), -1, -1));
+
+        String avatarUrl = SoundcloudParsingHelper.getAvatarUrl(playlist);
+
+        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -3,6 +3,8 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -56,7 +58,7 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() {
+    public Image getThumbnail() {
         String artworkUrl = playlist.getString("artwork_url");
 
         if (artworkUrl == null) {
@@ -67,22 +69,22 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
                 if (infoItems.getItems().isEmpty()) return null;
 
                 for (StreamInfoItem item : infoItems.getItems()) {
-                    final String thumbnailUrl = item.getThumbnailUrl();
-                    if (thumbnailUrl == null || thumbnailUrl.isEmpty()) continue;
+                    final Image thumbnail = item.getThumbnail();
+                    if (thumbnail.getUrl() == null || thumbnail.getUrl().isEmpty()) continue;
 
-                    String thumbnailUrlBetterResolution = thumbnailUrl.replace("large.jpg", "crop.jpg");
-                    return thumbnailUrlBetterResolution;
+                    String thumbnailUrlBetterResolution = thumbnail.getUrl().replace("large.jpg", "crop.jpg");
+                    return new Image(thumbnailUrlBetterResolution, -1, -1);
                 }
             } catch (Exception ignored) {
             }
         }
 
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return artworkUrlBetterResolution;
+        return new Image(artworkUrlBetterResolution, -1, -1);
     }
 
     @Override
-    public String getBannerUrl() {
+    public Image getBanner() {
         return null;
     }
 
@@ -97,8 +99,8 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getUploaderAvatarUrl() {
-        return SoundcloudParsingHelper.getAvatarUrl(playlist);
+    public Image getUploaderAvatar() {
+        return new Image(SoundcloudParsingHelper.getAvatarUrl(playlist), -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -14,10 +14,11 @@ import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 @SuppressWarnings("WeakerAccess")
 public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
@@ -81,7 +82,8 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
 
         List<Image> images = new ArrayList<>();
 
-        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(artworkUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;
@@ -108,7 +110,8 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
 
         String avatarUrl = SoundcloudParsingHelper.getAvatarUrl(playlist);
 
-        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(avatarUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -16,6 +16,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
@@ -58,7 +60,7 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public Image getThumbnail() {
+    public List<Image> getThumbnails() {
         String artworkUrl = playlist.getString("artwork_url");
 
         if (artworkUrl == null) {
@@ -69,22 +71,24 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
                 if (infoItems.getItems().isEmpty()) return null;
 
                 for (StreamInfoItem item : infoItems.getItems()) {
-                    final Image thumbnail = item.getThumbnail();
-                    if (thumbnail.getUrl() == null || thumbnail.getUrl().isEmpty()) continue;
-
-                    String thumbnailUrlBetterResolution = thumbnail.getUrl().replace("large.jpg", "crop.jpg");
-                    return new Image(thumbnailUrlBetterResolution, -1, -1);
+                    final List<Image> thumbnails = item.getThumbnails();
+                    if (thumbnails.isEmpty()) continue;
+                    return thumbnails;
                 }
             } catch (Exception ignored) {
             }
         }
 
+        List<Image> images = new ArrayList<>();
+
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return new Image(artworkUrlBetterResolution, -1, -1);
+        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+
+        return images;
     }
 
     @Override
-    public Image getBanner() {
+    public List<Image> getBanners() {
         return null;
     }
 
@@ -99,8 +103,10 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public Image getUploaderAvatar() {
-        return new Image(SoundcloudParsingHelper.getAvatarUrl(playlist), -1, -1);
+    public List<Image> getUploaderAvatars() {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(SoundcloudParsingHelper.getAvatarUrl(playlist), -1, -1));
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
@@ -40,8 +40,9 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
         if (itemObject.isString(ARTWORK_URL_KEY)) {
             final String artworkUrl = itemObject.getString(ARTWORK_URL_KEY, "");
             if (!artworkUrl.isEmpty()) {
-                String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                images.add(new Image(artworkUrlBetterResolution, -1, -1));
+                images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+                images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
                 return images;
             }
         }
@@ -55,8 +56,9 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                 if (trackObject.isString(ARTWORK_URL_KEY)) {
                     String artworkUrl = trackObject.getString(ARTWORK_URL_KEY, "");
                     if (!artworkUrl.isEmpty()) {
-                        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+                        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+                        images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
                         return images;
                     }
                 }
@@ -65,7 +67,9 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                 final JsonObject creator = trackObject.getObject(USER_KEY, new JsonObject());
                 final String creatorAvatar = creator.getString(AVATAR_URL_KEY, "");
                 if (!creatorAvatar.isEmpty()) {
-                    images.add(new Image(creatorAvatar, -1, -1));
+                    images.add(new Image(creatorAvatar, Image.LOW, Image.LOW));
+                    images.add(new Image(creatorAvatar.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
                     return images;
                 }
             }
@@ -75,7 +79,11 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
 
         try {
             // Last resort, use user avatar url. If still not found, then throw exception.
-            images.add(new Image(itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, ""), -1, -1));
+            final String creatorAvatar = itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, "");
+
+            images.add(new Image(creatorAvatar, Image.LOW, Image.LOW));
+            images.add(new Image(creatorAvatar.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
             return images;
         } catch (Exception e) {
             throw new ParsingException("Failed to extract playlist thumbnail url", e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 
@@ -28,13 +30,13 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         // Over-engineering at its finest
         if (itemObject.isString(ARTWORK_URL_KEY)) {
             final String artworkUrl = itemObject.getString(ARTWORK_URL_KEY, "");
             if (!artworkUrl.isEmpty()) {
                 String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                return artworkUrlBetterResolution;
+                return new Image(artworkUrlBetterResolution, -1, -1);
             }
         }
 
@@ -48,14 +50,14 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                     String artworkUrl = trackObject.getString(ARTWORK_URL_KEY, "");
                     if (!artworkUrl.isEmpty()) {
                         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                        return artworkUrlBetterResolution;
+                        return new Image(artworkUrlBetterResolution, -1, -1);
                     }
                 }
 
                 // Then look for track creator avatar url
                 final JsonObject creator = trackObject.getObject(USER_KEY, new JsonObject());
                 final String creatorAvatar = creator.getString(AVATAR_URL_KEY, "");
-                if (!creatorAvatar.isEmpty()) return creatorAvatar;
+                if (!creatorAvatar.isEmpty()) return new Image(creatorAvatar, -1, -1);
             }
         } catch (Exception ignored) {
             // Try other method
@@ -63,7 +65,7 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
 
         try {
             // Last resort, use user avatar url. If still not found, then throw exception.
-            return itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, "");
+            return new Image(itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, ""), -1, -1);
         } catch (Exception e) {
             throw new ParsingException("Failed to extract playlist thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
@@ -6,6 +6,9 @@ import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtractor {
@@ -30,13 +33,16 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
+        List<Image> images = new ArrayList<>();
+
         // Over-engineering at its finest
         if (itemObject.isString(ARTWORK_URL_KEY)) {
             final String artworkUrl = itemObject.getString(ARTWORK_URL_KEY, "");
             if (!artworkUrl.isEmpty()) {
                 String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                return new Image(artworkUrlBetterResolution, -1, -1);
+                images.add(new Image(artworkUrlBetterResolution, -1, -1));
+                return images;
             }
         }
 
@@ -50,14 +56,18 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                     String artworkUrl = trackObject.getString(ARTWORK_URL_KEY, "");
                     if (!artworkUrl.isEmpty()) {
                         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-                        return new Image(artworkUrlBetterResolution, -1, -1);
+                        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+                        return images;
                     }
                 }
 
                 // Then look for track creator avatar url
                 final JsonObject creator = trackObject.getObject(USER_KEY, new JsonObject());
                 final String creatorAvatar = creator.getString(AVATAR_URL_KEY, "");
-                if (!creatorAvatar.isEmpty()) return new Image(creatorAvatar, -1, -1);
+                if (!creatorAvatar.isEmpty()) {
+                    images.add(new Image(creatorAvatar, -1, -1));
+                    return images;
+                }
             }
         } catch (Exception ignored) {
             // Try other method
@@ -65,7 +75,8 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
 
         try {
             // Last resort, use user avatar url. If still not found, then throw exception.
-            return new Image(itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, ""), -1, -1);
+            images.add(new Image(itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, ""), -1, -1));
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Failed to extract playlist thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistInfoItemExtractor.java
@@ -40,7 +40,8 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
         if (itemObject.isString(ARTWORK_URL_KEY)) {
             final String artworkUrl = itemObject.getString(ARTWORK_URL_KEY, "");
             if (!artworkUrl.isEmpty()) {
-                images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+                images.add(new Image(artworkUrl, Image.MEDIUM, Image.MEDIUM));
+                images.add(new Image(artworkUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
                 images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
                 return images;
@@ -56,7 +57,8 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                 if (trackObject.isString(ARTWORK_URL_KEY)) {
                     String artworkUrl = trackObject.getString(ARTWORK_URL_KEY, "");
                     if (!artworkUrl.isEmpty()) {
-                        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+                        images.add(new Image(artworkUrl, Image.MEDIUM, Image.MEDIUM));
+                        images.add(new Image(artworkUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
                         images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
                         return images;
@@ -67,7 +69,8 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
                 final JsonObject creator = trackObject.getObject(USER_KEY, new JsonObject());
                 final String creatorAvatar = creator.getString(AVATAR_URL_KEY, "");
                 if (!creatorAvatar.isEmpty()) {
-                    images.add(new Image(creatorAvatar, Image.LOW, Image.LOW));
+                    images.add(new Image(creatorAvatar, Image.MEDIUM, Image.MEDIUM));
+                    images.add(new Image(creatorAvatar.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
                     images.add(new Image(creatorAvatar.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
                     return images;
@@ -81,7 +84,8 @@ public class SoundcloudPlaylistInfoItemExtractor implements PlaylistInfoItemExtr
             // Last resort, use user avatar url. If still not found, then throw exception.
             final String creatorAvatar = itemObject.getObject(USER_KEY).getString(AVATAR_URL_KEY, "");
 
-            images.add(new Image(creatorAvatar, Image.LOW, Image.LOW));
+            images.add(new Image(creatorAvatar, Image.MEDIUM, Image.MEDIUM));
+            images.add(new Image(creatorAvatar.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
             images.add(new Image(creatorAvatar.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
             return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -15,9 +15,15 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
-import org.schabi.newpipe.extractor.stream.*;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.Description;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.SubtitlesStream;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -25,6 +31,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+
+import javax.annotation.Nonnull;
 
 public class SoundcloudStreamExtractor extends StreamExtractor {
     private JsonObject track;
@@ -77,7 +85,8 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
             artworkUrl = track.getObject("user").getString("avatar_url", "");
         }
 
-        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(artworkUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;
@@ -137,7 +146,8 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
         String avatarUrl = SoundcloudParsingHelper.getAvatarUrl(track);
 
-        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(avatarUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -67,13 +69,13 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getThumbnailUrl() {
+    public Image getThumbnail() {
         String artworkUrl = track.getString("artwork_url", "");
         if (artworkUrl.isEmpty()) {
             artworkUrl = track.getObject("user").getString("avatar_url", "");
         }
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return artworkUrlBetterResolution;
+        return new Image(artworkUrlBetterResolution, -1, -1);
     }
 
     @Override
@@ -125,8 +127,8 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getUploaderAvatarUrl() {
-        return SoundcloudParsingHelper.getAvatarUrl(track);
+    public Image getUploaderAvatar() {
+        return new Image(SoundcloudParsingHelper.getAvatarUrl(track), -1, -1);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -69,13 +69,18 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getThumbnail() {
+    public List<Image> getThumbnails() {
+        List<Image> images = new ArrayList<>();
+
         String artworkUrl = track.getString("artwork_url", "");
         if (artworkUrl.isEmpty()) {
             artworkUrl = track.getObject("user").getString("avatar_url", "");
         }
+
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return new Image(artworkUrlBetterResolution, -1, -1);
+        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+
+        return images;
     }
 
     @Override
@@ -127,8 +132,10 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getUploaderAvatar() {
-        return new Image(SoundcloudParsingHelper.getAvatarUrl(track), -1, -1);
+    public List<Image> getUploaderAvatars() {
+        List<Image> images = new ArrayList<>();
+        images.add(new Image(SoundcloudParsingHelper.getAvatarUrl(track), -1, -1));
+        return images;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -77,8 +77,8 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
             artworkUrl = track.getObject("user").getString("avatar_url", "");
         }
 
-        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;
     }
@@ -134,7 +134,12 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
     @Override
     public List<Image> getUploaderAvatars() {
         List<Image> images = new ArrayList<>();
-        images.add(new Image(SoundcloudParsingHelper.getAvatarUrl(track), -1, -1));
+
+        String avatarUrl = SoundcloudParsingHelper.getAvatarUrl(track);
+
+        images.add(new Image(avatarUrl, Image.LOW, Image.LOW));
+        images.add(new Image(avatarUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
+
         return images;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -74,8 +74,8 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
             artworkUrl = itemObject.getObject("user").getString("avatar_url");
         }
 
-        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -8,6 +8,9 @@ import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtractor {
@@ -63,13 +66,18 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
     }
 
     @Override
-    public Image getThumbnail() {
+    public List<Image> getThumbnails() {
+        List<Image> images = new ArrayList<>();
+
         String artworkUrl = itemObject.getString("artwork_url", "");
         if (artworkUrl.isEmpty()) {
             artworkUrl = itemObject.getObject("user").getString("avatar_url");
         }
+
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return new Image(artworkUrlBetterResolution, -1, -1);
+        images.add(new Image(artworkUrlBetterResolution, -1, -1));
+
+        return images;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -74,7 +74,8 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
             artworkUrl = itemObject.getObject("user").getString("avatar_url");
         }
 
-        images.add(new Image(artworkUrl, Image.LOW, Image.LOW));
+        images.add(new Image(artworkUrl, Image.MEDIUM, Image.MEDIUM));
+        images.add(new Image(artworkUrl.replace("large.jpg", "small.jpg"), Image.LOW, Image.LOW));
         images.add(new Image(artworkUrl.replace("large.jpg", "crop.jpg"), Image.HIGH, Image.HIGH));
 
         return images;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
@@ -61,13 +63,13 @@ public class SoundcloudStreamInfoItemExtractor implements StreamInfoItemExtracto
     }
 
     @Override
-    public String getThumbnailUrl() {
+    public Image getThumbnail() {
         String artworkUrl = itemObject.getString("artwork_url", "");
         if (artworkUrl.isEmpty()) {
             artworkUrl = itemObject.getObject("user").getString("avatar_url");
         }
         String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return artworkUrlBetterResolution;
+        return new Image(artworkUrlBetterResolution, -1, -1);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -18,6 +18,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -103,33 +105,43 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public Image getAvatar() throws ParsingException {
+    public List<Image> getAvatars() throws ParsingException {
         try {
-            JsonObject thumbnail = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("avatar")
-                    .getArray("thumbnails").getObject(0);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = initialData.getObject("header").getObject("c4TabbedHeaderRenderer")
+                    .getObject("avatar").getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get avatar", e);
         }
     }
 
     @Override
-    public Image getBanner() throws ParsingException {
+    public List<Image> getBanners() throws ParsingException {
         try {
-            JsonObject thumbnail = null;
-            try {
-                thumbnail = initialData.getObject("header").getObject("c4TabbedHeaderRenderer")
-                        .getObject("banner").getArray("thumbnails").getObject(0);
-            } catch (Exception ignored) {}
-            if (thumbnail == null || thumbnail.getString("url").contains("s.ytimg.com")
-                    || thumbnail.getString("url").contains("default_banner")) {
-                return null;
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = initialData.getObject("header").getObject("c4TabbedHeaderRenderer")
+                    .getObject("avatar").getArray("thumbnails");
+
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+
+                if (thumbnail.getString("url").contains("s.ytimg.com")
+                        || thumbnail.getString("url").contains("default_banner"))
+                    return null;
+
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
             }
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get banner", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -102,30 +103,33 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
     }
 
     @Override
-    public String getAvatarUrl() throws ParsingException {
+    public Image getAvatar() throws ParsingException {
         try {
-            String url = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("avatar")
-                    .getArray("thumbnails").getObject(0).getString("url");
+            JsonObject thumbnail = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("avatar")
+                    .getArray("thumbnails").getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get avatar", e);
         }
     }
 
     @Override
-    public String getBannerUrl() throws ParsingException {
+    public Image getBanner() throws ParsingException {
         try {
-            String url = null;
+            JsonObject thumbnail = null;
             try {
-                url = initialData.getObject("header").getObject("c4TabbedHeaderRenderer").getObject("banner")
-                        .getArray("thumbnails").getObject(0).getString("url");
+                thumbnail = initialData.getObject("header").getObject("c4TabbedHeaderRenderer")
+                        .getObject("banner").getArray("thumbnails").getObject(0);
             } catch (Exception ignored) {}
-            if (url == null || url.contains("s.ytimg.com") || url.contains("default_banner")) {
+            if (thumbnail == null || thumbnail.getString("url").contains("s.ytimg.com")
+                    || thumbnail.getString("url").contains("default_banner")) {
                 return null;
             }
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get banner", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
 import org.schabi.newpipe.extractor.Image;
@@ -7,6 +8,9 @@ import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
@@ -39,12 +43,18 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
         try {
-            JsonObject thumbnail = channelInfoItem.getObject("thumbnail").getArray("thumbnails").getObject(0);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = channelInfoItem.getObject("thumbnail").getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonObject;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
@@ -38,11 +39,12 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         try {
-            String url = channelInfoItem.getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
+            JsonObject thumbnail = channelInfoItem.getObject("thumbnail").getArray("thumbnails").getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
+import org.omg.PortableServer.LIFESPAN_POLICY_ID;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -10,6 +11,9 @@ import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -33,13 +37,18 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
         try {
-            JsonObject thumbnail = json.getObject("authorThumbnail").getArray("thumbnails")
-                    .getObject(2);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = json.getObject("authorThumbnail").getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }
@@ -104,10 +113,18 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     }
 
     @Override
-    public String getAuthorThumbnail() throws ParsingException {
+    public List<Image> getAuthorThumbnails() throws ParsingException {
         try {
-            JsonArray arr = JsonUtils.getArray(json, "authorThumbnail.thumbnails");
-            return JsonUtils.getString(arr.getObject(2), "url");
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = JsonUtils.getArray(json, "authorThumbnail.thumbnails");
+
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get author thumbnail", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -10,6 +12,8 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
+
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 
 public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtractor {
 
@@ -29,10 +33,13 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         try {
-            JsonArray arr = JsonUtils.getArray(json, "authorThumbnail.thumbnails");
-            return JsonUtils.getString(arr.getObject(2), "url");
+            JsonObject thumbnail = json.getObject("authorThumbnail").getArray("thumbnails")
+                    .getObject(2);
+
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
-import org.omg.PortableServer.LIFESPAN_POLICY_ID;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import org.jsoup.nodes.Element;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
@@ -88,7 +89,7 @@ public class YoutubeFeedInfoItemExtractor implements StreamInfoItemExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() {
-        return entryElement.getElementsByTag("media:thumbnail").first().attr("url");
+    public Image getThumbnail() {
+        return new Image(entryElement.getElementsByTag("media:thumbnail").first().attr("url"), -1, -1);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
@@ -1,5 +1,8 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+
 import org.jsoup.nodes.Element;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -10,9 +13,13 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
+
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 
 public class YoutubeFeedInfoItemExtractor implements StreamInfoItemExtractor {
     private final Element entryElement;
@@ -89,7 +96,14 @@ public class YoutubeFeedInfoItemExtractor implements StreamInfoItemExtractor {
     }
 
     @Override
-    public Image getThumbnail() {
-        return new Image(entryElement.getElementsByTag("media:thumbnail").first().attr("url"), -1, -1);
+    public List<Image> getThumbnails() {
+        List<Image> images = new ArrayList<>();
+        Element thumbnail = entryElement.getElementsByTag("media:thumbnail").first();
+
+        images.add(new Image(fixThumbnailUrl(thumbnail.attr("url")),
+                Integer.parseInt(thumbnail.attr("width")),
+                Integer.parseInt(thumbnail.attr("height"))));
+
+        return images;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -101,29 +102,30 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
-        String url = null;
+    public Image getThumbnail() throws ParsingException {
+        JsonObject thumbnail = null;
 
         try {
-            url = playlistInfo.getObject("thumbnailRenderer").getObject("playlistVideoThumbnailRenderer")
-                    .getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
+            thumbnail = playlistInfo.getObject("thumbnailRenderer").getObject("playlistVideoThumbnailRenderer")
+                    .getObject("thumbnail").getArray("thumbnails").getObject(0);
         } catch (Exception ignored) {}
 
-        if (url == null) {
+        if (thumbnail == null) {
             try {
-                url = initialData.getObject("microformat").getObject("microformatDataRenderer").getObject("thumbnail")
-                        .getArray("thumbnails").getObject(0).getString("url");
+                thumbnail = initialData.getObject("microformat").getObject("microformatDataRenderer")
+                        .getObject("thumbnail").getArray("thumbnails").getObject(0);
             } catch (Exception ignored) {}
 
-            if (url == null) throw new ParsingException("Could not get playlist thumbnail");
+            if (thumbnail == null) throw new ParsingException("Could not get playlist thumbnail");
         }
 
-        return fixThumbnailUrl(url);
+        return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                thumbnail.getInt("width"), thumbnail.getInt("height"));
     }
 
     @Override
-    public String getBannerUrl() {
-        return "";      // Banner can't be handled by frontend right now.
+    public Image getBanner() {
+        return null;      // Banner can't be handled by frontend right now.
         // Whoever is willing to implement this should also implement it in the frontend.
     }
 
@@ -146,11 +148,12 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getUploaderAvatarUrl() throws ParsingException {
+    public Image getUploaderAvatar() throws ParsingException {
         try {
-            String url = getUploaderInfo().getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
+            JsonObject thumbnail = getUploaderInfo().getObject("thumbnail").getArray("thumbnails").getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get playlist uploader avatar", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
 import org.schabi.newpipe.extractor.Image;
@@ -7,6 +8,9 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.fixThumbnailUrl;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeParsingHelper.getTextFromObject;
@@ -19,13 +23,19 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
         try {
-            JsonObject thumbnail = playlistInfoItem.getArray("thumbnails").getObject(0)
-                    .getArray("thumbnails").getObject(0);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = playlistInfoItem.getArray("thumbnails").getObject(0)
+                    .getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistInfoItemExtractor.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonObject;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
@@ -18,12 +19,13 @@ public class YoutubePlaylistInfoItemExtractor implements PlaylistInfoItemExtract
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         try {
-            String url = playlistInfoItem.getArray("thumbnails").getObject(0)
-                    .getArray("thumbnails").getObject(0).getString("url");
+            JsonObject thumbnail = playlistInfoItem.getArray("thumbnails").getObject(0)
+                    .getArray("thumbnails").getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -7,6 +7,7 @@ import com.grack.nanojson.JsonParser;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -189,14 +190,15 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         assertPageFetched();
         try {
             JsonArray thumbnails = playerResponse.getObject("videoDetails").getObject("thumbnail").getArray("thumbnails");
             // the last thumbnail is the one with the highest resolution
-            String url = thumbnails.getObject(thumbnails.size() - 1).getString("url");
+            JsonObject thumbnail = thumbnails.getObject(thumbnails.size() - 1);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url");
         }
@@ -369,13 +371,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getUploaderAvatarUrl() throws ParsingException {
+    public Image getUploaderAvatar() throws ParsingException {
         assertPageFetched();
         try {
-            String url = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
-                    .getObject("thumbnail").getArray("thumbnails").getObject(0).getString("url");
+            JsonObject thumbnail = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
+                    .getObject("thumbnail").getArray("thumbnails").getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get uploader avatar url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -190,15 +190,19 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
         assertPageFetched();
         try {
+            List<Image> images = new ArrayList<>();
             JsonArray thumbnails = playerResponse.getObject("videoDetails").getObject("thumbnail").getArray("thumbnails");
-            // the last thumbnail is the one with the highest resolution
-            JsonObject thumbnail = thumbnails.getObject(thumbnails.size() - 1);
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url");
         }
@@ -371,14 +375,20 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public Image getUploaderAvatar() throws ParsingException {
+    public List<Image> getUploaderAvatars() throws ParsingException {
         assertPageFetched();
         try {
-            JsonObject thumbnail = getVideoSecondaryInfoRenderer().getObject("owner").getObject("videoOwnerRenderer")
-                    .getObject("thumbnail").getArray("thumbnails").getObject(0);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = getVideoSecondaryInfoRenderer().getObject("owner")
+                    .getObject("videoOwnerRenderer").getObject("thumbnail").getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get uploader avatar url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
@@ -239,13 +241,14 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     }
 
     @Override
-    public String getThumbnailUrl() throws ParsingException {
+    public Image getThumbnail() throws ParsingException {
         try {
             // TODO: Don't simply get the first item, but look at all thumbnails and their resolution
-            String url = videoInfo.getObject("thumbnail").getArray("thumbnails")
-                    .getObject(0).getString("url");
+            JsonObject thumbnail = videoInfo.getObject("thumbnail").getArray("thumbnails")
+                    .getObject(0);
 
-            return fixThumbnailUrl(url);
+            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                    thumbnail.getInt("width"), thumbnail.getInt("height"));
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -13,6 +13,9 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nullable;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -241,14 +244,18 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
     }
 
     @Override
-    public Image getThumbnail() throws ParsingException {
+    public List<Image> getThumbnails() throws ParsingException {
         try {
-            // TODO: Don't simply get the first item, but look at all thumbnails and their resolution
-            JsonObject thumbnail = videoInfo.getObject("thumbnail").getArray("thumbnails")
-                    .getObject(0);
+            List<Image> images = new ArrayList<>();
+            JsonArray thumbnails = videoInfo.getObject("thumbnail").getArray("thumbnails");
 
-            return new Image(fixThumbnailUrl(thumbnail.getString("url")),
-                    thumbnail.getInt("width"), thumbnail.getInt("height"));
+            for (Object thumbnailObject : thumbnails) {
+                final JsonObject thumbnail = (JsonObject) thumbnailObject;
+                images.add(new Image(fixThumbnailUrl(thumbnail.getString("url")),
+                        thumbnail.getInt("width"), thumbnail.getInt("height")));
+            }
+
+            return images;
         } catch (Exception e) {
             throw new ParsingException("Could not get thumbnail url", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -78,11 +78,11 @@ public abstract class StreamExtractor extends Extractor {
     /**
      * This will return the url to the thumbnail of the stream. Try to return the medium resolution here.
      *
-     * @return An {@code Image} instance with the URL of the thumbnail.
+     * @return A {@code List} of {@code Image} instances with the URL of the thumbnail.
      * @throws ParsingException
      */
     @Nonnull
-    public abstract Image getThumbnail() throws ParsingException;
+    public abstract List<Image> getThumbnails() throws ParsingException;
 
     /**
      * This is the stream description.
@@ -173,11 +173,11 @@ public abstract class StreamExtractor extends Extractor {
      * The url to the image file/profile picture/avatar of the creator/uploader of the stream.
      * If the url is not available you can return an empty String.
      *
-     * @return An {@code Image} instance with the URL of the image file of the uploader
+     * @return A {@code List} of {@code Image} instances with the URL of the image file of the uploader
      * @throws ParsingException
      */
     @Nonnull
-    public abstract Image getUploaderAvatar() throws ParsingException;
+    public abstract List<Image> getUploaderAvatars() throws ParsingException;
 
     /**
      * Get the dash mpd url. If you don't know what a dash MPD is you can read about it

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -21,6 +21,7 @@ package org.schabi.newpipe.extractor.stream;
  */
 
 import org.schabi.newpipe.extractor.Extractor;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -77,11 +78,11 @@ public abstract class StreamExtractor extends Extractor {
     /**
      * This will return the url to the thumbnail of the stream. Try to return the medium resolution here.
      *
-     * @return The url of the thumbnail.
+     * @return An {@code Image} instance with the URL of the thumbnail.
      * @throws ParsingException
      */
     @Nonnull
-    public abstract String getThumbnailUrl() throws ParsingException;
+    public abstract Image getThumbnail() throws ParsingException;
 
     /**
      * This is the stream description.
@@ -172,11 +173,11 @@ public abstract class StreamExtractor extends Extractor {
      * The url to the image file/profile picture/avatar of the creator/uploader of the stream.
      * If the url is not available you can return an empty String.
      *
-     * @return The url of the image file of the uploader or an empty String
+     * @return An {@code Image} instance with the URL of the image file of the uploader
      * @throws ParsingException
      */
     @Nonnull
-    public abstract String getUploaderAvatarUrl() throws ParsingException;
+    public abstract Image getUploaderAvatar() throws ParsingException;
 
     /**
      * Get the dash mpd url. If you don't know what a dash MPD is you can read about it

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.stream;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.Info;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -201,7 +202,7 @@ public class StreamInfo extends Info {
         // so the frontend can afterwards check where errors happened.
 
         try {
-            streamInfo.setThumbnailUrl(extractor.getThumbnailUrl());
+            streamInfo.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             streamInfo.addError(e);
         }
@@ -241,7 +242,7 @@ public class StreamInfo extends Info {
             streamInfo.addError(e);
         }
         try {
-            streamInfo.setUploaderAvatarUrl(extractor.getUploaderAvatarUrl());
+            streamInfo.setUploaderAvatar(extractor.getUploaderAvatar());
         } catch (Exception e) {
             streamInfo.addError(e);
         }
@@ -314,7 +315,7 @@ public class StreamInfo extends Info {
     }
 
     private StreamType streamType;
-    private String thumbnailUrl = "";
+    private Image thumbnail = null;
     private String textualUploadDate;
     private DateWrapper uploadDate;
     private long duration = -1;
@@ -327,7 +328,7 @@ public class StreamInfo extends Info {
 
     private String uploaderName = "";
     private String uploaderUrl = "";
-    private String uploaderAvatarUrl = "";
+    private Image uploaderAvatar = null;
 
     private List<VideoStream> videoStreams = new ArrayList<>();
     private List<AudioStream> audioStreams = new ArrayList<>();
@@ -370,14 +371,14 @@ public class StreamInfo extends Info {
     /**
      * Get the thumbnail url
      *
-     * @return the thumbnail url as a string
+     * @return An {@code Image} instance with the thumbnail URL
      */
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
+    public Image getThumbnail() {
+        return thumbnail;
     }
 
-    public void setThumbnailUrl(String thumbnailUrl) {
-        this.thumbnailUrl = thumbnailUrl;
+    public void setThumbnail(Image thumbnail) {
+        this.thumbnail = thumbnail;
     }
 
     public String getTextualUploadDate() {
@@ -475,12 +476,12 @@ public class StreamInfo extends Info {
         this.uploaderUrl = uploaderUrl;
     }
 
-    public String getUploaderAvatarUrl() {
-        return uploaderAvatarUrl;
+    public Image getUploaderAvatar() {
+        return uploaderAvatar;
     }
 
-    public void setUploaderAvatarUrl(String uploaderAvatarUrl) {
-        this.uploaderAvatarUrl = uploaderAvatarUrl;
+    public void setUploaderAvatar(Image uploaderAvatar) {
+        this.uploaderAvatar = uploaderAvatar;
     }
 
     public List<VideoStream> getVideoStreams() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -202,7 +202,7 @@ public class StreamInfo extends Info {
         // so the frontend can afterwards check where errors happened.
 
         try {
-            streamInfo.setThumbnail(extractor.getThumbnail());
+            streamInfo.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             streamInfo.addError(e);
         }
@@ -242,7 +242,7 @@ public class StreamInfo extends Info {
             streamInfo.addError(e);
         }
         try {
-            streamInfo.setUploaderAvatar(extractor.getUploaderAvatar());
+            streamInfo.setUploaderAvatars(extractor.getUploaderAvatars());
         } catch (Exception e) {
             streamInfo.addError(e);
         }
@@ -315,7 +315,7 @@ public class StreamInfo extends Info {
     }
 
     private StreamType streamType;
-    private Image thumbnail = null;
+    private List<Image> thumbnails = null;
     private String textualUploadDate;
     private DateWrapper uploadDate;
     private long duration = -1;
@@ -328,7 +328,7 @@ public class StreamInfo extends Info {
 
     private String uploaderName = "";
     private String uploaderUrl = "";
-    private Image uploaderAvatar = null;
+    private List<Image> uploaderAvatars = null;
 
     private List<VideoStream> videoStreams = new ArrayList<>();
     private List<AudioStream> audioStreams = new ArrayList<>();
@@ -371,14 +371,14 @@ public class StreamInfo extends Info {
     /**
      * Get the thumbnail url
      *
-     * @return An {@code Image} instance with the thumbnail URL
+     * @return A {@code List} of {@code Image} instances with the thumbnail URL
      */
-    public Image getThumbnail() {
-        return thumbnail;
+    public List<Image> getThumbnails() {
+        return thumbnails;
     }
 
-    public void setThumbnail(Image thumbnail) {
-        this.thumbnail = thumbnail;
+    public void setThumbnails(List<Image> thumbnails) {
+        this.thumbnails = thumbnails;
     }
 
     public String getTextualUploadDate() {
@@ -476,12 +476,12 @@ public class StreamInfo extends Info {
         this.uploaderUrl = uploaderUrl;
     }
 
-    public Image getUploaderAvatar() {
-        return uploaderAvatar;
+    public List<Image> getUploaderAvatars() {
+        return uploaderAvatars;
     }
 
-    public void setUploaderAvatar(Image uploaderAvatar) {
-        this.uploaderAvatar = uploaderAvatar;
+    public void setUploaderAvatars(List<Image> uploaderAvatars) {
+        this.uploaderAvatars = uploaderAvatars;
     }
 
     public List<VideoStream> getVideoStreams() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
@@ -111,7 +111,6 @@ public class StreamInfoItem extends InfoItem {
                 ", serviceId=" + getServiceId() +
                 ", url='" + getUrl() + '\'' +
                 ", name='" + getName() + '\'' +
-                ", thumbnailUrl='" + getThumbnail().getUrl() + '\'' +
                 '}';
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
@@ -111,7 +111,7 @@ public class StreamInfoItem extends InfoItem {
                 ", serviceId=" + getServiceId() +
                 ", url='" + getUrl() + '\'' +
                 ", name='" + getName() + '\'' +
-                ", thumbnailUrl='" + getThumbnailUrl() + '\'' +
+                ", thumbnailUrl='" + getThumbnail().getUrl() + '\'' +
                 '}';
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
@@ -76,7 +76,7 @@ public class StreamInfoItemsCollector extends InfoItemsCollector<StreamInfoItem,
             addError(e);
         }
         try {
-            resultItem.setThumbnail(extractor.getThumbnail());
+            resultItem.setThumbnails(extractor.getThumbnails());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
@@ -76,7 +76,7 @@ public class StreamInfoItemsCollector extends InfoItemsCollector<StreamInfoItem,
             addError(e);
         }
         try {
-            resultItem.setThumbnailUrl(extractor.getThumbnailUrl());
+            resultItem.setThumbnail(extractor.getThumbnail());
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseChannelExtractorTest.java
@@ -3,8 +3,8 @@ package org.schabi.newpipe.extractor.services;
 @SuppressWarnings("unused")
 public interface BaseChannelExtractorTest extends BaseListExtractorTest {
     void testDescription() throws Exception;
-    void testAvatar() throws Exception;
-    void testBanner() throws Exception;
+    void testAvatars() throws Exception;
+    void testBanners() throws Exception;
     void testFeedUrl() throws Exception;
     void testSubscriberCount() throws Exception;
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseChannelExtractorTest.java
@@ -3,8 +3,8 @@ package org.schabi.newpipe.extractor.services;
 @SuppressWarnings("unused")
 public interface BaseChannelExtractorTest extends BaseListExtractorTest {
     void testDescription() throws Exception;
-    void testAvatarUrl() throws Exception;
-    void testBannerUrl() throws Exception;
+    void testAvatar() throws Exception;
+    void testBanner() throws Exception;
     void testFeedUrl() throws Exception;
     void testSubscriberCount() throws Exception;
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BasePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BasePlaylistExtractorTest.java
@@ -2,9 +2,9 @@ package org.schabi.newpipe.extractor.services;
 
 @SuppressWarnings("unused")
 public interface BasePlaylistExtractorTest extends BaseListExtractorTest {
-    void testThumbnailUrl() throws Exception;
-    void testBannerUrl() throws Exception;
+    void testThumbnail() throws Exception;
+    void testBanner() throws Exception;
     void testUploaderName() throws Exception;
-    void testUploaderAvatarUrl() throws Exception;
+    void testUploaderAvatar() throws Exception;
     void testStreamCount() throws Exception;
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BasePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BasePlaylistExtractorTest.java
@@ -2,9 +2,9 @@ package org.schabi.newpipe.extractor.services;
 
 @SuppressWarnings("unused")
 public interface BasePlaylistExtractorTest extends BaseListExtractorTest {
-    void testThumbnail() throws Exception;
-    void testBanner() throws Exception;
+    void testThumbnails() throws Exception;
+    void testBanners() throws Exception;
     void testUploaderName() throws Exception;
-    void testUploaderAvatar() throws Exception;
+    void testUploaderAvatars() throws Exception;
     void testStreamCount() throws Exception;
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
@@ -28,8 +28,8 @@ public final class DefaultTests {
 
         for (InfoItem item : itemsList) {
             assertIsSecureUrl(item.getUrl());
-            if (item.getThumbnailUrl() != null && !item.getThumbnailUrl().isEmpty()) {
-                assertIsSecureUrl(item.getThumbnailUrl());
+            if (item.getThumbnail() != null && !item.getThumbnail().getUrl().isEmpty()) {
+                assertIsSecureUrl(item.getThumbnail().getUrl());
             }
             assertNotNull("InfoItem type not set: " + item, item.getInfoType());
             assertEquals("Unexpected item service id", expectedService.getServiceId(), item.getServiceId());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
@@ -1,13 +1,11 @@
 package org.schabi.newpipe.extractor.services;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
-import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -16,9 +14,14 @@ import java.util.Calendar;
 import java.util.List;
 
 import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.*;
-import static org.schabi.newpipe.extractor.ExtractorAsserts.*;
-import static org.schabi.newpipe.extractor.StreamingService.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmptyErrors;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertNotEmpty;
+import static org.schabi.newpipe.extractor.StreamingService.LinkType;
 
 public final class DefaultTests {
     public static void defaultTestListOfItems(StreamingService expectedService, List<? extends InfoItem> itemsList, List<Throwable> errors) throws ParsingException {
@@ -28,8 +31,10 @@ public final class DefaultTests {
 
         for (InfoItem item : itemsList) {
             assertIsSecureUrl(item.getUrl());
-            if (item.getThumbnails() != null && !item.getThumbnails().get(0).getUrl().isEmpty()) {
-                assertIsSecureUrl(item.getThumbnails().get(0).getUrl());
+            if (item.getThumbnails() != null) {
+                for (Image image : item.getThumbnails()) {
+                    assertIsSecureUrl(image.getUrl());
+                }
             }
             assertNotNull("InfoItem type not set: " + item, item.getInfoType());
             assertEquals("Unexpected item service id", expectedService.getServiceId(), item.getServiceId());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultTests.java
@@ -28,8 +28,8 @@ public final class DefaultTests {
 
         for (InfoItem item : itemsList) {
             assertIsSecureUrl(item.getUrl());
-            if (item.getThumbnail() != null && !item.getThumbnail().getUrl().isEmpty()) {
-                assertIsSecureUrl(item.getThumbnail().getUrl());
+            if (item.getThumbnails() != null && !item.getThumbnails().get(0).getUrl().isEmpty()) {
+                assertIsSecureUrl(item.getThumbnails().get(0).getUrl());
             }
             assertNotNull("InfoItem type not set: " + item, item.getInfoType());
             assertEquals("Unexpected item service id", expectedService.getServiceId(), item.getServiceId());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCConferenceExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCConferenceExtractorTest.java
@@ -39,8 +39,8 @@ public class MediaCCCConferenceExtractorTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/froscon/2017/logo.png", extractor.getAvatarUrl());
+    public void testGetThumbnail() throws Exception {
+        assertEquals("https://static.media.ccc.de/media/events/froscon/2017/logo.png", extractor.getAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCConferenceExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCConferenceExtractorTest.java
@@ -39,8 +39,8 @@ public class MediaCCCConferenceExtractorTest {
     }
 
     @Test
-    public void testGetThumbnail() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/froscon/2017/logo.png", extractor.getAvatar().getUrl());
+    public void testGetThumbnails() throws Exception {
+        assertEquals("https://static.media.ccc.de/media/events/froscon/2017/logo.png", extractor.getAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCSearchExtractorEventsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCSearchExtractorEventsTest.java
@@ -57,10 +57,10 @@ public class MediaCCCSearchExtractorEventsTest {
     }
 
     @Test
-    public void testThumbnailUrl() throws Exception {
-        assertTrue(itemsPage.getItems().get(0).getThumbnailUrl(),
-                itemsPage.getItems().get(0).getThumbnailUrl().startsWith("https://static.media.ccc.de/media/")
-                && itemsPage.getItems().get(0).getThumbnailUrl().endsWith(".jpg"));
+    public void testThumbnail() throws Exception {
+        assertTrue(itemsPage.getItems().get(0).getThumbnail().getUrl(),
+                itemsPage.getItems().get(0).getThumbnail().getUrl().startsWith("https://static.media.ccc.de/media/")
+                && itemsPage.getItems().get(0).getThumbnail().getUrl().endsWith(".jpg"));
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCSearchExtractorEventsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCSearchExtractorEventsTest.java
@@ -57,10 +57,10 @@ public class MediaCCCSearchExtractorEventsTest {
     }
 
     @Test
-    public void testThumbnail() throws Exception {
-        assertTrue(itemsPage.getItems().get(0).getThumbnail().getUrl(),
-                itemsPage.getItems().get(0).getThumbnail().getUrl().startsWith("https://static.media.ccc.de/media/")
-                && itemsPage.getItems().get(0).getThumbnail().getUrl().endsWith(".jpg"));
+    public void testThumbnails() throws Exception {
+        assertTrue(itemsPage.getItems().get(0).getThumbnails().get(0).getUrl(),
+                itemsPage.getItems().get(0).getThumbnails().get(0).getUrl().startsWith("https://static.media.ccc.de/media/")
+                && itemsPage.getItems().get(0).getThumbnails().get(0).getUrl().endsWith(".jpg"));
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
@@ -58,8 +58,8 @@ public class MediaCCCStreamExtractorTest implements BaseExtractorTest {
     }
 
     @Test
-    public void testThumbnail() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/105-hd.jpg", extractor.getThumbnail().getUrl());
+    public void testThumbnails() throws Exception {
+        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/105-hd.jpg", extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
@@ -73,8 +73,8 @@ public class MediaCCCStreamExtractorTest implements BaseExtractorTest {
     }
 
     @Test
-    public void testUploaderAvatar() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/logo.png", extractor.getUploaderAvatar().getUrl());
+    public void testUploaderAvatars() throws Exception {
+        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/logo.png", extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
@@ -59,7 +59,7 @@ public class MediaCCCStreamExtractorTest implements BaseExtractorTest {
 
     @Test
     public void testThumbnail() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/105-hd.jpg", extractor.getThumbnailUrl());
+        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/105-hd.jpg", extractor.getThumbnail().getUrl());
     }
 
     @Test
@@ -73,8 +73,8 @@ public class MediaCCCStreamExtractorTest implements BaseExtractorTest {
     }
 
     @Test
-    public void testUploaderAvatarUrl() throws Exception {
-        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/logo.png", extractor.getUploaderAvatarUrl());
+    public void testUploaderAvatar() throws Exception {
+        assertEquals("https://static.media.ccc.de/media/events/gpn/gpn18/logo.png", extractor.getUploaderAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
@@ -4,17 +4,22 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
 import org.schabi.newpipe.extractor.services.peertube.extractors.PeertubeChannelExtractor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmpty;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.PeerTube;
-import static org.schabi.newpipe.extractor.services.DefaultTests.*;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestGetPageInNewExtractor;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestMoreItems;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestRelatedItems;
 
 /**
  * Test for {@link PeertubeChannelExtractor}
@@ -87,13 +92,17 @@ public class PeertubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() throws ParsingException {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -184,13 +193,17 @@ public class PeertubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() throws ParsingException {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
@@ -86,14 +86,14 @@ public class PeertubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatarUrl());
+        public void testAvatar() throws ParsingException {
+            assertIsSecureUrl(extractor.getAvatar().getUrl());
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() throws ParsingException {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test
@@ -183,14 +183,14 @@ public class PeertubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatarUrl());
+        public void testAvatar() throws ParsingException {
+            assertIsSecureUrl(extractor.getAvatar().getUrl());
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() throws ParsingException {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
@@ -86,14 +86,14 @@ public class PeertubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatar().getUrl());
+        public void testAvatars() throws ParsingException {
+            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
         }
 
         @Ignore
         @Test
-        public void testBanner() throws ParsingException {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() throws ParsingException {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test
@@ -183,14 +183,14 @@ public class PeertubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws ParsingException {
-            assertIsSecureUrl(extractor.getAvatar().getUrl());
+        public void testAvatars() throws ParsingException {
+            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
         }
 
         @Ignore
         @Test
-        public void testBanner() throws ParsingException {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() throws ParsingException {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
@@ -4,6 +4,7 @@ import org.jsoup.helper.StringUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
@@ -66,12 +67,21 @@ public class PeertubeCommentsExtractorTest {
         for (CommentsInfoItem c : comments.getItems()) {
             assertFalse(StringUtil.isBlank(c.getAuthorEndpoint()));
             assertFalse(StringUtil.isBlank(c.getAuthorName()));
-            assertFalse(StringUtil.isBlank(c.getAuthorThumbnails().get(0).getUrl()));
+
+
+            for (Image image : c.getAuthorThumbnails()) {
+                assertFalse(StringUtil.isBlank(image.getUrl()));
+            }
+
             assertFalse(StringUtil.isBlank(c.getCommentId()));
             assertFalse(StringUtil.isBlank(c.getCommentText()));
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
-            assertFalse(StringUtil.isBlank(c.getThumbnails().get(0).getUrl()));
+
+            for (Image image : c.getThumbnails()) {
+                assertFalse(StringUtil.isBlank(image.getUrl()));
+            }
+
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() != -1);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
@@ -71,7 +71,7 @@ public class PeertubeCommentsExtractorTest {
             assertFalse(StringUtil.isBlank(c.getCommentText()));
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
-            assertFalse(StringUtil.isBlank(c.getThumbnailUrl()));
+            assertFalse(StringUtil.isBlank(c.getThumbnail().getUrl()));
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() != -1);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
@@ -66,12 +66,12 @@ public class PeertubeCommentsExtractorTest {
         for (CommentsInfoItem c : comments.getItems()) {
             assertFalse(StringUtil.isBlank(c.getAuthorEndpoint()));
             assertFalse(StringUtil.isBlank(c.getAuthorName()));
-            assertFalse(StringUtil.isBlank(c.getAuthorThumbnail()));
+            assertFalse(StringUtil.isBlank(c.getAuthorThumbnails().get(0).getUrl()));
             assertFalse(StringUtil.isBlank(c.getCommentId()));
             assertFalse(StringUtil.isBlank(c.getCommentText()));
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
-            assertFalse(StringUtil.isBlank(c.getThumbnail().getUrl()));
+            assertFalse(StringUtil.isBlank(c.getThumbnails().get(0).getUrl()));
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() != -1);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
@@ -105,13 +105,13 @@ public class PeertubeStreamExtractorDefaultTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
+    public void testGetThumbnail() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnail().getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+    public void testGetUploaderAvatar() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
@@ -105,13 +105,13 @@ public class PeertubeStreamExtractorDefaultTest {
     }
 
     @Test
-    public void testGetThumbnail() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnail().getUrl());
+    public void testGetThumbnails() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatar() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+    public void testGetUploaderAvatars() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -106,12 +107,16 @@ public class PeertubeStreamExtractorDefaultTest {
 
     @Test
     public void testGetThumbnails() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+        for (Image image : extractor.getThumbnails()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test
     public void testGetUploaderAvatars() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+        for (Image image : extractor.getUploaderAvatars()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -82,13 +82,13 @@ public class SoundcloudChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() {
-            assertIsSecureUrl(extractor.getAvatarUrl());
+        public void testAvatar() {
+            assertIsSecureUrl(extractor.getAvatar().getUrl());
         }
 
         @Test
-        public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test
@@ -176,13 +176,13 @@ public class SoundcloudChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() {
-            assertIsSecureUrl(extractor.getAvatarUrl());
+        public void testAvatar() {
+            assertIsSecureUrl(extractor.getAvatar().getUrl());
         }
 
         @Test
-        public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -83,12 +84,16 @@ public class SoundcloudChannelExtractorTest {
 
         @Test
         public void testAvatars() {
-            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
         public void testBanners() {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -177,12 +182,16 @@ public class SoundcloudChannelExtractorTest {
 
         @Test
         public void testAvatars() {
-            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
         public void testBanners() {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -82,13 +82,13 @@ public class SoundcloudChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() {
-            assertIsSecureUrl(extractor.getAvatar().getUrl());
+        public void testAvatars() {
+            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
         }
 
         @Test
-        public void testBanner() {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test
@@ -176,13 +176,13 @@ public class SoundcloudChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() {
-            assertIsSecureUrl(extractor.getAvatar().getUrl());
+        public void testAvatars() {
+            assertIsSecureUrl(extractor.getAvatars().get(0).getUrl());
         }
 
         @Test
-        public void testBanner() {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -85,14 +85,14 @@ public class SoundcloudPlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnailUrl() {
-            assertIsSecureUrl(extractor.getThumbnailUrl());
+        public void testThumbnail() {
+            assertIsSecureUrl(extractor.getThumbnail().getUrl());
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test
@@ -108,8 +108,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatarUrl() {
-            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        public void testUploaderAvatar() {
+            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
         }
 
         @Test
@@ -177,14 +177,14 @@ public class SoundcloudPlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnailUrl() {
-            assertIsSecureUrl(extractor.getThumbnailUrl());
+        public void testThumbnail() {
+            assertIsSecureUrl(extractor.getThumbnail().getUrl());
         }
 
         @Ignore("not implemented")
         @Test
-        public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test
@@ -200,8 +200,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatarUrl() {
-            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        public void testUploaderAvatar() {
+            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
         }
 
         @Test
@@ -288,14 +288,14 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Ignore
         @Test
-        public void testThumbnailUrl() {
-            assertIsSecureUrl(extractor.getThumbnailUrl());
+        public void testThumbnail() {
+            assertIsSecureUrl(extractor.getThumbnail().getUrl());
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+        public void testBanner() {
+            assertIsSecureUrl(extractor.getBanner().getUrl());
         }
 
         @Test
@@ -311,8 +311,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatarUrl() {
-            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        public void testUploaderAvatar() {
+            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -85,14 +85,14 @@ public class SoundcloudPlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnail() {
-            assertIsSecureUrl(extractor.getThumbnail().getUrl());
+        public void testThumbnails() {
+            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
         }
 
         @Ignore
         @Test
-        public void testBanner() {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test
@@ -108,8 +108,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatar() {
-            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+        public void testUploaderAvatars() {
+            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
         }
 
         @Test
@@ -177,14 +177,14 @@ public class SoundcloudPlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnail() {
-            assertIsSecureUrl(extractor.getThumbnail().getUrl());
+        public void testThumbnails() {
+            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
         }
 
         @Ignore("not implemented")
         @Test
-        public void testBanner() {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test
@@ -200,8 +200,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatar() {
-            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+        public void testUploaderAvatars() {
+            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
         }
 
         @Test
@@ -288,14 +288,14 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Ignore
         @Test
-        public void testThumbnail() {
-            assertIsSecureUrl(extractor.getThumbnail().getUrl());
+        public void testThumbnails() {
+            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
         }
 
         @Ignore
         @Test
-        public void testBanner() {
-            assertIsSecureUrl(extractor.getBanner().getUrl());
+        public void testBanners() {
+            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
         }
 
         @Test
@@ -311,8 +311,8 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatar() {
-            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+        public void testUploaderAvatars() {
+            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
@@ -86,13 +87,17 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testThumbnails() {
-            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -109,7 +114,9 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testUploaderAvatars() {
-            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -178,13 +185,17 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testThumbnails() {
-            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Ignore("not implemented")
         @Test
         public void testBanners() {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -201,7 +212,9 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testUploaderAvatars() {
-            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -289,13 +302,17 @@ public class SoundcloudPlaylistExtractorTest {
         @Ignore
         @Test
         public void testThumbnails() {
-            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() {
-            assertIsSecureUrl(extractor.getBanners().get(0).getUrl());
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
@@ -312,7 +329,9 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testUploaderAvatars() {
-            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -91,13 +91,13 @@ public class SoundcloudStreamExtractorDefaultTest {
     }
 
     @Test
-    public void testGetThumbnail() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnail().getUrl());
+    public void testGetThumbnails() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatar() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+    public void testGetUploaderAvatars() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -91,13 +91,13 @@ public class SoundcloudStreamExtractorDefaultTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
+    public void testGetThumbnail() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnail().getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+    public void testGetUploaderAvatar() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class SoundcloudStreamExtractorDefaultTest {
 
     @Test
     public void testStreamType() throws ParsingException {
-        assertTrue(extractor.getStreamType() == StreamType.AUDIO_STREAM);
+        assertSame(extractor.getStreamType(), StreamType.AUDIO_STREAM);
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -92,12 +93,16 @@ public class SoundcloudStreamExtractorDefaultTest {
 
     @Test
     public void testGetThumbnails() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+        for (Image image : extractor.getThumbnails()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test
     public void testGetUploaderAvatars() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+        for (Image image : extractor.getUploaderAvatars()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -105,15 +105,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -196,15 +196,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -300,15 +300,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -389,15 +389,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -479,15 +479,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -577,15 +577,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatarUrl() throws Exception {
-            String avatarUrl = extractor.getAvatarUrl();
+        public void testAvatar() throws Exception {
+            String avatarUrl = extractor.getAvatar().getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBannerUrl() throws Exception {
-            String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -105,15 +105,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -196,15 +196,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -300,15 +300,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -389,15 +389,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -479,15 +479,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }
@@ -577,15 +577,15 @@ public class YoutubeChannelExtractorTest {
         }
 
         @Test
-        public void testAvatar() throws Exception {
-            String avatarUrl = extractor.getAvatar().getUrl();
+        public void testAvatars() throws Exception {
+            String avatarUrl = extractor.getAvatars().get(0).getUrl();
             assertIsSecureUrl(avatarUrl);
             assertTrue(avatarUrl, avatarUrl.contains("yt3"));
         }
 
         @Test
-        public void testBanner() throws Exception {
-            String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt3"));
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
@@ -106,16 +107,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -197,16 +200,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -301,16 +306,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -390,16 +397,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -480,16 +489,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -578,16 +589,18 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testAvatars() throws Exception {
-            String avatarUrl = extractor.getAvatars().get(0).getUrl();
-            assertIsSecureUrl(avatarUrl);
-            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+            for (Image image : extractor.getAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
         public void testBanners() throws Exception {
-            String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt3"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -94,7 +94,7 @@ public class YoutubeCommentsExtractorTest {
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
             assertNotNull(c.getPublishedTime());
-            assertFalse(StringUtil.isBlank(c.getThumbnailUrl()));
+            assertFalse(StringUtil.isBlank(c.getThumbnail().getUrl()));
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() < 0);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -88,13 +88,13 @@ public class YoutubeCommentsExtractorTest {
         for (CommentsInfoItem c : comments.getItems()) {
             assertFalse(StringUtil.isBlank(c.getAuthorEndpoint()));
             assertFalse(StringUtil.isBlank(c.getAuthorName()));
-            assertFalse(StringUtil.isBlank(c.getAuthorThumbnail()));
+            assertFalse(StringUtil.isBlank(c.getAuthorThumbnails().get(0).getUrl()));
             assertFalse(StringUtil.isBlank(c.getCommentId()));
             assertFalse(StringUtil.isBlank(c.getCommentText()));
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
             assertNotNull(c.getPublishedTime());
-            assertFalse(StringUtil.isBlank(c.getThumbnail().getUrl()));
+            assertFalse(StringUtil.isBlank(c.getThumbnails().get(0).getUrl()));
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() < 0);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -4,6 +4,7 @@ import org.jsoup.helper.StringUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
@@ -88,13 +89,22 @@ public class YoutubeCommentsExtractorTest {
         for (CommentsInfoItem c : comments.getItems()) {
             assertFalse(StringUtil.isBlank(c.getAuthorEndpoint()));
             assertFalse(StringUtil.isBlank(c.getAuthorName()));
-            assertFalse(StringUtil.isBlank(c.getAuthorThumbnails().get(0).getUrl()));
+
+            for (Image image : c.getAuthorThumbnails()) {
+                assertFalse(StringUtil.isBlank(image.getUrl()));
+            }
+
+
             assertFalse(StringUtil.isBlank(c.getCommentId()));
             assertFalse(StringUtil.isBlank(c.getCommentText()));
             assertFalse(StringUtil.isBlank(c.getName()));
             assertFalse(StringUtil.isBlank(c.getTextualPublishedTime()));
             assertNotNull(c.getPublishedTime());
-            assertFalse(StringUtil.isBlank(c.getThumbnails().get(0).getUrl()));
+
+            for (Image image : c.getThumbnails()) {
+                assertFalse(StringUtil.isBlank(image.getUrl()));
+            }
+
             assertFalse(StringUtil.isBlank(c.getUrl()));
             assertFalse(c.getLikeCount() < 0);
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 
@@ -107,17 +108,19 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testThumbnails() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnails().get(0).getUrl();
-            assertIsSecureUrl(thumbnailUrl);
-            assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("ytimg"));
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() throws Exception {
-            final String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -133,8 +136,10 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testUploaderAvatars() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatars().get(0).getUrl();
-            assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -220,17 +225,19 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testThumbnails() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnails().get(0).getUrl();
-            assertIsSecureUrl(thumbnailUrl);
-            assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("ytimg"));
+            }
         }
 
         @Ignore
         @Test
         public void testBanners() throws Exception {
-            final String bannerUrl = extractor.getBanners().get(0).getUrl();
-            assertIsSecureUrl(bannerUrl);
-            assertTrue(bannerUrl, bannerUrl.contains("yt"));
+            for (Image image : extractor.getBanners()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test
@@ -245,8 +252,10 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testUploaderAvatars() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatars().get(0).getUrl();
-            assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+                assertTrue(image.getUrl(), image.getUrl().contains("yt3"));
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -106,16 +106,16 @@ public class YoutubePlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnailUrl() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnailUrl();
+        public void testThumbnail() throws Exception {
+            final String thumbnailUrl = extractor.getThumbnail().getUrl();
             assertIsSecureUrl(thumbnailUrl);
             assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() throws Exception {
-            final String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            final String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt"));
         }
@@ -132,8 +132,8 @@ public class YoutubePlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatarUrl() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatarUrl();
+        public void testUploaderAvatar() throws Exception {
+            final String uploaderAvatarUrl = extractor.getUploaderAvatar().getUrl();
             assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
         }
 
@@ -219,16 +219,16 @@ public class YoutubePlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnailUrl() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnailUrl();
+        public void testThumbnail() throws Exception {
+            final String thumbnailUrl = extractor.getThumbnail().getUrl();
             assertIsSecureUrl(thumbnailUrl);
             assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
         }
 
         @Ignore
         @Test
-        public void testBannerUrl() throws Exception {
-            final String bannerUrl = extractor.getBannerUrl();
+        public void testBanner() throws Exception {
+            final String bannerUrl = extractor.getBanner().getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt"));
         }
@@ -244,8 +244,8 @@ public class YoutubePlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatarUrl() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatarUrl();
+        public void testUploaderAvatar() throws Exception {
+            final String uploaderAvatarUrl = extractor.getUploaderAvatar().getUrl();
             assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -106,16 +106,16 @@ public class YoutubePlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnail() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnail().getUrl();
+        public void testThumbnails() throws Exception {
+            final String thumbnailUrl = extractor.getThumbnails().get(0).getUrl();
             assertIsSecureUrl(thumbnailUrl);
             assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
         }
 
         @Ignore
         @Test
-        public void testBanner() throws Exception {
-            final String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            final String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt"));
         }
@@ -132,8 +132,8 @@ public class YoutubePlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatar() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatar().getUrl();
+        public void testUploaderAvatars() throws Exception {
+            final String uploaderAvatarUrl = extractor.getUploaderAvatars().get(0).getUrl();
             assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
         }
 
@@ -219,16 +219,16 @@ public class YoutubePlaylistExtractorTest {
         //////////////////////////////////////////////////////////////////////////*/
 
         @Test
-        public void testThumbnail() throws Exception {
-            final String thumbnailUrl = extractor.getThumbnail().getUrl();
+        public void testThumbnails() throws Exception {
+            final String thumbnailUrl = extractor.getThumbnails().get(0).getUrl();
             assertIsSecureUrl(thumbnailUrl);
             assertTrue(thumbnailUrl, thumbnailUrl.contains("yt"));
         }
 
         @Ignore
         @Test
-        public void testBanner() throws Exception {
-            final String bannerUrl = extractor.getBanner().getUrl();
+        public void testBanners() throws Exception {
+            final String bannerUrl = extractor.getBanners().get(0).getUrl();
             assertIsSecureUrl(bannerUrl);
             assertTrue(bannerUrl, bannerUrl.contains("yt"));
         }
@@ -244,8 +244,8 @@ public class YoutubePlaylistExtractorTest {
         }
 
         @Test
-        public void testUploaderAvatar() throws Exception {
-            final String uploaderAvatarUrl = extractor.getUploaderAvatar().getUrl();
+        public void testUploaderAvatars() throws Exception {
+            final String uploaderAvatarUrl = extractor.getUploaderAvatars().get(0).getUrl();
             assertTrue(uploaderAvatarUrl, uploaderAvatarUrl.contains("yt"));
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
@@ -96,13 +96,13 @@ public class YoutubeStreamExtractorAgeRestrictedTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
+    public void testGetThumbnail() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnail().getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+    public void testGetUploaderAvatar() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.stream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -97,12 +98,16 @@ public class YoutubeStreamExtractorAgeRestrictedTest {
 
     @Test
     public void testGetThumbnails() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+        for (Image image : extractor.getThumbnails()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test
     public void testGetUploaderAvatars() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+        for (Image image : extractor.getUploaderAvatars()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
@@ -96,13 +96,13 @@ public class YoutubeStreamExtractorAgeRestrictedTest {
     }
 
     @Test
-    public void testGetThumbnail() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnail().getUrl());
+    public void testGetThumbnails() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatar() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+    public void testGetUploaderAvatars() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
@@ -97,13 +97,13 @@ public class YoutubeStreamExtractorControversialTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
+    public void testGetThumbnail() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnail().getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+    public void testGetUploaderAvatar() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
@@ -97,13 +97,13 @@ public class YoutubeStreamExtractorControversialTest {
     }
 
     @Test
-    public void testGetThumbnail() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnail().getUrl());
+    public void testGetThumbnails() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatar() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+    public void testGetUploaderAvatars() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorControversialTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -98,12 +99,16 @@ public class YoutubeStreamExtractorControversialTest {
 
     @Test
     public void testGetThumbnails() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+        for (Image image : extractor.getThumbnails()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test
     public void testGetUploaderAvatars() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+        for (Image image : extractor.getUploaderAvatars()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -160,13 +160,13 @@ public class YoutubeStreamExtractorDefaultTest {
         }
 
         @Test
-        public void testGetThumbnail() throws ParsingException {
-            assertIsSecureUrl(extractor.getThumbnail().getUrl());
+        public void testGetThumbnails() throws ParsingException {
+            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
         }
 
         @Test
-        public void testGetUploaderAvatar() throws ParsingException {
-            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+        public void testGetUploaderAvatars() throws ParsingException {
+            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -160,13 +160,13 @@ public class YoutubeStreamExtractorDefaultTest {
         }
 
         @Test
-        public void testGetThumbnailUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getThumbnailUrl());
+        public void testGetThumbnail() throws ParsingException {
+            assertIsSecureUrl(extractor.getThumbnail().getUrl());
         }
 
         @Test
-        public void testGetUploaderAvatarUrl() throws ParsingException {
-            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        public void testGetUploaderAvatar() throws ParsingException {
+            assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.ExtractorAsserts;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
@@ -161,12 +162,16 @@ public class YoutubeStreamExtractorDefaultTest {
 
         @Test
         public void testGetThumbnails() throws ParsingException {
-            assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+            for (Image image : extractor.getThumbnails()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test
         public void testGetUploaderAvatars() throws ParsingException {
-            assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+            for (Image image : extractor.getUploaderAvatars()) {
+                assertIsSecureUrl(image.getUrl());
+            }
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
@@ -85,13 +85,13 @@ public class YoutubeStreamExtractorLivestreamTest {
     }
 
     @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
+    public void testGetThumbnail() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnail().getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+    public void testGetUploaderAvatar() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
@@ -85,13 +85,13 @@ public class YoutubeStreamExtractorLivestreamTest {
     }
 
     @Test
-    public void testGetThumbnail() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnail().getUrl());
+    public void testGetThumbnails() throws ParsingException {
+        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
     }
 
     @Test
-    public void testGetUploaderAvatar() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatar().getUrl());
+    public void testGetUploaderAvatars() throws ParsingException {
+        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorLivestreamTest.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.stream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -86,12 +87,16 @@ public class YoutubeStreamExtractorLivestreamTest {
 
     @Test
     public void testGetThumbnails() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnails().get(0).getUrl());
+        for (Image image : extractor.getThumbnails()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test
     public void testGetUploaderAvatars() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatars().get(0).getUrl());
+        for (Image image : extractor.getUploaderAvatars()) {
+            assertIsSecureUrl(image.getUrl());
+        }
     }
 
     @Test


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

See TeamNewPipe/NewPipe#3121.

This PR will introduce an Image class, so that NewPipeExtractor will also return the width and height of an image, which NewPipe could use to determine which image to load. It'll also provide a list of all available images (i.e. different resolutions), but that's not implemented yet. Also, currebtly I've only implemented getting the actual width and height of the image for YouTube, I still have to look into the other services.

~~@TobiGr: Don't merge this for v0.18.6 though, this will be for v0.19.0 (or whatever we end up calling the next proper non-hotfix release).~~