### PR TITLE
[SoundCloud] Fix by migrating to `api-v2` and other improvements

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChartsExtractor.java
@@ -44,7 +44,7 @@ public class SoundcloudChartsExtractor extends KioskExtractor<StreamInfoItem> {
     }
 
 
-    private void computNextPageAndStreams() throws IOException, ExtractionException {
+    private void computeNextPageAndStreams() throws IOException, ExtractionException {
         collector = new StreamInfoItemsCollector(getServiceId());
 
         String apiUrl = "https://api-v2.soundcloud.com/charts" +
@@ -69,7 +69,7 @@ public class SoundcloudChartsExtractor extends KioskExtractor<StreamInfoItem> {
     @Override
     public String getNextPageUrl() throws IOException, ExtractionException {
         if (nextPageUrl == null) {
-            computNextPageAndStreams();
+            computeNextPageAndStreams();
         }
         return nextPageUrl;
     }
@@ -78,7 +78,7 @@ public class SoundcloudChartsExtractor extends KioskExtractor<StreamInfoItem> {
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws IOException, ExtractionException {
         if (collector == null) {
-            computNextPageAndStreams();
+            computeNextPageAndStreams();
         }
         return new InfoItemsPage<>(collector, getNextPageUrl());
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -108,7 +108,7 @@ public class SoundcloudParsingHelper {
      * See https://developers.soundcloud.com/docs/api/reference#resolve
      */
     public static JsonObject resolveFor(Downloader downloader, String url) throws IOException, ExtractionException {
-        String apiUrl = "https://api.soundcloud.com/resolve"
+        String apiUrl = "https://api-v2.soundcloud.com/resolve"
                 + "?url=" + URLEncoder.encode(url, "UTF-8")
                 + "&client_id=" + clientId();
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -169,14 +169,14 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
                 + "&ids=").length();
         final int lengthOfEveryStream = 11;
 
-        String currentPageUrl;
+        String currentPageUrl, nextUrl;
         int lengthMaxStreams = lengthFirstPartOfUrl + lengthOfEveryStream * streamsPerRequestedPage;
         if (pageUrl.length() <= lengthMaxStreams) {
             currentPageUrl = pageUrl; // fetch every remaining video, there are less than the max
-            nextPageUrl = ""; // afterwards the list is complete
+            nextUrl = ""; // afterwards the list is complete
         } else {
             currentPageUrl = pageUrl.substring(0, lengthMaxStreams);
-            nextPageUrl = pageUrl.substring(0, lengthFirstPartOfUrl) + pageUrl.substring(lengthMaxStreams);
+            nextUrl = pageUrl.substring(0, lengthFirstPartOfUrl) + pageUrl.substring(lengthMaxStreams);
         }
 
         StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
@@ -193,6 +193,6 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
             throw new ParsingException("Could not parse json response", e);
         }
 
-        return new InfoItemsPage<>(collector, nextPageUrl);
+        return new InfoItemsPage<>(collector, nextUrl);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -15,12 +15,10 @@ import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
+import java.io.IOException;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
 public class SoundcloudPlaylistExtractor extends PlaylistExtractor {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -141,8 +141,9 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
             }
         }
 
+        nextPageUrlBuilder.setLength(nextPageUrlBuilder.length() - 1); // remove trailing ,
         nextPageUrl = nextPageUrlBuilder.toString();
-        if (nextPageUrl.endsWith("&ids=")) {
+        if (nextPageUrl.endsWith("&ids")) {
             // there are no other videos
             nextPageUrl = "";
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -66,6 +66,7 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
         return playlist.getString("title");
     }
 
+    @Nullable
     @Override
     public String getThumbnailUrl() {
         String artworkUrl = playlist.getString("artwork_url");
@@ -75,21 +76,20 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
             // if it also fails, return null
             try {
                 final InfoItemsPage<StreamInfoItem> infoItems = getInitialPage();
-                if (infoItems.getItems().isEmpty()) return null;
 
                 for (StreamInfoItem item : infoItems.getItems()) {
-                    final String thumbnailUrl = item.getThumbnailUrl();
-                    if (thumbnailUrl == null || thumbnailUrl.isEmpty()) continue;
-
-                    String thumbnailUrlBetterResolution = thumbnailUrl.replace("large.jpg", "crop.jpg");
-                    return thumbnailUrlBetterResolution;
+                    artworkUrl = item.getThumbnailUrl();
+                    if (artworkUrl != null && !artworkUrl.isEmpty()) break;
                 }
             } catch (Exception ignored) {
             }
+
+            if (artworkUrl == null) {
+                return null;
+            }
         }
 
-        String artworkUrlBetterResolution = artworkUrl.replace("large.jpg", "crop.jpg");
-        return artworkUrlBetterResolution;
+        return artworkUrl.replace("large.jpg", "crop.jpg");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractor.java
@@ -145,7 +145,7 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     private void computeAnotherNextPageUrl() throws IOException, ExtractionException {
-        if (nextTrackIdsIndex >= nextTrackIds.size()) {
+        if (nextTrackIds == null || nextTrackIdsIndex >= nextTrackIds.size()) {
             nextPageUrl = ""; // there are no more tracks
             return;
         }
@@ -160,6 +160,7 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
             urlBuilder.append(","); // a , at the end is ok
         }
 
+        nextTrackIdsIndex = upperIndex;
         nextPageUrl = urlBuilder.toString();
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -4,6 +4,7 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -15,16 +16,15 @@ import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.*;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+
+import javax.annotation.Nonnull;
 
 public class SoundcloudStreamExtractor extends StreamExtractor {
     private JsonObject track;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -14,7 +14,14 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
-import org.schabi.newpipe.extractor.stream.*;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.Description;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.SubtitlesStream;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -148,24 +155,13 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
         List<AudioStream> audioStreams = new ArrayList<>();
         Downloader dl = NewPipe.getDownloader();
 
-        String apiUrl = "https://api-v2.soundcloud.com/tracks/" + urlEncode(getId())
-                + "?client_id=" + urlEncode(SoundcloudParsingHelper.clientId());
-
-        String response = dl.get(apiUrl, getExtractorLocalization()).responseBody();
-        JsonObject responseObject;
-        try {
-            responseObject = JsonParser.object().from(response);
-        } catch (JsonParserException e) {
-            throw new ParsingException("Could not parse json response", e);
-        }
-
         // Streams can be streamable and downloadable - or explicitly not.
         // For playing the track, it is only necessary to have a streamable track.
         // If this is not the case, this track might not be published yet.
-        if (!responseObject.getBoolean("streamable")) return audioStreams;
+        if (!track.getBoolean("streamable")) return audioStreams;
 
         try {
-            JsonArray transcodings = responseObject.getObject("media").getArray("transcodings");
+            JsonArray transcodings = track.getObject("media").getArray("transcodings");
 
             // get information about what stream formats are available
             for (Object transcoding : transcodings) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -19,6 +19,8 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,14 +57,14 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public String getTextualUploadDate() {
-        return track.getString("created_at");
+    public String getTextualUploadDate() throws ParsingException {
+        return track.getString("created_at").replace("T"," ").replace("Z", "");
     }
 
     @Nonnull
     @Override
     public DateWrapper getUploadDate() throws ParsingException {
-        return new DateWrapper(SoundcloudParsingHelper.parseDate(getTextualUploadDate()));
+        return new DateWrapper(SoundcloudParsingHelper.parseDate(track.getString("created_at")));
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudSubscriptionExtractor.java
@@ -36,7 +36,7 @@ public class SoundcloudSubscriptionExtractor extends SubscriptionExtractor {
             throw new InvalidSourceException(e);
         }
 
-        String apiUrl = "https://api.soundcloud.com/users/" + id + "/followings"
+        String apiUrl = "https://api-v2.soundcloud.com/users/" + id + "/followings"
                 + "?client_id=" + SoundcloudParsingHelper.clientId()
                 + "&limit=200";
         ChannelInfoItemsCollector collector = new ChannelInfoItemsCollector(service.getServiceId());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelperTest.java
@@ -24,6 +24,8 @@ public class SoundcloudParsingHelperTest {
     public void resolveUrlWithEmbedPlayerTest() throws Exception {
         Assert.assertEquals("https://soundcloud.com/trapcity", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/26057743"));
         Assert.assertEquals("https://soundcloud.com/nocopyrightsounds", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/16069159"));
+        Assert.assertEquals("https://soundcloud.com/trapcity", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api-v2.soundcloud.com/users/26057743"));
+        Assert.assertEquals("https://soundcloud.com/nocopyrightsounds", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api-v2.soundcloud.com/users/16069159"));
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
@@ -10,6 +9,7 @@ import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
@@ -71,14 +71,6 @@ public class SoundcloudPlaylistExtractorTest {
         @Test
         public void testMoreRelatedItems() throws Exception {
             defaultTestMoreItems(extractor);
-
-            try {
-                defaultTestMoreItems(extractor);
-            } catch (Throwable ignored) {
-                return;
-            }
-
-            fail("This playlist doesn't have more items, it should throw an error");
         }
 
         /*//////////////////////////////////////////////////////////////////////////
@@ -100,7 +92,7 @@ public class SoundcloudPlaylistExtractorTest {
         public void testUploaderUrl() {
             final String uploaderUrl = extractor.getUploaderUrl();
             assertIsSecureUrl(uploaderUrl);
-            assertTrue(uploaderUrl, uploaderUrl.contains("liluzivert"));
+            assertThat(uploaderUrl, containsString("liluzivert"));
         }
 
         @Test
@@ -115,7 +107,7 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testStreamCount() {
-            assertTrue("Error in the streams count", extractor.getStreamCount() >= 10);
+            assertTrue("Stream count does not fit: " + extractor.getStreamCount(), extractor.getStreamCount() >= 10);
         }
     }
 
@@ -192,7 +184,7 @@ public class SoundcloudPlaylistExtractorTest {
         public void testUploaderUrl() {
             final String uploaderUrl = extractor.getUploaderUrl();
             assertIsSecureUrl(uploaderUrl);
-            assertThat(uploaderUrl, CoreMatchers.containsString("micky96"));
+            assertThat(uploaderUrl, containsString("micky96"));
         }
 
         @Test
@@ -207,7 +199,7 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testStreamCount() {
-            assertTrue("Error in the streams count", extractor.getStreamCount() >= 10);
+            assertTrue("Stream count does not fit: " + extractor.getStreamCount(), extractor.getStreamCount() >= 10);
         }
     }
 
@@ -228,17 +220,8 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testGetPageInNewExtractor() throws Exception {
-            final PlaylistExtractor newExtractor = SoundCloud.getPlaylistExtractor(extractor.getUrl());
+            PlaylistExtractor newExtractor = SoundCloud.getPlaylistExtractor(extractor.getUrl());
             defaultTestGetPageInNewExtractor(extractor, newExtractor);
-            String page1 = newExtractor.getNextPageUrl();
-            defaultTestMoreItems(newExtractor); // there has to be another page
-            String page2 = newExtractor.getNextPageUrl();
-            defaultTestMoreItems(newExtractor); // and another one
-            String page3 = newExtractor.getNextPageUrl();
-
-            assertNotEquals("Same pages", page1, page2);
-            assertNotEquals("Same pages", page2, page3);
-            assertNotEquals("Same pages", page3, page1);
         }
 
         /*//////////////////////////////////////////////////////////////////////////
@@ -324,6 +307,104 @@ public class SoundcloudPlaylistExtractorTest {
         @Test
         public void testStreamCount() {
             assertTrue("Stream count does not fit: " + extractor.getStreamCount(), extractor.getStreamCount() >= 370);
+        }
+    }
+
+    public static class SmallPlaylist implements BasePlaylistExtractorTest {
+        private static SoundcloudPlaylistExtractor extractor;
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            extractor = (SoundcloudPlaylistExtractor) SoundCloud
+                    .getPlaylistExtractor("https://soundcloud.com/breezy-123/sets/empty-playlist?test=123");
+            extractor.fetchPage();
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // Extractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testServiceId() {
+            assertEquals(SoundCloud.getServiceId(), extractor.getServiceId());
+        }
+
+        @Test
+        public void testName() {
+            assertEquals("EMPTY PLAYLIST", extractor.getName());
+        }
+
+        @Test
+        public void testId() {
+            assertEquals("23483459", extractor.getId());
+        }
+
+        @Test
+        public void testUrl() throws Exception {
+            assertEquals("https://soundcloud.com/breezy-123/sets/empty-playlist", extractor.getUrl());
+        }
+
+        @Test
+        public void testOriginalUrl() throws Exception {
+            assertEquals("https://soundcloud.com/breezy-123/sets/empty-playlist?test=123", extractor.getOriginalUrl());
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // ListExtractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testRelatedItems() throws Exception {
+            defaultTestRelatedItems(extractor);
+        }
+
+        @Test
+        public void testMoreRelatedItems() throws Exception {
+            try {
+                defaultTestMoreItems(extractor);
+            } catch (Throwable ignored) {
+                return;
+            }
+
+            fail("This playlist doesn't have more items, it should throw an error");
+        }
+
+        /*//////////////////////////////////////////////////////////////////////////
+        // PlaylistExtractor
+        //////////////////////////////////////////////////////////////////////////*/
+
+        @Test
+        public void testThumbnailUrl() {
+            assertIsSecureUrl(extractor.getThumbnailUrl());
+        }
+
+        @Test
+        public void testBannerUrl() {
+            // SoundCloud playlists do not have a banner
+            assertNull(extractor.getBannerUrl());
+        }
+
+        @Test
+        public void testUploaderUrl() {
+            final String uploaderUrl = extractor.getUploaderUrl();
+            assertIsSecureUrl(uploaderUrl);
+            assertThat(uploaderUrl, containsString("breezy-123"));
+        }
+
+        @Test
+        public void testUploaderName() {
+            assertEquals("breezy-123", extractor.getUploaderName());
+        }
+
+        @Test
+        public void testUploaderAvatarUrl() {
+            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        }
+
+        @Test
+        public void testStreamCount() {
+            assertEquals(2, extractor.getStreamCount());
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -2,17 +2,13 @@ package org.schabi.newpipe.extractor.services.soundcloud;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
-
-import java.io.IOException;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -317,7 +317,7 @@ public class SoundcloudPlaylistExtractorTest {
 
         @Test
         public void testStreamCount() {
-            assertTrue("Error in the streams count", extractor.getStreamCount() >= 3900);
+            assertTrue("Stream count does not fit: " + extractor.getStreamCount(), extractor.getStreamCount() >= 370);
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -7,9 +7,12 @@ import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+
+import java.io.IOException;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
@@ -70,7 +73,9 @@ public class SoundcloudPlaylistExtractorTest {
         }
 
         @Test
-        public void testMoreRelatedItems() {
+        public void testMoreRelatedItems() throws Exception {
+            defaultTestMoreItems(extractor);
+
             try {
                 defaultTestMoreItems(extractor);
             } catch (Throwable ignored) {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -234,6 +234,15 @@ public class SoundcloudPlaylistExtractorTest {
         public void testGetPageInNewExtractor() throws Exception {
             final PlaylistExtractor newExtractor = SoundCloud.getPlaylistExtractor(extractor.getUrl());
             defaultTestGetPageInNewExtractor(extractor, newExtractor);
+            String page1 = newExtractor.getNextPageUrl();
+            defaultTestMoreItems(newExtractor); // there has to be another page
+            String page2 = newExtractor.getNextPageUrl();
+            defaultTestMoreItems(newExtractor); // and another one
+            String page3 = newExtractor.getNextPageUrl();
+
+            assertNotEquals("Same pages", page1, page2);
+            assertNotEquals("Same pages", page2, page3);
+            assertNotEquals("Same pages", page3, page1);
         }
 
         /*//////////////////////////////////////////////////////////////////////////

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -94,10 +94,10 @@ public class SoundcloudPlaylistExtractorTest {
             assertIsSecureUrl(extractor.getThumbnailUrl());
         }
 
-        @Ignore
         @Test
         public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+            // SoundCloud playlists do not have a banner
+            assertNull(extractor.getBannerUrl());
         }
 
         @Test
@@ -186,10 +186,10 @@ public class SoundcloudPlaylistExtractorTest {
             assertIsSecureUrl(extractor.getThumbnailUrl());
         }
 
-        @Ignore("not implemented")
         @Test
         public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+            // SoundCloud playlists do not have a banner
+            assertNull(extractor.getBannerUrl());
         }
 
         @Test
@@ -293,10 +293,10 @@ public class SoundcloudPlaylistExtractorTest {
             assertIsSecureUrl(extractor.getThumbnailUrl());
         }
 
-        @Ignore
         @Test
         public void testBannerUrl() {
-            assertIsSecureUrl(extractor.getBannerUrl());
+            // SoundCloud playlists do not have a banner
+            assertNull(extractor.getBannerUrl());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudPlaylistExtractorTest.java
@@ -269,14 +269,11 @@ public class SoundcloudPlaylistExtractorTest {
         // ListExtractor
         //////////////////////////////////////////////////////////////////////////*/
 
-        @Ignore
         @Test
         public void testRelatedItems() throws Exception {
             defaultTestRelatedItems(extractor);
         }
 
-        //TODO: FUCK THIS: This triggers a 500 at sever
-        @Ignore
         @Test
         public void testMoreRelatedItems() throws Exception {
             ListExtractor.InfoItemsPage<StreamInfoItem> currentPage = defaultTestMoreItems(extractor);
@@ -291,7 +288,6 @@ public class SoundcloudPlaylistExtractorTest {
         // PlaylistExtractor
         //////////////////////////////////////////////////////////////////////////*/
 
-        @Ignore
         @Test
         public void testThumbnailUrl() {
             assertIsSecureUrl(extractor.getThumbnailUrl());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -74,7 +74,7 @@ public class SoundcloudStreamExtractorDefaultTest {
 
     @Test
     public void testGetTextualUploadDate() throws ParsingException {
-        Assert.assertEquals("2016/07/31 18:18:07 +0000", extractor.getTextualUploadDate());
+        Assert.assertEquals("2016-07-31 18:18:07", extractor.getTextualUploadDate());
     }
 
     @Test


### PR DESCRIPTION
- [ x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Even though now `api` started to work again with the hardcoded id, it seems to be unstable, as yesterday it returned a "403 Forbidden". `api-v2` works better than `api`, anyway, since I was able to unignore some previously ignored tests. This PR migrates every Extractor to `api-v2`, along with some other fixes. 
Fixes #290

These are all the improvements:
- Use `api-v2` in PlaylistExtractor: rewrote methods to calculate next page url and to get items from it. `api-v2` is different from `api` since the initial playlist page contains (usually) the full info of the first 3 streams and only the id of the others. Then the single tracks can be requested in batch using `/tracks?ids=id1,id2,...`, so that's the next url we get.
- Improve thumbnail url extraction in PlaylistExtractor: prevent NullPointerExceptions and remove duplicate code.
- Use api-v2 in SubscriptionExtractor: changing the url was enough. Also added some tests for channel urls with an `api-v2` url.
- Improve playlists tests: assert playlists do not have a banner, unignore every ignored test (now they all succeed)
