### PR TITLE
create YouTubeCommentsLinkHandlerFactoryTest

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YouTubeCommentsLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YouTubeCommentsLinkHandlerFactoryTest.java
@@ -1,0 +1,64 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.schabi.newpipe.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeCommentsLinkHandlerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class YouTubeCommentsLinkHandlerFactoryTest {
+
+    private static YoutubeCommentsLinkHandlerFactory linkHandler;
+
+    @BeforeClass
+    public static void setUp() {
+        NewPipe.init(DownloaderTestImpl.getInstance());
+        linkHandler = YoutubeCommentsLinkHandlerFactory.getInstance();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getIdWithNullAsUrl() throws ParsingException {
+        linkHandler.fromId(null);
+    }
+
+    @Test
+    public void getIdFromYt() throws ParsingException {
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://www.youtube.com/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://m.youtube.com/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://youtube.com/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://WWW.youtube.com/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://youtu.be/VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://youtu.be/VM_6n762j6M&t=20").getId());
+    }
+
+    @Test
+    public void testAcceptUrl() throws ParsingException {
+        assertTrue(linkHandler.acceptUrl("https://www.youtube.com/watch?v=VM_6n762j6M&t=20"));
+        assertTrue(linkHandler.acceptUrl("https://WWW.youtube.com/watch?v=VM_6n762j6M&t=20"));
+        assertTrue(linkHandler.acceptUrl("https://youtube.com/watch?v=VM_6n762j6M&t=20"));
+        assertTrue(linkHandler.acceptUrl("https://youtu.be/VM_6n762j6M&t=20"));
+    }
+
+    @Test
+    public void testDeniesUrl() throws ParsingException {
+        assertFalse(linkHandler.acceptUrl("https://www.you com/watch?v=VM_6n762j6M"));
+        assertFalse(linkHandler.acceptUrl("https://com/watch?v=VM_6n762j6M"));
+        assertFalse(linkHandler.acceptUrl("htt ://com/watch?v=VM_6n762j6M"));
+        assertFalse(linkHandler.acceptUrl("ftp://www.youtube.com/watch?v=VM_6n762j6M"));
+    }
+
+    @Test
+    public void getIdFromInvidious() throws ParsingException {
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://www.invidio.us/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://invidio.us/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://INVIDIO.US/watch?v=VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://invidio.us/VM_6n762j6M").getId());
+        assertEquals("VM_6n762j6M", linkHandler.fromUrl("https://invidio.us/VM_6n762j6M&t=20").getId());
+    }
+
+}

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -24,31 +24,25 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 public class YoutubeCommentsExtractorTest {
     /**
-     * Test a "normal" YouTube and Invidious page
+     * Test a "normal" YouTube
      */
     public static class Thomas {
-        private static final String urlYT = "https://www.youtube.com/watch?v=D00Au7k3i6o";
-        private static final String urlInvidious = "https://invidio.us/watch?v=D00Au7k3i6o";
-        private static YoutubeCommentsExtractor extractorYT;
-        private static YoutubeCommentsExtractor extractorInvidious;
+        private static final String url = "https://www.youtube.com/watch?v=D00Au7k3i6o";
+        private static YoutubeCommentsExtractor extractor;
 
         private static final String commentContent = "sub 4 sub";
 
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractorYT = (YoutubeCommentsExtractor) YouTube
-                    .getCommentsExtractor(urlYT);
-            extractorYT.fetchPage();
-            extractorInvidious = (YoutubeCommentsExtractor) YouTube
-                    .getCommentsExtractor(urlInvidious);
-            extractorInvidious.fetchPage();
+            extractor = (YoutubeCommentsExtractor) YouTube
+                    .getCommentsExtractor(url);
+            extractor.fetchPage();
         }
 
         @Test
         public void testGetComments() throws IOException, ExtractionException {
-            assertTrue(getCommentsHelper(extractorYT));
-            assertTrue(getCommentsHelper(extractorInvidious));
+            assertTrue(getCommentsHelper(extractor));
         }
 
         private boolean getCommentsHelper(YoutubeCommentsExtractor extractor) throws IOException, ExtractionException {
@@ -65,8 +59,7 @@ public class YoutubeCommentsExtractorTest {
 
         @Test
         public void testGetCommentsFromCommentsInfo() throws IOException, ExtractionException {
-            assertTrue(getCommentsFromCommentsInfoHelper(urlYT));
-            assertTrue(getCommentsFromCommentsInfoHelper(urlInvidious));
+            assertTrue(getCommentsFromCommentsInfoHelper(url));
         }
 
         private boolean getCommentsFromCommentsInfoHelper(String url) throws IOException, ExtractionException {
@@ -87,7 +80,7 @@ public class YoutubeCommentsExtractorTest {
 
         @Test
         public void testGetCommentsAllData() throws IOException, ExtractionException {
-            InfoItemsPage<CommentsInfoItem> comments = extractorYT.getInitialPage();
+            InfoItemsPage<CommentsInfoItem> comments = extractor.getInitialPage();
 
             DefaultTests.defaultTestListOfItems(YouTube, comments.getItems(), comments.getErrors());
             for (CommentsInfoItem c : comments.getItems()) {


### PR DESCRIPTION
and remove invidious test from YouTubeCommentsExtractorTest, because it was just testing if the URL is accepted, then the extractor does the same thing, we don't need to test the same thing twice

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

no need for the last two, it's only about tests

BTW, the test fail but it's expected. See issue #411 
