### PR TITLE
throw ContentNotSupportedException when content is known to be unsuppo…

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/ContentNotSupportedException.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/ContentNotSupportedException.java
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.extractor.exceptions;
+
+public class ContentNotSupportedException extends ParsingException {
+    public ContentNotSupportedException(String message) {
+        super(message);
+    }
+
+    public ContentNotSupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
@@ -194,6 +195,10 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
         } catch (NullPointerException e) {
             throw new ExtractionException("Could not get SoundCloud's track audio url", e);
+        }
+
+        if (audioStreams.isEmpty()) {
+            throw new ContentNotSupportedException("HLS audio streams / opus streams are not yet supported");
         }
 
         return audioStreams;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractor.java
@@ -198,7 +198,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
         }
 
         if (audioStreams.isEmpty()) {
-            throw new ContentNotSupportedException("HLS audio streams / opus streams are not yet supported");
+            throw new ContentNotSupportedException("HLS audio streams are not yet supported");
         }
 
         return audioStreams;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -5,6 +5,7 @@ import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
@@ -310,7 +311,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         }
 
         if (videoTab == null) {
-            throw new ParsingException("Could not find Videos tab");
+            throw new ContentNotSupportedException("This channel has no Videos tab");
         }
 
         try {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubePlaylistLinkHandlerFactory.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -47,7 +48,7 @@ public class YoutubePlaylistLinkHandlerFactory extends ListLinkHandlerFactory {
 
             // Don't accept auto-generated "Mix" playlists but auto-generated YouTube Music playlists
             if (listID.startsWith("RD") && !listID.startsWith("RDCLAK")) {
-                throw new ParsingException("YouTube Mix playlists are not yet supported");
+                throw new ContentNotSupportedException("YouTube Mix playlists are not yet supported");
             }
 
             return listID;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -5,6 +5,7 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.utils.DashMpdParser;
@@ -47,7 +48,7 @@ public class StreamInfo extends Info {
     }
 
     public StreamInfo(int serviceId, String url, String originalUrl, StreamType streamType, String id, String name,
-            int ageLimit) {
+                      int ageLimit) {
         super(serviceId, id, url, originalUrl, name);
         this.streamType = streamType;
         this.ageLimit = ageLimit;
@@ -131,6 +132,8 @@ public class StreamInfo extends Info {
         /* Load and extract audio */
         try {
             streamInfo.setAudioStreams(extractor.getAudioStreams());
+        } catch (ContentNotSupportedException e) {
+            throw e;
         } catch (Exception e) {
             streamInfo.addError(new ExtractionException("Couldn't get audio streams", e));
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
@@ -25,107 +26,134 @@ import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
  * Test for {@link StreamExtractor}
  */
 public class SoundcloudStreamExtractorDefaultTest {
-    private static SoundcloudStreamExtractor extractor;
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        NewPipe.init(DownloaderTestImpl.getInstance());
-        extractor = (SoundcloudStreamExtractor) SoundCloud.getStreamExtractor("https://soundcloud.com/liluzivert/do-what-i-want-produced-by-maaly-raw-don-cannon");
-        extractor.fetchPage();
+    public static class LilUziVertDoWhatIWant {
+        private static SoundcloudStreamExtractor extractor;
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            extractor = (SoundcloudStreamExtractor) SoundCloud.getStreamExtractor("https://soundcloud.com/liluzivert/do-what-i-want-produced-by-maaly-raw-don-cannon");
+            extractor.fetchPage();
+        }
+
+        @Test
+        public void testGetInvalidTimeStamp() throws ParsingException {
+            assertTrue(extractor.getTimeStamp() + "",
+                    extractor.getTimeStamp() <= 0);
+        }
+
+        @Test
+        public void testGetValidTimeStamp() throws IOException, ExtractionException {
+            StreamExtractor extractor = SoundCloud.getStreamExtractor("https://soundcloud.com/liluzivert/do-what-i-want-produced-by-maaly-raw-don-cannon#t=69");
+            assertEquals("69", extractor.getTimeStamp() + "");
+        }
+
+        @Test
+        public void testGetTitle() throws ParsingException {
+            assertEquals("Do What I Want [Produced By Maaly Raw + Don Cannon]", extractor.getName());
+        }
+
+        @Test
+        public void testGetDescription() throws ParsingException {
+            assertEquals("The Perfect LUV Tape®️", extractor.getDescription().getContent());
+        }
+
+        @Test
+        public void testGetUploaderName() throws ParsingException {
+            assertEquals("LIL UZI VERT", extractor.getUploaderName());
+        }
+
+        @Test
+        public void testGetLength() throws ParsingException {
+            assertEquals(175, extractor.getLength());
+        }
+
+        @Test
+        public void testGetViewCount() throws ParsingException {
+            assertTrue(Long.toString(extractor.getViewCount()),
+                    extractor.getViewCount() > 44227978);
+        }
+
+        @Test
+        public void testGetTextualUploadDate() throws ParsingException {
+            Assert.assertEquals("2016-07-31 18:18:07", extractor.getTextualUploadDate());
+        }
+
+        @Test
+        public void testGetUploadDate() throws ParsingException, ParseException {
+            final Calendar instance = Calendar.getInstance();
+            instance.setTime(new SimpleDateFormat("yyyy/MM/dd HH:mm:ss +0000").parse("2016/07/31 18:18:07 +0000"));
+            assertEquals(instance, requireNonNull(extractor.getUploadDate()).date());
+        }
+
+        @Test
+        public void testGetUploaderUrl() throws ParsingException {
+            assertIsSecureUrl(extractor.getUploaderUrl());
+            assertEquals("https://soundcloud.com/liluzivert", extractor.getUploaderUrl());
+        }
+
+        @Test
+        public void testGetThumbnailUrl() throws ParsingException {
+            assertIsSecureUrl(extractor.getThumbnailUrl());
+        }
+
+        @Test
+        public void testGetUploaderAvatarUrl() throws ParsingException {
+            assertIsSecureUrl(extractor.getUploaderAvatarUrl());
+        }
+
+        @Test
+        public void testGetAudioStreams() throws IOException, ExtractionException {
+            assertFalse(extractor.getAudioStreams().isEmpty());
+        }
+
+        @Test
+        public void testStreamType() throws ParsingException {
+            assertTrue(extractor.getStreamType() == StreamType.AUDIO_STREAM);
+        }
+
+        @Test
+        public void testGetRelatedVideos() throws ExtractionException, IOException {
+            StreamInfoItemsCollector relatedVideos = extractor.getRelatedStreams();
+            assertFalse(relatedVideos.getItems().isEmpty());
+            assertTrue(relatedVideos.getErrors().isEmpty());
+        }
+
+        @Test
+        public void testGetSubtitlesListDefault() throws IOException, ExtractionException {
+            // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
+            assertTrue(extractor.getSubtitlesDefault().isEmpty());
+        }
+
+        @Test
+        public void testGetSubtitlesList() throws IOException, ExtractionException {
+            // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
+            assertTrue(extractor.getSubtitlesDefault().isEmpty());
+        }
     }
 
-    @Test
-    public void testGetInvalidTimeStamp() throws ParsingException {
-        assertTrue(extractor.getTimeStamp() + "",
-                extractor.getTimeStamp() <= 0);
-    }
+    public static class ContentNotSupported {
+        @BeforeClass
+        public static void setUp() {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+        }
 
-    @Test
-    public void testGetValidTimeStamp() throws IOException, ExtractionException {
-        StreamExtractor extractor = SoundCloud.getStreamExtractor("https://soundcloud.com/liluzivert/do-what-i-want-produced-by-maaly-raw-don-cannon#t=69");
-        assertEquals("69", extractor.getTimeStamp() + "");
-    }
+        @Test(expected = ContentNotSupportedException.class)
+        public void hlsAudioStream() throws Exception {
+            final StreamExtractor extractor =
+                    SoundCloud.getStreamExtractor("https://soundcloud.com/dualipa/cool");
+            extractor.fetchPage();
+            extractor.getAudioStreams();
+        }
 
-    @Test
-    public void testGetTitle() throws ParsingException {
-        assertEquals("Do What I Want [Produced By Maaly Raw + Don Cannon]", extractor.getName());
-    }
-
-    @Test
-    public void testGetDescription() throws ParsingException {
-        assertEquals("The Perfect LUV Tape®️", extractor.getDescription().getContent());
-    }
-
-    @Test
-    public void testGetUploaderName() throws ParsingException {
-        assertEquals("LIL UZI VERT", extractor.getUploaderName());
-    }
-
-    @Test
-    public void testGetLength() throws ParsingException {
-        assertEquals(175, extractor.getLength());
-    }
-
-    @Test
-    public void testGetViewCount() throws ParsingException {
-        assertTrue(Long.toString(extractor.getViewCount()),
-                extractor.getViewCount() > 44227978);
-    }
-
-    @Test
-    public void testGetTextualUploadDate() throws ParsingException {
-        Assert.assertEquals("2016-07-31 18:18:07", extractor.getTextualUploadDate());
-    }
-
-    @Test
-    public void testGetUploadDate() throws ParsingException, ParseException {
-        final Calendar instance = Calendar.getInstance();
-        instance.setTime(new SimpleDateFormat("yyyy/MM/dd HH:mm:ss +0000").parse("2016/07/31 18:18:07 +0000"));
-        assertEquals(instance, requireNonNull(extractor.getUploadDate()).date());
-    }
-
-    @Test
-    public void testGetUploaderUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderUrl());
-        assertEquals("https://soundcloud.com/liluzivert", extractor.getUploaderUrl());
-    }
-
-    @Test
-    public void testGetThumbnailUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getThumbnailUrl());
-    }
-
-    @Test
-    public void testGetUploaderAvatarUrl() throws ParsingException {
-        assertIsSecureUrl(extractor.getUploaderAvatarUrl());
-    }
-
-    @Test
-    public void testGetAudioStreams() throws IOException, ExtractionException {
-        assertFalse(extractor.getAudioStreams().isEmpty());
-    }
-
-    @Test
-    public void testStreamType() throws ParsingException {
-        assertTrue(extractor.getStreamType() == StreamType.AUDIO_STREAM);
-    }
-
-    @Test
-    public void testGetRelatedVideos() throws ExtractionException, IOException {
-        StreamInfoItemsCollector relatedVideos = extractor.getRelatedStreams();
-        assertFalse(relatedVideos.getItems().isEmpty());
-        assertTrue(relatedVideos.getErrors().isEmpty());
-    }
-
-    @Test
-    public void testGetSubtitlesListDefault() throws IOException, ExtractionException {
-        // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
-        assertTrue(extractor.getSubtitlesDefault().isEmpty());
-    }
-
-    @Test
-    public void testGetSubtitlesList() throws IOException, ExtractionException {
-        // Video (/view?v=YQHsXMglC9A) set in the setUp() method has no captions => null
-        assertTrue(extractor.getSubtitlesDefault().isEmpty());
+        @Test(expected = ContentNotSupportedException.class)
+        public void bothHlsAndOpusAudioStreams() throws Exception {
+            final StreamExtractor extractor =
+                    SoundCloud.getStreamExtractor("https://soundcloud.com/lil-baby-4pf/no-sucker");
+            extractor.fetchPage();
+            extractor.getAudioStreams();
+        }
     }
 }
+

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -5,13 +5,14 @@ import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
-import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeChannelExtractor;
 
-import java.util.List;
+import java.io.IOException;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmpty;
@@ -42,6 +43,20 @@ public class YoutubeChannelExtractorTest {
             final ChannelExtractor extractor =
                     YouTube.getChannelExtractor("https://www.youtube.com/channel/DOESNT-EXIST");
             extractor.fetchPage();
+        }
+    }
+
+    public static class NotSupported {
+        @BeforeClass
+        public static void setUp() {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+        }
+
+        @Test(expected = ContentNotSupportedException.class)
+        public void noVideoTab() throws Exception {
+            final ChannelExtractor extractor = YouTube.getChannelExtractor("https://invidio.us/channel/UC-9-kyTW8ZkZNDHQJ6FgpwQ");
+            extractor.fetchPage();
+            extractor.getInitialPage();
         }
     }
 


### PR DESCRIPTION
…rted

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I did test the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to ASAP create a PULL request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) for making in compatible when I changed the api.


Follows the discussion we had in #250
It will greatly improve SoundCloud usability, because instead of randomly crashing, it will show the error with an appropriated UI, not a crash report, then the average user will understand why, and he can go back to play another track.
Before, the user was confused, and it went back to main kiosk each time, so it was really annoying.
Screenshots from UI:
<img src="https://user-images.githubusercontent.com/58657617/78676267-b9df2e80-78d5-11ea-938d-8b07a6d8a76e.png" width="200"> <img src="https://user-images.githubusercontent.com/58657617/78676277-bc418880-78d5-11ea-97c3-ad283bfb9a1e.png" width="200">

PR in Front-end: https://github.com/TeamNewPipe/NewPipe/pull/3300