### PR TITLE
Pass additional regexes to youtube extractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -37,6 +37,8 @@ import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -69,8 +71,16 @@ import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCap
 
 public class YoutubeService extends StreamingService {
 
+    private List<String> additionalRegexes;
+
     public YoutubeService(int id) {
         super(id, "YouTube", asList(AUDIO, VIDEO, LIVE, COMMENTS));
+        this.additionalRegexes = new ArrayList<String>();
+    }
+
+    public YoutubeService(int id, List<String> additionalRegexes) {
+        super(id, "YouTube", asList(AUDIO, VIDEO, LIVE, COMMENTS));
+        this.additionalRegexes = additionalRegexes;
     }
 
     @Override
@@ -217,5 +227,9 @@ public class YoutubeService extends StreamingService {
 
     public List<ContentCountry> getSupportedCountries() {
         return SUPPORTED_COUNTRIES;
+    }
+
+    public List<String> getAdditionalRegexes() {
+        return this.additionalRegexes;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -23,6 +23,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoPatternsManager;
 import org.schabi.newpipe.extractor.services.youtube.ItagItem;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.services.youtube.YoutubeService;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.Frameset;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -775,7 +777,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 DECRYPTION_AKAMAIZED_STRING_REGEX
         };
         Parser.RegexException exception = null;
-        for (String regex : decryptionFuncNameRegexes) {
+        List<String> allRegexes = new ArrayList<>(Arrays.asList(decryptionFuncNameRegexes));
+        allRegexes.addAll(((YoutubeService)this.getService()).getAdditionalRegexes());
+        for (final String regex : allRegexes) {
             try {
                 return Parser.matchGroup1(regex, playerCode);
             } catch (Parser.RegexException re) {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.

Adds support for passing additional regexes (from file, server, etc.) through youtube's extractor in order to fix extraction errors without an update. Closes TeamNewPipe/NewPipeExtractor#255 