### PR TITLE
[peertube] add feed url in channels

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
@@ -57,7 +57,7 @@ public class PeertubeChannelExtractor extends ChannelExtractor {
 
     @Override
     public String getFeedUrl() throws ParsingException {
-        return null;
+        return getBaseUrl() + "/feeds/videos.xml?accountId=" + json.get("id");
     }
 
     @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeChannelExtractorTest.java
@@ -98,7 +98,7 @@ public class PeertubeChannelExtractorTest {
 
         @Test
         public void testFeedUrl() throws ParsingException {
-            assertEmpty(extractor.getFeedUrl());
+            assertEquals("https://peertube.mastodon.host/feeds/videos.xml?accountId=32465", extractor.getFeedUrl());
         }
 
         @Test
@@ -195,7 +195,7 @@ public class PeertubeChannelExtractorTest {
 
         @Test
         public void testFeedUrl() throws ParsingException {
-            assertEmpty(extractor.getFeedUrl());
+            assertEquals("https://peertube.mastodon.host/feeds/videos.xml?accountId=1753", extractor.getFeedUrl());
         }
 
         @Test


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- ~~I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.~~ no need

This will add the rss icon on peertube channels.
I haven't made feedextractor in this pr, because it's not faster (the original page is already small).
