### PR TITLE
[YouTube] Fix channel with redirects directly in the response

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -621,7 +621,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         playerResponse = getPlayerResponse();
 
-        final JsonObject playabilityStatus = playerResponse.getObject("playabilityStatus", JsonUtils.DEFAULT_EMPTY);
+        final JsonObject playabilityStatus = playerResponse.getObject("playabilityStatus", JsonUtils.EMPTY_OBJECT);
         final String status = playabilityStatus.getString("status");
         // If status exist, and is not "OK", throw a ContentNotAvailableException with the reason.
         if (status != null && !status.toLowerCase().equals("ok")) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JsonUtils.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class JsonUtils {
-    public static final JsonObject DEFAULT_EMPTY = new JsonObject();
+    public static final JsonObject EMPTY_OBJECT = new JsonObject();
+    public static final JsonArray EMPTY_ARRAY = new JsonArray();
+    public static final String EMPTY_STRING = "";
 
     private JsonUtils() {
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -5,12 +5,16 @@ import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeChannelExtractor;
 
+import java.util.List;
+
 import static org.junit.Assert.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmpty;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.services.DefaultTests.*;
@@ -505,6 +509,97 @@ public class YoutubeChannelExtractorTest {
         }
     }
 
+    /**
+     * Some VEVO channels will redirect to a new page with a new channel id.
+     * <p>
+     * Though, it isn't a simple redirect, but a redirect instruction embed in the response itself, this
+     * test assure that we account for that.
+     */
+    public static class RedirectedChannel implements BaseChannelExtractorTest {
+        private static YoutubeChannelExtractor extractor;
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            extractor = (YoutubeChannelExtractor) YouTube
+                    .getChannelExtractor("https://www.youtube.com/channel/UCITk7Ky4iE5_xISw9IaHqpQ");
+            extractor.fetchPage();
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // Extractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testServiceId() {
+            assertEquals(YouTube.getServiceId(), extractor.getServiceId());
+        }
+
+        @Test
+        public void testName() throws Exception {
+            assertEquals("LordiVEVO", extractor.getName());
+        }
+
+        @Test
+        public void testId() throws Exception {
+            assertEquals("UCrxkwepj7-4Wz1wHyfzw-sQ", extractor.getId());
+        }
+
+        @Test
+        public void testUrl() throws ParsingException {
+            assertEquals("https://www.youtube.com/channel/UCrxkwepj7-4Wz1wHyfzw-sQ", extractor.getUrl());
+        }
+
+        @Test
+        public void testOriginalUrl() throws ParsingException {
+            assertEquals("https://www.youtube.com/channel/UCITk7Ky4iE5_xISw9IaHqpQ", extractor.getOriginalUrl());
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // ListExtractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testRelatedItems() throws Exception {
+            defaultTestRelatedItems(extractor);
+        }
+
+        @Test
+        public void testMoreRelatedItems() throws Exception {
+            assertNoMoreItems(extractor);
+        }
+
+         /*//////////////////////////////////////////////////////////////////////////
+         // ChannelExtractor
+         //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testDescription() throws Exception {
+            assertEmpty(extractor.getDescription());
+        }
+
+        @Test
+        public void testAvatarUrl() throws Exception {
+            String avatarUrl = extractor.getAvatarUrl();
+            assertIsSecureUrl(avatarUrl);
+            assertTrue(avatarUrl, avatarUrl.contains("yt3"));
+        }
+
+        @Test
+        public void testBannerUrl() throws Exception {
+            assertEmpty(extractor.getBannerUrl());
+        }
+
+        @Test
+        public void testFeedUrl() throws Exception {
+            assertEquals("https://www.youtube.com/feeds/videos.xml?channel_id=UCrxkwepj7-4Wz1wHyfzw-sQ", extractor.getFeedUrl());
+        }
+
+        @Test
+        public void testSubscriberCount() throws Exception {
+            assertEquals(-1, extractor.getSubscriberCount());
+        }
+    }
 
     public static class RandomChannel implements BaseChannelExtractorTest {
         private static YoutubeChannelExtractor extractor;


### PR DESCRIPTION
Some redirects were embed directly into the response as instructions for the page, instead of the usual http redirects.

- Fix channel extraction when redirects are in the response.
- Fix id extraction for some channels.
    - Some channels had no reliable way to get the redirected id in the response.

There's still some problems though, channels generated by YouTube won't have video tabs and in some cases, even the `subscriberCountText` has completely unrelated text in it  (e.g. [Movies & Shows](https://www.youtube.com/channel/UClgRkhTL3_hImCAmdLfDE4g)).

@wb9688 Maybe we have to extract the essentials and report that it has no videos (technically the truth), or even ignore those generated channels completely? I guess the essentials are better than nothing (like the old extractor did).

---

Fixes #283.