### PR TITLE
Fix parsing Soundcloud tracks that contain the term 'sets'

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
@@ -30,8 +30,6 @@ public class SoundcloudStreamLinkHandlerFactory extends LinkHandlerFactory {
     @Override
     public String getId(String url) throws ParsingException {
         Utils.checkUrl(URL_PATTERN, url);
-        // Remove the tailing slash from URLs due to issues with the SoundCloud API
-        if (url.charAt(url.length() -1) == '/') url = url.substring(0, url.length()-1);
 
         try {
             return SoundcloudParsingHelper.resolveIdWithEmbedPlayer(url);

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamLinkHandlerFactoryTest.java
@@ -53,6 +53,7 @@ public class SoundcloudStreamLinkHandlerFactoryTest {
         assertEquals("309689103", linkHandler.fromUrl("https://soundcloud.com/liluzivert/15-ysl").getId());
         assertEquals("309689082", linkHandler.fromUrl("https://www.soundcloud.com/liluzivert/15-luv-scars-ko").getId());
         assertEquals("309689035", linkHandler.fromUrl("http://soundcloud.com/liluzivert/15-boring-shit").getId());
+        assertEquals("259273264", linkHandler.fromUrl("https://soundcloud.com/liluzivert/ps-qs-produced-by-don-cannon/").getId());
         assertEquals("294488599", linkHandler.fromUrl("http://www.soundcloud.com/liluzivert/secure-the-bag-produced-by-glohan-beats").getId());
         assertEquals("294488438", linkHandler.fromUrl("HtTpS://sOuNdClOuD.cOm/LiLuZiVeRt/In-O4-pRoDuCeD-bY-dP-bEaTz").getId());
         assertEquals("294488147", linkHandler.fromUrl("https://soundcloud.com/liluzivert/fresh-produced-by-zaytoven#t=69").getId());
@@ -60,6 +61,7 @@ public class SoundcloudStreamLinkHandlerFactoryTest {
         assertEquals("294487684", linkHandler.fromUrl("https://soundcloud.com/liluzivert/blonde-brigitte-produced-manny-fresh#t=1:9").getId());
         assertEquals("294487428", linkHandler.fromUrl("https://soundcloud.com/liluzivert/today-produced-by-c-note#t=1m9s").getId());
         assertEquals("294487157", linkHandler.fromUrl("https://soundcloud.com/liluzivert/changed-my-phone-produced-by-c-note#t=1m09s").getId());
+        assertEquals("44556776", linkHandler.fromUrl("https://soundcloud.com/kechuspider-sets-1/last-days").getId());
     }
 
 


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

In the current builds of newpipe, if a track contained the term _sets_ in their url, regardless of position, it would be treated as a playlist, causing a ParsingException.
On the assumption that all sets on the soundcloud URL scheme that playlist sets are always within slashes, this should provide an adequate solution

Before the change, the following Exception would be displayed
## Exception
* __User Action:__ requested stream
* __Request:__ https://soundcloud.com/armadamusic/armin-van-buuren-a-state-of-trance-650-warm-up-sets-out-now
* __Content Country:__ AU
* __Content Language:__ en-AU
* __App Language:__ en_AU
* __Service:__ SoundCloud
* __Version:__ 0.20.0
* __OS:__ Linux Android 8.1.0 - 27
<details><summary><b>Crash log </b></summary><p>

```
org.schabi.newpipe.extractor.exceptions.ParsingException: failed to find pattern ""uri":\s*"https:\/\/api\.soundcloud\.com\/playlists\/((\d)*?)"
	at org.schabi.newpipe.extractor.services.soundcloud.linkHandler.SoundcloudStreamLinkHandlerFactory.getId(SoundcloudStreamLinkHandlerFactory.java:37)
	at org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory.fromUrl(LinkHandlerFactory.java:57)
	at org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory.fromUrl(LinkHandlerFactory.java:48)
	at org.schabi.newpipe.extractor.StreamingService.getStreamExtractor(StreamingService.java:261)
	at org.schabi.newpipe.extractor.stream.StreamInfo.getInfo(StreamInfo.java:64)
	at org.schabi.newpipe.util.ExtractorHelper.lambda$getStreamInfo$3(ExtractorHelper.java:116)
	at org.schabi.newpipe.util.-$$Lambda$ExtractorHelper$5fJcha6Sq5APJBLdG6osaJby-mc.call(Unknown Source:4)
	at io.reactivex.internal.operators.single.SingleFromCallable.subscribeActual(SingleFromCallable.java:44)
	at io.reactivex.Single.subscribe(Single.java:3666)
	at io.reactivex.internal.operators.single.SingleDoOnSuccess.subscribeActual(SingleDoOnSuccess.java:35)
	at io.reactivex.Single.subscribe(Single.java:3666)
	at io.reactivex.internal.operators.maybe.MaybeFromSingle.subscribeActual(MaybeFromSingle.java:41)
	at io.reactivex.Maybe.subscribe(Maybe.java:4290)
	at io.reactivex.internal.operators.maybe.MaybeConcatArray$ConcatMaybeObserver.drain(MaybeConcatArray.java:153)
	at io.reactivex.internal.operators.maybe.MaybeConcatArray$ConcatMaybeObserver.request(MaybeConcatArray.java:78)
	at io.reactivex.internal.operators.flowable.FlowableElementAtMaybe$ElementAtSubscriber.onSubscribe(FlowableElementAtMaybe.java:66)
	at io.reactivex.internal.operators.maybe.MaybeConcatArray.subscribeActual(MaybeConcatArray.java:42)
	at io.reactivex.Flowable.subscribe(Flowable.java:14935)
	at io.reactivex.internal.operators.flowable.FlowableElementAtMaybe.subscribeActual(FlowableElementAtMaybe.java:36)
	at io.reactivex.Maybe.subscribe(Maybe.java:4290)
	at io.reactivex.internal.operators.maybe.MaybeToSingle.subscribeActual(MaybeToSingle.java:46)
	at io.reactivex.Single.subscribe(Single.java:3666)
	at io.reactivex.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
	at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:578)
	at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
	at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
	at java.lang.Thread.run(Thread.java:764)
Caused by: org.schabi.newpipe.extractor.utils.Parser$RegexException: failed to find pattern ""uri":\s*"https:\/\/api\.soundcloud\.com\/playlists\/((\d)*?)"
	at org.schabi.newpipe.extractor.utils.Parser.matchGroup(Parser.java:72)
	at org.schabi.newpipe.extractor.utils.Parser.matchGroup(Parser.java:61)
	at org.schabi.newpipe.extractor.utils.Parser.matchGroup1(Parser.java:52)
	at org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.resolveIdWithEmbedPlayer(SoundcloudParsingHelper.java:157)
	at org.schabi.newpipe.extractor.services.soundcloud.linkHandler.SoundcloudStreamLinkHandlerFactory.getId(SoundcloudStreamLinkHandlerFactory.java:35)
	... 30 more

```
</details>
<hr>

and now the given URL is parsed correctly
![image](https://user-images.githubusercontent.com/12771982/95669581-1b0df480-0bce-11eb-901a-208aca3c58db.png)
