### PR TITLE
Search: add isCorrectedSearch() and fix YoutubeSearchExtractor#getSea…

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
@@ -25,6 +25,16 @@ public abstract class SearchExtractor extends ListExtractor<InfoItem> {
         return getLinkHandler().getSearchString();
     }
 
+    /**
+     * The search suggestion provided by the service.
+     * <p>
+     * This method may also return the corrected query,
+     * see {@link SearchExtractor#isCorrectedSearch()}.
+     *
+     * @return a suggestion to another query, the corrected query, or an empty String.
+     * @throws ParsingException
+     */
+    @Nonnull
     public abstract String getSearchSuggestion() throws ParsingException;
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
@@ -37,4 +37,15 @@ public abstract class SearchExtractor extends ListExtractor<InfoItem> {
     public String getName() {
         return getLinkHandler().getSearchString();
     }
+
+    /**
+     * When you search on some service, it can give you another and corrected request.
+     * This method says if it's the case.
+     * <p>
+     * Example: on YouTube, if you search for "pewdeipie",
+     * it will give you results for "pewdiepie", then isCorrectedSearch should return true.
+     *
+     * @return whether the results comes from a corrected query or not.
+     */
+    public abstract boolean isCorrectedSearch() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchExtractor.java
@@ -28,8 +28,8 @@ public abstract class SearchExtractor extends ListExtractor<InfoItem> {
     /**
      * The search suggestion provided by the service.
      * <p>
-     * This method may also return the corrected query,
-     * see {@link SearchExtractor#isCorrectedSearch()}.
+     * This method also returns the corrected query if
+     * {@link SearchExtractor#isCorrectedSearch()} is true.
      *
      * @return a suggestion to another query, the corrected query, or an empty String.
      * @throws ParsingException
@@ -49,8 +49,7 @@ public abstract class SearchExtractor extends ListExtractor<InfoItem> {
     }
 
     /**
-     * When you search on some service, it can give you another and corrected request.
-     * This method says if it's the case.
+     * Tell if the search was corrected by the service (if it's not exactly the search you typed).
      * <p>
      * Example: on YouTube, if you search for "pewdeipie",
      * it will give you results for "pewdiepie", then isCorrectedSearch should return true.

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
@@ -70,11 +70,11 @@ public class SearchInfo extends ListInfo<InfoItem> {
 
     // Getter
     public String getSearchString() {
-        return searchString;
+        return this.searchString;
     }
 
     public String getSearchSuggestion() {
-        return searchSuggestion;
+        return this.searchSuggestion;
     }
 
     public boolean isCorrectedSearch() {
@@ -82,7 +82,7 @@ public class SearchInfo extends ListInfo<InfoItem> {
     }
 
     public void setCorrectedSearch(boolean correctedSearch) {
-        isCorrectedSearch = correctedSearch;
+        this.isCorrectedSearch = correctedSearch;
     }
 
     public void setSearchSuggestion(String searchSuggestion) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
@@ -43,12 +43,12 @@ public class SearchInfo extends ListInfo<InfoItem> {
             info.addError(e);
         }
         try {
-            info.searchSuggestion = extractor.getSearchSuggestion();
+            info.setSearchSuggestion(extractor.getSearchSuggestion());
         } catch (Exception e) {
             info.addError(e);
         }
         try {
-            info.isCorrectedSearch = extractor.isCorrectedSearch();
+            info.setCorrectedSearch(extractor.isCorrectedSearch());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -79,5 +79,13 @@ public class SearchInfo extends ListInfo<InfoItem> {
 
     public boolean isCorrectedSearch() {
         return this.isCorrectedSearch;
+    }
+
+    public void setCorrectedSearch(boolean correctedSearch) {
+        isCorrectedSearch = correctedSearch;
+    }
+
+    public void setSearchSuggestion(String searchSuggestion) {
+        this.searchSuggestion = searchSuggestion;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
@@ -48,7 +48,7 @@ public class SearchInfo extends ListInfo<InfoItem> {
             info.addError(e);
         }
         try {
-            info.setCorrectedSearch(extractor.isCorrectedSearch());
+            info.setIsCorrectedSearch(extractor.isCorrectedSearch());
         } catch (Exception e) {
             info.addError(e);
         }
@@ -81,8 +81,8 @@ public class SearchInfo extends ListInfo<InfoItem> {
         return this.isCorrectedSearch;
     }
 
-    public void setCorrectedSearch(boolean correctedSearch) {
-        this.isCorrectedSearch = correctedSearch;
+    public void setIsCorrectedSearch(boolean isCorrectedSearch) {
+        this.isCorrectedSearch = isCorrectedSearch;
     }
 
     public void setSearchSuggestion(String searchSuggestion) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
@@ -15,6 +15,7 @@ public class SearchInfo extends ListInfo<InfoItem> {
 
     private String searchString;
     private String searchSuggestion;
+    private boolean isCorrectedSearch;
 
     public SearchInfo(int serviceId,
                       SearchQueryHandler qIHandler,
@@ -46,6 +47,11 @@ public class SearchInfo extends ListInfo<InfoItem> {
         } catch (Exception e) {
             info.addError(e);
         }
+        try {
+            info.isCorrectedSearch = extractor.isCorrectedSearch();
+        } catch (Exception e) {
+            info.addError(e);
+        }
 
         ListExtractor.InfoItemsPage<InfoItem> page = ExtractorHelper.getItemsPageOrLogError(info, extractor);
         info.setRelatedItems(page.getItems());
@@ -69,5 +75,9 @@ public class SearchInfo extends ListInfo<InfoItem> {
 
     public String getSearchSuggestion() {
         return searchSuggestion;
+    }
+
+    public boolean isCorrectedSearch() {
+        return this.isCorrectedSearch;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
@@ -45,7 +45,7 @@ public class MediaCCCSearchExtractor extends SearchExtractor {
 
     @Nonnull
     @Override
-    public String getSearchSuggestion() throws ParsingException {
+    public String getSearchSuggestion() {
         return "";
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
@@ -47,6 +47,11 @@ public class MediaCCCSearchExtractor extends SearchExtractor {
         return null;
     }
 
+    @Override
+    public boolean isCorrectedSearch() {
+        return false;
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<InfoItem> getInitialPage() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCSearchExtractor.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
@@ -42,9 +43,10 @@ public class MediaCCCSearchExtractor extends SearchExtractor {
         }
     }
 
+    @Nonnull
     @Override
-    public String getSearchSuggestion() {
-        return null;
+    public String getSearchSuggestion() throws ParsingException {
+        return "";
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeSearchExtractor.java
@@ -41,6 +41,11 @@ public class PeertubeSearchExtractor extends SearchExtractor {
     }
 
     @Override
+    public boolean isCorrectedSearch() {
+        return false;
+    }
+
+    @Override
     public InfoItemsPage<InfoItem> getInitialPage() throws IOException, ExtractionException {
         super.fetchPage();
         return initPage;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeSearchExtractor.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Parser.RegexException;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 public class PeertubeSearchExtractor extends SearchExtractor {
@@ -35,9 +36,10 @@ public class PeertubeSearchExtractor extends SearchExtractor {
         super(service, linkHandler);
     }
 
+    @Nonnull
     @Override
     public String getSearchSuggestion() throws ParsingException {
-        return null;
+        return "";
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSearchExtractor.java
@@ -33,9 +33,10 @@ public class SoundcloudSearchExtractor extends SearchExtractor {
         super(service, linkHandler);
     }
 
+    @Nonnull
     @Override
     public String getSearchSuggestion() {
-        return null;
+        return "";
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSearchExtractor.java
@@ -38,6 +38,11 @@ public class SoundcloudSearchExtractor extends SearchExtractor {
         return null;
     }
 
+    @Override
+    public boolean isCorrectedSearch() {
+        return false;
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<InfoItem> getInitialPage() throws IOException, ExtractionException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -130,7 +130,7 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
     public String getSearchSuggestion() throws ParsingException {
         final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
                 .getArray("contents").getObject(0).getObject("itemSectionRenderer");
-        if (itemSectionRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
+        if (itemSectionRenderer.isEmpty()) {
             return "";
         }
 
@@ -139,9 +139,9 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
 
-        if (!didYouMeanRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
+        if (!didYouMeanRenderer.isEmpty()) {
             return getTextFromObject(didYouMeanRenderer.getObject("correctedQuery"));
-        } else if (!showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
+        } else if (!showingResultsForRenderer.isEmpty()) {
             return JsonUtils.getString(showingResultsForRenderer, "correctedQueryEndpoint.searchEndpoint.query");
         } else {
             return "";
@@ -152,13 +152,13 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
     public boolean isCorrectedSearch() {
         final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
                 .getArray("contents").getObject(0).getObject("itemSectionRenderer");
-        if (itemSectionRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
+        if (itemSectionRenderer.isEmpty()) {
             return false;
         }
 
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
-        return !showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT);
+        return !showingResultsForRenderer.isEmpty();
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -143,7 +143,7 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
             return false;
         }
 
-        JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
+        final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
         return showingResultsForRenderer != null;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -135,6 +135,19 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
         return getTextFromObject(didYouMeanRenderer.getObject("correctedQuery"));
     }
 
+    @Override
+    public boolean isCorrectedSearch() {
+        final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
+                .getArray("contents").getObject(0).getObject("itemSectionRenderer");
+        if (itemSectionRenderer == null) {
+            return false;
+        }
+
+        JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
+                .getObject("showingResultsForRenderer");
+        return showingResultsForRenderer != null;
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<InfoItem> getInitialPage() throws ExtractionException, IOException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -18,6 +18,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
@@ -124,15 +125,27 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
         return super.getUrl();
     }
 
+    @Nonnull
     @Override
     public String getSearchSuggestion() throws ParsingException {
-        final JsonObject didYouMeanRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
-                .getArray("contents").getObject(0).getObject("itemSectionRenderer")
-                .getArray("contents").getObject(0).getObject("didYouMeanRenderer");
-        if (!didYouMeanRenderer.has("correctedQuery")) {
+        final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
+                .getArray("contents").getObject(0).getObject("itemSectionRenderer");
+        if (itemSectionRenderer == null) {
             return "";
         }
-        return getTextFromObject(didYouMeanRenderer.getObject("correctedQuery"));
+
+        final JsonObject didYouMeanRenderer = itemSectionRenderer.getArray("contents")
+                .getObject(0).getObject("didYouMeanRenderer");
+        final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
+                .getObject("showingResultsForRenderer");
+
+        if (didYouMeanRenderer != null) {
+            return getTextFromObject(didYouMeanRenderer.getObject("correctedQuery"));
+        } else if (showingResultsForRenderer != null) {
+            return JsonUtils.getString(showingResultsForRenderer, "correctedQueryEndpoint.searchEndpoint.query");
+        } else {
+            return "";
+        }
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -130,7 +130,7 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
     public String getSearchSuggestion() throws ParsingException {
         final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
                 .getArray("contents").getObject(0).getObject("itemSectionRenderer");
-        if (itemSectionRenderer == null) {
+        if (itemSectionRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
             return "";
         }
 
@@ -139,9 +139,9 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
 
-        if (didYouMeanRenderer != null) {
+        if (!didYouMeanRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
             return getTextFromObject(didYouMeanRenderer.getObject("correctedQuery"));
-        } else if (showingResultsForRenderer != null) {
+        } else if (!showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
             return JsonUtils.getString(showingResultsForRenderer, "correctedQueryEndpoint.searchEndpoint.query");
         } else {
             return "";
@@ -152,13 +152,13 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
     public boolean isCorrectedSearch() {
         final JsonObject itemSectionRenderer = initialData.getObject("contents").getObject("sectionListRenderer")
                 .getArray("contents").getObject(0).getObject("itemSectionRenderer");
-        if (itemSectionRenderer == null) {
+        if (itemSectionRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
             return false;
         }
 
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
-        return showingResultsForRenderer != null;
+        return !showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -73,7 +73,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
 
-        if (didYouMeanRenderer != null) {
+        if (!didYouMeanRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
             return JsonUtils.getString(didYouMeanRenderer, "correctedQueryEndpoint.searchEndpoint.query");
         } else if (showingResultsForRenderer != null) {
             return getTextFromObject(showingResultsForRenderer.getObject("correctedQuery"));
@@ -89,7 +89,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
                 .getObject("sectionListRenderer").getArray("contents").getObject(0)
                 .getObject("itemSectionRenderer").getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
-        return showingResultsForRenderer != null;
+        return !showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -73,7 +73,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
 
-        if (!didYouMeanRenderer.equals(JsonUtils.EMPTY_OBJECT)) {
+        if (!didYouMeanRenderer.isEmpty()) {
             return JsonUtils.getString(didYouMeanRenderer, "correctedQueryEndpoint.searchEndpoint.query");
         } else if (showingResultsForRenderer != null) {
             return getTextFromObject(showingResultsForRenderer.getObject("correctedQuery"));
@@ -89,7 +89,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
                 .getObject("sectionListRenderer").getArray("contents").getObject(0)
                 .getObject("itemSectionRenderer").getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
-        return !showingResultsForRenderer.equals(JsonUtils.EMPTY_OBJECT);
+        return !showingResultsForRenderer.isEmpty();
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -61,17 +61,25 @@ public class YoutubeSearchExtractor extends SearchExtractor {
         return super.getUrl() + "&gl=" + getExtractorContentCountry().getCountryCode();
     }
 
+    @Nonnull
     @Override
     public String getSearchSuggestion() throws ParsingException {
-        final JsonObject didYouMeanRenderer = initialData.getObject("contents")
+        final JsonObject itemSectionRenderer = initialData.getObject("contents")
                 .getObject("twoColumnSearchResultsRenderer").getObject("primaryContents")
                 .getObject("sectionListRenderer").getArray("contents").getObject(0)
-                .getObject("itemSectionRenderer").getArray("contents").getObject(0)
+                .getObject("itemSectionRenderer");
+        final JsonObject didYouMeanRenderer = itemSectionRenderer.getArray("contents").getObject(0)
                 .getObject("didYouMeanRenderer");
-        if (didYouMeanRenderer == null) {
+        final JsonObject showingResultsForRenderer = itemSectionRenderer.getArray("contents").getObject(0)
+                .getObject("showingResultsForRenderer");
+
+        if (didYouMeanRenderer != null) {
+            return JsonUtils.getString(didYouMeanRenderer, "correctedQueryEndpoint.searchEndpoint.query");
+        } else if (showingResultsForRenderer != null) {
+            return getTextFromObject(showingResultsForRenderer.getObject("correctedQuery"));
+        } else {
             return "";
         }
-        return JsonUtils.getString(didYouMeanRenderer, "correctedQueryEndpoint.searchEndpoint.query");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
-
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -12,10 +11,10 @@ import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
-
-import java.io.IOException;
+import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonResponse;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
@@ -64,15 +63,25 @@ public class YoutubeSearchExtractor extends SearchExtractor {
 
     @Override
     public String getSearchSuggestion() throws ParsingException {
+        final JsonObject didYouMeanRenderer = initialData.getObject("contents")
+                .getObject("twoColumnSearchResultsRenderer").getObject("primaryContents")
+                .getObject("sectionListRenderer").getArray("contents").getObject(0)
+                .getObject("itemSectionRenderer").getArray("contents").getObject(0)
+                .getObject("didYouMeanRenderer");
+        if (didYouMeanRenderer == null) {
+            return "";
+        }
+        return JsonUtils.getString(didYouMeanRenderer, "correctedQueryEndpoint.searchEndpoint.query");
+    }
+
+    @Override
+    public boolean isCorrectedSearch() {
         final JsonObject showingResultsForRenderer = initialData.getObject("contents")
                 .getObject("twoColumnSearchResultsRenderer").getObject("primaryContents")
                 .getObject("sectionListRenderer").getArray("contents").getObject(0)
                 .getObject("itemSectionRenderer").getArray("contents").getObject(0)
                 .getObject("showingResultsForRenderer");
-        if (!showingResultsForRenderer.has("correctedQuery")) {
-            return "";
-        }
-        return getTextFromObject(showingResultsForRenderer.getObject("correctedQuery"));
+        return showingResultsForRenderer != null;
     }
 
     @Nonnull

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseSearchExtractorTest.java
@@ -4,4 +4,5 @@ package org.schabi.newpipe.extractor.services;
 public interface BaseSearchExtractorTest extends BaseListExtractorTest {
     void testSearchString() throws Exception;
     void testSearchSuggestion() throws Exception;
+    void testSearchCorrected() throws Exception;
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultSearchExtractorTest.java
@@ -15,6 +15,10 @@ public abstract class DefaultSearchExtractorTest extends DefaultListExtractorTes
     public abstract String expectedSearchString();
     @Nullable public abstract String expectedSearchSuggestion();
 
+    public boolean isCorrectedSearch() {
+        return false;
+    }
+
     @Test
     @Override
     public void testSearchString() throws Exception {
@@ -30,5 +34,10 @@ public abstract class DefaultSearchExtractorTest extends DefaultListExtractorTes
         } else {
             assertEquals(expectedSearchSuggestion, extractor().getSearchSuggestion());
         }
+    }
+
+    @Test
+    public void testSearchCorrected() throws Exception {
+        assertEquals(isCorrectedSearch(), extractor().isCorrectedSearch());
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
@@ -150,4 +150,27 @@ public class YoutubeMusicSearchExtractorTest {
         @Nullable @Override public String expectedSearchSuggestion() { return "mega man x3"; }
         @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
     }
+
+    public static class CorrectedSearch extends DefaultSearchExtractorTest {
+        private static SearchExtractor extractor;
+        private static final String QUERY = "duo lipa";
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
+            extractor.fetchPage();
+        }
+
+        @Override public SearchExtractor extractor() { return extractor; }
+        @Override public StreamingService expectedService() { return YouTube; }
+        @Override public String expectedName() { return QUERY; }
+        @Override public String expectedId() { return QUERY; }
+        @Override public String expectedUrlContains() { return "music.youtube.com/search?q=" + URLEncoder.encode(QUERY); }
+        @Override public String expectedOriginalUrlContains() { return "music.youtube.com/search?q=" + URLEncoder.encode(QUERY); }
+        @Override public String expectedSearchString() { return QUERY; }
+        @Nullable @Override public String expectedSearchSuggestion() { return null; }
+        @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
+        @Override public boolean isCorrectedSearch() { return true; }
+    }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
@@ -154,6 +154,7 @@ public class YoutubeMusicSearchExtractorTest {
     public static class CorrectedSearch extends DefaultSearchExtractorTest {
         private static SearchExtractor extractor;
         private static final String QUERY = "duo lipa";
+        private static final String EXPECTED_SUGGESTION = "dua lipa";
 
         @BeforeClass
         public static void setUp() throws Exception {
@@ -169,7 +170,7 @@ public class YoutubeMusicSearchExtractorTest {
         @Override public String expectedUrlContains() { return "music.youtube.com/search?q=" + URLEncoder.encode(QUERY); }
         @Override public String expectedOriginalUrlContains() { return "music.youtube.com/search?q=" + URLEncoder.encode(QUERY); }
         @Override public String expectedSearchString() { return QUERY; }
-        @Nullable @Override public String expectedSearchSuggestion() { return null; }
+        @Nullable @Override public String expectedSearchSuggestion() { return EXPECTED_SUGGESTION; }
         @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
         @Override public boolean isCorrectedSearch() { return true; }
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -114,8 +114,8 @@ public class YoutubeSearchExtractorTest {
 
     public static class Suggestion extends DefaultSearchExtractorTest {
         private static SearchExtractor extractor;
-        private static final String QUERY = "pewdeipie";
-        private static final String EXPECTED_SUGGESTION = "pewdiepie";
+        private static final String QUERY = "newpip";
+        private static final String EXPECTED_SUGGESTION = "newpipe";
 
         @BeforeClass
         public static void setUp() throws Exception {
@@ -132,8 +132,30 @@ public class YoutubeSearchExtractorTest {
         @Override public String expectedOriginalUrlContains() { return "youtube.com/results?search_query=" + QUERY; }
         @Override public String expectedSearchString() { return QUERY; }
         @Nullable @Override public String expectedSearchSuggestion() { return EXPECTED_SUGGESTION; }
-
         @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
+    }
+
+    public static class CorrectedSearch extends DefaultSearchExtractorTest {
+        private static SearchExtractor extractor;
+        private static final String QUERY = "pewdeipie";
+
+        @BeforeClass
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            extractor = YouTube.getSearchExtractor(QUERY, singletonList(VIDEOS), "");
+            extractor.fetchPage();
+        }
+
+        @Override public SearchExtractor extractor() { return extractor; }
+        @Override public StreamingService expectedService() { return YouTube; }
+        @Override public String expectedName() { return QUERY; }
+        @Override public String expectedId() { return QUERY; }
+        @Override public String expectedUrlContains() { return "youtube.com/results?search_query=" + QUERY; }
+        @Override public String expectedOriginalUrlContains() { return "youtube.com/results?search_query=" + QUERY; }
+        @Override public String expectedSearchString() { return QUERY; }
+        @Nullable @Override public String expectedSearchSuggestion() { return null; }
+        @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
+        @Override public boolean isCorrectedSearch() { return true; }
     }
 
     public static class RandomQueryNoMorePages extends DefaultSearchExtractorTest {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 
@@ -138,6 +139,7 @@ public class YoutubeSearchExtractorTest {
     public static class CorrectedSearch extends DefaultSearchExtractorTest {
         private static SearchExtractor extractor;
         private static final String QUERY = "pewdeipie";
+        private static final String EXPECTED_SUGGESTION = "pewdiepie";
 
         @BeforeClass
         public static void setUp() throws Exception {
@@ -153,7 +155,7 @@ public class YoutubeSearchExtractorTest {
         @Override public String expectedUrlContains() { return "youtube.com/results?search_query=" + QUERY; }
         @Override public String expectedOriginalUrlContains() { return "youtube.com/results?search_query=" + QUERY; }
         @Override public String expectedSearchString() { return QUERY; }
-        @Nullable @Override public String expectedSearchSuggestion() { return null; }
+        @Nullable @Override public String expectedSearchSuggestion() { return EXPECTED_SUGGESTION; }
         @Override public InfoItem.InfoType expectedInfoItemType() { return InfoItem.InfoType.STREAM; }
         @Override public boolean isCorrectedSearch() { return true; }
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -7,7 +7,6 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

See https://github.com/TeamNewPipe/NewPipe/issues/3419 and https://github.com/TeamNewPipe/NewPipe/issues/3419#issuecomment-612453811
With https://github.com/TeamNewPipe/NewPipe/issues/3419, I figured out two things:

YouTube (& YouTube Music) either corrects your query, or suggest another one.
I fixed the suggestion in YouTube which were actually the corrected query, and added a boolean to know if the query was corrected.