### PR TITLE
Add tests for parseDurationString()

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -142,9 +142,10 @@ public class YoutubeParsingHelper {
             default:
                 throw new ParsingException("Error duration string with unknown format: " + input);
         }
-        return ((((Long.parseLong(Utils.removeNonDigitCharacters(days)) * 24)
-                + Long.parseLong(Utils.removeNonDigitCharacters(hours)) * 60)
-                + Long.parseLong(Utils.removeNonDigitCharacters(minutes))) * 60)
+
+        return ((Long.parseLong(Utils.removeNonDigitCharacters(days)) * 24
+                + Long.parseLong(Utils.removeNonDigitCharacters(hours))) * 60
+                + Long.parseLong(Utils.removeNonDigitCharacters(minutes))) * 60
                 + Long.parseLong(Utils.removeNonDigitCharacters(seconds));
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelperTest.java
@@ -5,9 +5,11 @@ import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class YoutubeParsingHelperTest {
@@ -26,5 +28,12 @@ public class YoutubeParsingHelperTest {
     public void testAreHardcodedYoutubeMusicKeysValid() throws IOException, ExtractionException {
         assertTrue("Hardcoded YouTube Music keys are not valid anymore",
                 YoutubeParsingHelper.areHardcodedYoutubeMusicKeysValid());
+    }
+
+    @Test
+    public void testParseDurationString() throws ParsingException {
+        assertEquals(1162567, YoutubeParsingHelper.parseDurationString("12:34:56:07"));
+        assertEquals(4445767, YoutubeParsingHelper.parseDurationString("1,234:56:07"));
+        assertEquals(754, YoutubeParsingHelper.parseDurationString("12:34 "));
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

I added some tests for `parseDurationString()` and found out that apparently the days behavior was already broken, however YouTube doesn't seem to use days anymore.