### PR TITLE
Add support for Google search redirect url

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
@@ -16,6 +16,7 @@ import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
+import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -277,12 +278,13 @@ public abstract class StreamingService {
      * Figures out where the link is pointing to (a channel, a video, a playlist, etc.)
      * @param url the url on which it should be decided of which link type it is
      * @return the link type of url
-     * @throws ParsingException
      */
     public final LinkType getLinkTypeByUrl(String url) throws ParsingException {
-        LinkHandlerFactory sH = getStreamLHFactory();
-        LinkHandlerFactory cH = getChannelLHFactory();
-        LinkHandlerFactory pH = getPlaylistLHFactory();
+        url = Utils.followGoogleRedirectIfNeeded(url);
+
+        final LinkHandlerFactory sH = getStreamLHFactory();
+        final LinkHandlerFactory cH = getChannelLHFactory();
+        final LinkHandlerFactory pH = getPlaylistLHFactory();
 
         if (sH != null && sH.acceptUrl(url)) {
             return LinkType.STREAM;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
@@ -279,18 +279,18 @@ public abstract class StreamingService {
      * @param url the url on which it should be decided of which link type it is
      * @return the link type of url
      */
-    public final LinkType getLinkTypeByUrl(String url) throws ParsingException {
-        url = Utils.followGoogleRedirectIfNeeded(url);
+    public final LinkType getLinkTypeByUrl(final String url) throws ParsingException {
+        final String polishedUrl = Utils.followGoogleRedirectIfNeeded(url);
 
         final LinkHandlerFactory sH = getStreamLHFactory();
         final LinkHandlerFactory cH = getChannelLHFactory();
         final LinkHandlerFactory pH = getPlaylistLHFactory();
 
-        if (sH != null && sH.acceptUrl(url)) {
+        if (sH != null && sH.acceptUrl(polishedUrl)) {
             return LinkType.STREAM;
-        } else if (cH != null && cH.acceptUrl(url)) {
+        } else if (cH != null && cH.acceptUrl(polishedUrl)) {
             return LinkType.CHANNEL;
-        } else if (pH != null && pH.acceptUrl(url)) {
+        } else if (pH != null && pH.acceptUrl(polishedUrl)) {
             return LinkType.PLAYLIST;
         } else {
             return LinkType.NONE;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/LinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/LinkHandlerFactory.java
@@ -49,11 +49,10 @@ public abstract class LinkHandlerFactory {
      * @param url the url to extract path and id from
      * @return a {@link LinkHandler} complete with information
      */
-    public LinkHandler fromUrl(String url) throws ParsingException {
-        if (url == null) throw new IllegalArgumentException("url can not be null");
-        url = Utils.followGoogleRedirectIfNeeded(url);
-        final String baseUrl = Utils.getBaseUrl(url);
-        return fromUrl(url, baseUrl);
+    public LinkHandler fromUrl(final String url) throws ParsingException {
+        final String polishedUrl = Utils.followGoogleRedirectIfNeeded(url);
+        final String baseUrl = Utils.getBaseUrl(polishedUrl);
+        return fromUrl(polishedUrl, baseUrl);
     }
 
     /**

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/LinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/LinkHandlerFactory.java
@@ -42,12 +42,30 @@ public abstract class LinkHandlerFactory {
     // Logic
     ///////////////////////////////////
 
+    /**
+     * Builds a {@link LinkHandler} from a url.<br>
+     * Be sure to call {@link Utils#followGoogleRedirectIfNeeded(String)} on the url if overriding
+     * this function.
+     * @param url the url to extract path and id from
+     * @return a {@link LinkHandler} complete with information
+     */
     public LinkHandler fromUrl(String url) throws ParsingException {
         if (url == null) throw new IllegalArgumentException("url can not be null");
+        url = Utils.followGoogleRedirectIfNeeded(url);
         final String baseUrl = Utils.getBaseUrl(url);
         return fromUrl(url, baseUrl);
     }
 
+    /**
+     * Builds a {@link LinkHandler} from a url and a base url. The url is expected to be already
+     * polished from google search redirects (otherwise how could {@code baseUrl} have been
+     * extracted?).<br>
+     * So do not call {@link Utils#followGoogleRedirectIfNeeded(String)} on the url if overriding
+     * this function, since that should be done in {@link #fromUrl(String)}.
+     * @param url the url without google search redirects to extract id from
+     * @param baseUrl the base url
+     * @return a {@link LinkHandler} complete with information
+     */
     public LinkHandler fromUrl(String url, String baseUrl) throws ParsingException {
         if (url == null) throw new IllegalArgumentException("url can not be null");
         if (!acceptUrl(url)) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
@@ -32,7 +32,8 @@ public abstract class ListLinkHandlerFactory extends LinkHandlerFactory {
 
     @Override
     public ListLinkHandler fromUrl(String url) throws ParsingException {
-        String baseUrl = Utils.getBaseUrl(url);
+        url = Utils.followGoogleRedirectIfNeeded(url);
+        final String baseUrl = Utils.getBaseUrl(url);
         return fromUrl(url, baseUrl);
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
@@ -31,10 +31,10 @@ public abstract class ListLinkHandlerFactory extends LinkHandlerFactory {
     ///////////////////////////////////
 
     @Override
-    public ListLinkHandler fromUrl(String url) throws ParsingException {
-        url = Utils.followGoogleRedirectIfNeeded(url);
-        final String baseUrl = Utils.getBaseUrl(url);
-        return fromUrl(url, baseUrl);
+    public ListLinkHandler fromUrl(final String url) throws ParsingException {
+        final String polishedUrl = Utils.followGoogleRedirectIfNeeded(url);
+        final String baseUrl = Utils.getBaseUrl(polishedUrl);
+        return fromUrl(polishedUrl, baseUrl);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -55,12 +55,6 @@ public class YoutubeParsingHelper {
     private YoutubeParsingHelper() {
     }
 
-    /**
-     * The official youtube app supports intents in this format, where after the ':' is the videoId.
-     * Accordingly there are other apps sharing streams in this format.
-     */
-    public final static String BASE_YOUTUBE_INTENT_URL = "vnd.youtube";
-
     private static final String HARDCODED_CLIENT_VERSION = "2.20200214.04.00";
     private static String clientVersion;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeCommentsLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeCommentsLinkHandlerFactory.java
@@ -1,10 +1,7 @@
 package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.BASE_YOUTUBE_INTENT_URL;
-
 import org.schabi.newpipe.extractor.exceptions.FoundAdException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 
 import java.util.List;
@@ -15,15 +12,6 @@ public class YoutubeCommentsLinkHandlerFactory extends ListLinkHandlerFactory {
 
     public static YoutubeCommentsLinkHandlerFactory getInstance() {
         return instance;
-    }
-
-    @Override
-    public ListLinkHandler fromUrl(String url) throws ParsingException {
-        if (url.startsWith(BASE_YOUTUBE_INTENT_URL)){
-            return super.fromUrl(url, BASE_YOUTUBE_INTENT_URL);
-        } else {
-            return super.fromUrl(url);
-        }
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeStreamLinkHandlerFactory.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 
 import org.schabi.newpipe.extractor.exceptions.FoundAdException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -14,8 +13,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.BASE_YOUTUBE_INTENT_URL;
 
 /*
  * Created by Christian Schabesberger on 02.02.16.
@@ -64,15 +61,6 @@ public class YoutubeStreamLinkHandlerFactory extends LinkHandlerFactory {
             return extractedId;
         } else {
             throw new ParsingException("The given string is not a Youtube-Video-ID");
-        }
-    }
-
-    @Override
-    public LinkHandler fromUrl(String url) throws ParsingException {
-        if (url.startsWith(BASE_YOUTUBE_INTENT_URL)) {
-            return super.fromUrl(url, BASE_YOUTUBE_INTENT_URL);
-        } else {
-            return super.fromUrl(url);
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -181,15 +181,15 @@ public class Utils {
         return s;
     }
 
-    public static String getBaseUrl(String url) throws ParsingException {
+    public static String getBaseUrl(final String url) throws ParsingException {
         try {
             final URL uri = stringToURL(url);
             return uri.getProtocol() + "://" + uri.getAuthority();
-        } catch (MalformedURLException e) {
+        } catch (final MalformedURLException e) {
             final String message = e.getMessage();
             if (message.startsWith("unknown protocol: ")) {
-                System.out.println(message.substring(18));
-                return message.substring(18); // return just the protocol (e.g. vnd.youtube)
+                // return just the protocol (e.g. vnd.youtube)
+                return message.substring("unknown protocol: ".length());
             }
 
             throw new ParsingException("Malformed url: " + url, e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -196,6 +196,26 @@ public class Utils {
         }
     }
 
+    /**
+     * If the provided url is a Google search redirect, then the actual url is extracted from the
+     * {@code url=} query value and returned, otherwise the original url is returned.
+     * @param url the url which can possibly be a Google search redirect
+     * @return an url with no Google search redirects
+     */
+    public static String followGoogleRedirectIfNeeded(final String url) {
+        // if the url is a redirect from a Google search, extract the actual url
+        try {
+            final URL decoded = Utils.stringToURL(url);
+            if (decoded.getHost().contains("google") && decoded.getPath().equals("/url")) {
+                return URLDecoder.decode(Parser.matchGroup1("&url=([^&]+)(?:&|$)", url), "UTF-8");
+            }
+        } catch (final Exception ignored) {
+        }
+
+        // url is not a google search redirect
+        return url;
+    }
+
     public static boolean isNullOrEmpty(final String str) {
         return str == null || str.isEmpty();
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -182,13 +182,18 @@ public class Utils {
     }
 
     public static String getBaseUrl(String url) throws ParsingException {
-        URL uri;
         try {
-            uri = stringToURL(url);
+            final URL uri = stringToURL(url);
+            return uri.getProtocol() + "://" + uri.getAuthority();
         } catch (MalformedURLException e) {
+            final String message = e.getMessage();
+            if (message.startsWith("unknown protocol: ")) {
+                System.out.println(message.substring(18));
+                return message.substring(18); // return just the protocol (e.g. vnd.youtube)
+            }
+
             throw new ParsingException("Malformed url: " + url, e);
         }
-        return uri.getProtocol() + "://" + uri.getAuthority();
     }
 
     public static boolean isNullOrEmpty(final String str) {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/NewPipeTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/NewPipeTest.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 
 import static org.junit.Assert.*;
 import static org.schabi.newpipe.extractor.NewPipe.getServiceByUrl;
+import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 public class NewPipeTest {
@@ -39,8 +40,10 @@ public class NewPipeTest {
         assertEquals(getServiceByUrl("https://www.youtube.com/watch?v=_r6CgaFNAGg"), YouTube);
         assertEquals(getServiceByUrl("https://www.youtube.com/channel/UCi2bIyFtz-JdI-ou8kaqsqg"), YouTube);
         assertEquals(getServiceByUrl("https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH"), YouTube);
+        assertEquals(getServiceByUrl("https://www.google.it/url?sa=t&rct=j&q=&esrc=s&cd=&cad=rja&uact=8&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DHu80uDzh8RY&source=video"), YouTube);
 
-        assertNotEquals(getServiceByUrl("https://soundcloud.com/pegboardnerds"), YouTube);
+        assertEquals(getServiceByUrl("https://soundcloud.com/pegboardnerds"), SoundCloud);
+        assertEquals(getServiceByUrl("https://www.google.com/url?sa=t&url=https%3A%2F%2Fsoundcloud.com%2Fciaoproduction&rct=j&q=&esrc=s&source=web&cd="), SoundCloud);
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/utils/UtilsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/utils/UtilsTest.java
@@ -30,4 +30,19 @@ public class UtilsTest {
         assertEquals("vnd.youtube", Utils.getBaseUrl("vnd.youtube://n8X9_MgEdCg"));
         assertEquals("https://music.youtube.com", Utils.getBaseUrl("https://music.youtube.com/watch?v=O0EDx9WAelc"));
     }
+
+    @Test
+    public void testFollowGoogleRedirect() {
+        assertEquals("https://www.youtube.com/watch?v=Hu80uDzh8RY",
+                Utils.followGoogleRedirectIfNeeded("https://www.google.it/url?sa=t&rct=j&q=&esrc=s&cd=&cad=rja&uact=8&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DHu80uDzh8RY&source=video"));
+        assertEquals("https://www.youtube.com/watch?v=0b6cFWG45kA",
+                Utils.followGoogleRedirectIfNeeded("https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=video&cd=&cad=rja&uact=8&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0b6cFWG45kA"));
+        assertEquals("https://soundcloud.com/ciaoproduction",
+                Utils.followGoogleRedirectIfNeeded("https://www.google.com/url?sa=t&url=https%3A%2F%2Fsoundcloud.com%2Fciaoproduction&rct=j&q=&esrc=s&source=web&cd="));
+
+        assertEquals("https://www.youtube.com/watch?v=Hu80uDzh8RY&param=xyz",
+                Utils.followGoogleRedirectIfNeeded("https://www.youtube.com/watch?v=Hu80uDzh8RY&param=xyz"));
+        assertEquals("https://www.youtube.com/watch?v=Hu80uDzh8RY&url=hello",
+                Utils.followGoogleRedirectIfNeeded("https://www.youtube.com/watch?v=Hu80uDzh8RY&url=hello"));
+    }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/utils/UtilsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/utils/UtilsTest.java
@@ -21,4 +21,13 @@ public class UtilsTest {
     public void testJoin() {
         assertEquals("some,random,stuff", Utils.join(",", Arrays.asList("some", "random", "stuff")));
     }
+
+    @Test
+    public void testGetBaseUrl() throws ParsingException {
+        assertEquals("https://www.youtube.com", Utils.getBaseUrl("https://www.youtube.com/watch?v=Hu80uDzh8RY"));
+        assertEquals("vnd.youtube", Utils.getBaseUrl("vnd.youtube://www.youtube.com/watch?v=jZViOEv90dI"));
+        assertEquals("vnd.youtube", Utils.getBaseUrl("vnd.youtube:jZViOEv90dI"));
+        assertEquals("vnd.youtube", Utils.getBaseUrl("vnd.youtube://n8X9_MgEdCg"));
+        assertEquals("https://music.youtube.com", Utils.getBaseUrl("https://music.youtube.com/watch?v=O0EDx9WAelc"));
+    }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

This PR handles *Google search redirect URL*s such as `https://www.google.it/url?sa=t&rct=j&q=&esrc=s&cd=&cad=rja&uact=8&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DHu80uDzh8RY&source=video` by extracting the `url=` parameter before anything else happens. For this reason `originalUrl`s inside `linkHandler`s are then not really the full original url, but only the extracted parameter, which I think is a good behaviour (those links are redirects, so using the pointed-to url as the original one looks good imo). Also note that *Google search redirect URL*s will be opened in NewPipe only when manually shared to it, since I wouldn't consider a good idea adding the `google` domain to the manifest.

This PR also fixes `baseUrl` extraction from urls with custom intents like "vnd.youtube", thus allowing to remove some useless overrides of `getUrl`.

Fixes TeamNewPipe/NewPipe#3790
Test apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/4840633/app-debug.zip)
@webber-naut please check if this suits you, thank you in advance ;-)