### PR TITLE
Remove tailing slash from SoundCloud URLs

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -46,7 +46,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Override
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
-        track = SoundcloudParsingHelper.resolveFor(downloader, getOriginalUrl());
+        track = SoundcloudParsingHelper.resolveFor(downloader, getUrl());
 
         String policy = track.getString("policy", EMPTY_STRING);
         if (!policy.equals("ALLOW") && !policy.equals("MONETIZE")) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
@@ -30,6 +30,8 @@ public class SoundcloudStreamLinkHandlerFactory extends LinkHandlerFactory {
     @Override
     public String getId(String url) throws ParsingException {
         Utils.checkUrl(URL_PATTERN, url);
+        // Remove the tailing slash from URLs due to issues with the SoundCloud API
+        if (url.charAt(url.length() -1) == '/') url = url.substring(0, url.length()-1);
 
         try {
             return SoundcloudParsingHelper.resolveIdWithEmbedPlayer(url);


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

As researched in the provided issue, SoundCloud do not really support trailing consistently throughout the backend, but work appropriately on the frontend. This change alters NewPipe to remove the trailing slash from any URL, and the streamextractor has been changed to the changed url for fetching content.

Tests have been executed on Android Studio and there appear to be no regressions in functionality