### PR TITLE
Catch a NFE in YoutubeStreamExtractor.getViewCount - for new videos, …

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -278,8 +278,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             if (views == null) throw new ParsingException("Could not get view count");
         }
-
-        return Long.parseLong(Utils.removeNonDigitCharacters(views));
+        try {
+            return Long.parseLong(Utils.removeNonDigitCharacters(views));
+        } catch (NumberFormatException nfe) {
+            throw new ParsingException("Could not parse \"" + views + "\" as a Long", nfe);
+        }
     }
 
     @Override


### PR DESCRIPTION
…sometimes the viewCount is empty

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.
