### PR TITLE
Fix SoundCloud test artist account name

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudChannelExtractorTest.java
@@ -41,7 +41,7 @@ public class SoundcloudChannelExtractorTest {
 
         @Test
         public void testName() {
-            assertEquals("LIL UZI VERT", extractor.getName());
+            assertEquals("Lil Uzi Vert", extractor.getName());
         }
 
         @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorDefaultTest.java
@@ -63,7 +63,7 @@ public class SoundcloudStreamExtractorDefaultTest {
 
         @Test
         public void testGetUploaderName() throws ParsingException {
-            assertEquals("LIL UZI VERT", extractor.getUploaderName());
+            assertEquals("Lil Uzi Vert", extractor.getUploaderName());
         }
 
         @Test


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

The account used to run tests on no longer has their account name as specified in the testing suite.
![image](https://user-images.githubusercontent.com/12771982/96207075-0eb2de80-0fb6-11eb-8fc4-440fef11a7ed.png)

There are a few other tests that fail on my system, but I believe this to be a problem with the testing utilities, as my system locale is set to Japanese
![image](https://user-images.githubusercontent.com/12771982/96207152-3e61e680-0fb6-11eb-875a-1ae560dc455b.png)

Ideally, these should be run on controlled accounts run by maintainers. This is something I am not putting my name forward for. In the meantime this is a simple solution