### PR TITLE
[YouTube] Improve response status checks

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -623,7 +623,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         final JsonObject playabilityStatus = playerResponse.getObject("playabilityStatus", JsonUtils.DEFAULT_EMPTY);
         final String status = playabilityStatus.getString("status");
-        if (status != null && status.toLowerCase().equals("error")) {
+        // If status exist, and is not "OK", throw a ContentNotAvailableException with the reason.
+        if (status != null && !status.toLowerCase().equals("ok")) {
             final String reason = playabilityStatus.getString("reason");
             throw new ContentNotAvailableException("Got error: \"" + reason + "\"");
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorDefaultTest.java
@@ -145,7 +145,7 @@ public class PeertubeStreamExtractorDefaultTest {
     @Test
     public void testGetAgeLimit() throws ExtractionException, IOException {
         assertEquals(0, extractor.getAgeLimit());
-        PeertubeStreamExtractor ageLimit = (PeertubeStreamExtractor) PeerTube.getStreamExtractor("https://peertube.co.uk/videos/watch/6762bb04-cad5-407b-81ee-c18eac4715a7");
+        PeertubeStreamExtractor ageLimit = (PeertubeStreamExtractor) PeerTube.getStreamExtractor("https://peertube.co.uk/videos/watch/3c0da7fb-e4d9-442e-84e3-a8c47004ee28");
         ageLimit.fetchPage();
         assertEquals(18, ageLimit.getAgeLimit());
     }


### PR DESCRIPTION
### YouTube
- Fail-fast if status exist and is anything other than "OK"

### PeerTube
- Update video used in age limit test (the previous was 404)

---

Incredible, forgot how a green check mark for tests looked like (though some areas are lacking tests).