### PR TITLE
Don't accept YouTube Mix playlists

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
@@ -54,10 +54,9 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
     @Override
     public boolean onAcceptUrl(final String url) {
         try {
-            getId(url);
+            return !getId(url).startsWith("RD"); // Don't accept auto-generated "Mix" playlists
         } catch (ParsingException e) {
             return false;
         }
-        return true;
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

This will let NewPipe open the actual video from the YouTube Mix playlist you're watching, as NewPipeExtractor can't handle YouTube Mix playlists yet. This would vastly improve YouTube Music support for now, as when you watch a video there, it'll automatically go to the Mix.

Or we could wait until someone implemens properly extracting those Mix playlists.