### PR TITLE
[SoundCloud] Fix concurrency issue when getting the client id

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -37,7 +37,7 @@ import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 public class SoundcloudParsingHelper {
-    private static final String HARDCODED_CLIENT_ID = "Uz4aPhG7GAl1VYGOnvOPW1wQ0M6xKtA9"; // Updated on 16/03/20
+    private static final String HARDCODED_CLIENT_ID = "H2c34Q0E7hftqnuDHGsk88DbNqhYpgMm"; // Updated on 24/06/20
     private static String clientId;
 
     private SoundcloudParsingHelper() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -43,13 +43,15 @@ public class SoundcloudParsingHelper {
     private SoundcloudParsingHelper() {
     }
 
-    public static String clientId() throws ExtractionException, IOException {
+    public synchronized static String clientId() throws ExtractionException, IOException {
         if (!isNullOrEmpty(clientId)) return clientId;
 
         Downloader dl = NewPipe.getDownloader();
         clientId = HARDCODED_CLIENT_ID;
         if (checkIfHardcodedClientIdIsValid()) {
             return clientId;
+        } else {
+            clientId = null;
         }
 
         final Response download = dl.get("https://soundcloud.com");


### PR DESCRIPTION
The client id method didn't work properly when the hardcoded key was no longer valid, an easy example would be when playing a playlist that pre-loaded more than 1 item.

Simply making the method `synchronized` should solve this problem.