### PR TITLE
Little optimization for lower tier devices

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -108,7 +108,7 @@ public class YoutubeParsingHelper {
         return host.equalsIgnoreCase("invidio.us") || host.equalsIgnoreCase("dev.invidio.us") || host.equalsIgnoreCase("www.invidio.us") || host.equalsIgnoreCase("invidious.snopyta.org") || host.equalsIgnoreCase("de.invidious.snopyta.org") || host.equalsIgnoreCase("fi.invidious.snopyta.org") || host.equalsIgnoreCase("vid.wxzm.sx") || host.equalsIgnoreCase("invidious.kabi.tk") || host.equalsIgnoreCase("invidiou.sh") || host.equalsIgnoreCase("www.invidiou.sh") || host.equalsIgnoreCase("no.invidiou.sh") || host.equalsIgnoreCase("invidious.enkirton.net") || host.equalsIgnoreCase("tube.poal.co") || host.equalsIgnoreCase("invidious.13ad.de") || host.equalsIgnoreCase("yt.elukerio.org");
     }
 
-    public static long parseDurationString(String input)
+    public static int parseDurationString(String input)
             throws ParsingException, NumberFormatException {
         // If time separator : is not detected, try . instead
         final String[] splitInput = input.contains(":")
@@ -142,10 +142,10 @@ public class YoutubeParsingHelper {
             default:
                 throw new ParsingException("Error duration string with unknown format: " + input);
         }
-        return ((((Long.parseLong(Utils.removeNonDigitCharacters(days)) * 24)
-                + Long.parseLong(Utils.removeNonDigitCharacters(hours)) * 60)
-                + Long.parseLong(Utils.removeNonDigitCharacters(minutes))) * 60)
-                + Long.parseLong(Utils.removeNonDigitCharacters(seconds));
+        return ((((Integer.parseInt(Utils.removeNonDigitCharacters(days)) * 24)
+                + Integer.parseInt(Utils.removeNonDigitCharacters(hours)) * 60)
+                + Integer.parseInt(Utils.removeNonDigitCharacters(minutes))) * 60)
+                + Integer.parseInt(Utils.removeNonDigitCharacters(seconds));
     }
 
     public static String getFeedUrlFrom(final String channelIdOrUser) {


### PR DESCRIPTION
the duration is parsed in seconds. Maximum Youtube video length is 12 hours, while earlier Videos have up to 24 hours (Source: https://support.google.com/youtube/answer/71673).

24 hours are just 86400 seconds. So we will never be close to getting an integer overflow.

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
