### PR TITLE
Use Java 9 collection factory methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk8
+  - openjdk9
 
 script:
   - ./gradlew check aggregatedJavadocs

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're using Gradle, you could add NewPipe Extractor as a dependency with the
 1. Add `maven { url 'https://jitpack.io' }` to the `repositories` in your `build.gradle`.
 2. Add `implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.20.1'`the `dependencies` in your `build.gradle`. Replace `v0.20.1` with the latest release.
 
-**Note:** To use NewPipe Extractor in projects with a `minSdkVersion` below 26, [API desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required.
+**Note:** To use NewPipe Extractor in projects with a `minSdkVersion` below 30, [API desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required.
 
 ### Testing changes
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ allprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven'
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.9
+    targetCompatibility = 1.9
 
     version 'v0.20.2'
     group 'com.github.TeamNewPipe'

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
@@ -5,8 +5,6 @@ import org.schabi.newpipe.extractor.services.peertube.PeertubeService;
 import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudService;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeService;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /*
@@ -35,22 +33,16 @@ public final class ServiceList {
         //no instance
     }
 
-    public static final YoutubeService YouTube;
-    public static final SoundcloudService SoundCloud;
-    public static final MediaCCCService MediaCCC;
-    public static final PeertubeService PeerTube;
+    public static final YoutubeService YouTube = new YoutubeService(0);
+    public static final SoundcloudService SoundCloud = new SoundcloudService(1);
+    public static final MediaCCCService MediaCCC = new MediaCCCService(2);
+    public static final PeertubeService PeerTube = new PeertubeService(3);
 
     /**
      * When creating a new service, put this service in the end of this list,
      * and give it the next free id.
      */
-    private static final List<StreamingService> SERVICES = Collections.unmodifiableList(
-            Arrays.asList(
-                    YouTube = new YoutubeService(0),
-                    SoundCloud = new SoundcloudService(1),
-                    MediaCCC = new MediaCCCService(2),
-                    PeerTube = new PeertubeService(3)
-            ));
+    private static final List<StreamingService> SERVICES = List.of(YouTube, SoundCloud, MediaCCC, PeerTube);
 
     /**
      * Get all the supported services.

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
@@ -19,7 +19,6 @@ import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 
 /*
@@ -53,11 +52,11 @@ public abstract class StreamingService {
         /**
          * Creates a new instance of a ServiceInfo
          * @param name the name of the service
-         * @param mediaCapabilities the type of media this service can handle
+         * @param mediaCapabilities the type of media this service can handle, has to be an immutable list
          */
         public ServiceInfo(String name, List<MediaCapability> mediaCapabilities) {
             this.name = name;
-            this.mediaCapabilities = Collections.unmodifiableList(mediaCapabilities);
+            this.mediaCapabilities = mediaCapabilities;
         }
 
         public String getName() {
@@ -95,7 +94,7 @@ public abstract class StreamingService {
      * All other parameters can be set directly from the overriding constructor.
      * @param id the number of the service to identify him within the NewPipe frontend
      * @param name the name of the service
-     * @param capabilities the type of media this service can handle
+     * @param capabilities the type of media this service can handle, has to be an immutable list
      */
     public StreamingService(int id, String name, List<ServiceInfo.MediaCapability> capabilities) {
         this.serviceId = id;
@@ -305,14 +304,14 @@ public abstract class StreamingService {
      * Returns a list of localizations that this service supports.
      */
     public List<Localization> getSupportedLocalizations() {
-        return Collections.singletonList(Localization.DEFAULT);
+        return List.of(Localization.DEFAULT);
     }
 
     /**
      * Returns a list of countries that this service supports.<br>
      */
     public List<ContentCountry> getSupportedCountries() {
-        return Collections.singletonList(ContentCountry.DEFAULT);
+        return List.of(ContentCountry.DEFAULT);
     }
 
     /**

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Request.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Request.java
@@ -213,13 +213,12 @@ public class Request {
         }
 
         public Builder setHeader(String headerName, String headerValue) {
-            return setHeaders(headerName, Collections.singletonList(headerValue));
+            return setHeaders(headerName, List.of(headerValue));
         }
 
         public Builder addHeader(String headerName, String headerValue) {
-            return addHeaders(headerName, Collections.singletonList(headerValue));
+            return addHeaders(headerName, List.of(headerValue));
         }
-
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -231,14 +230,14 @@ public class Request {
     public static Map<String, List<String>> headersFromLocalization(@Nullable Localization localization) {
         if (localization == null) return Collections.emptyMap();
 
-        final Map<String, List<String>> headers = new LinkedHashMap<>();
+        final List<String> acceptLanguage;
         if (!localization.getCountryCode().isEmpty()) {
-            headers.put("Accept-Language", Collections.singletonList(localization.getLocalizationCode() +
-                    ", " + localization.getLanguageCode() + ";q=0.9"));
+            acceptLanguage = List.of(localization.getLocalizationCode() +
+                    ", " + localization.getLanguageCode() + ";q=0.9");
         } else {
-            headers.put("Accept-Language", Collections.singletonList(localization.getLanguageCode()));
+            acceptLanguage = List.of(localization.getLanguageCode());
         }
 
-        return headers;
+        return Map.of("Accept-Language", acceptLanguage);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandler.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandler.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.extractor.linkhandler;
 
-import java.util.Collections;
 import java.util.List;
 
 public class ListLinkHandler extends LinkHandler {
@@ -13,7 +12,7 @@ public class ListLinkHandler extends LinkHandler {
                            List<String> contentFilters,
                            String sortFilter) {
         super(originalUrl, url, id);
-        this.contentFilters = Collections.unmodifiableList(contentFilters);
+        this.contentFilters = contentFilters;
         this.sortFilter = sortFilter;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ListLinkHandlerFactory.java
@@ -13,7 +13,7 @@ public abstract class ListLinkHandlerFactory extends LinkHandlerFactory {
     ///////////////////////////////////
 
     public List<String> getContentFilter(String url) throws ParsingException {
-        return new ArrayList<>(0);
+        return List.of();
     }
 
     public String getSortFilter(String url) throws ParsingException {
@@ -46,12 +46,12 @@ public abstract class ListLinkHandlerFactory extends LinkHandlerFactory {
 
     @Override
     public ListLinkHandler fromId(String id) throws ParsingException {
-        return new ListLinkHandler(super.fromId(id), new ArrayList<String>(0), "");
+        return new ListLinkHandler(super.fromId(id), List.of(), "");
     }
 
     @Override
     public ListLinkHandler fromId(String id, String baseUrl) throws ParsingException {
-        return new ListLinkHandler(super.fromId(id, baseUrl), new ArrayList<String>(0), "");
+        return new ListLinkHandler(super.fromId(id, baseUrl), List.of(), "");
     }
 
     public ListLinkHandler fromQuery(String id,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/SearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/SearchQueryHandlerFactory.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.linkhandler;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public abstract class SearchQueryHandlerFactory extends ListLinkHandlerFactory {
@@ -35,7 +34,7 @@ public abstract class SearchQueryHandlerFactory extends ListLinkHandlerFactory {
     }
 
     public SearchQueryHandler fromQuery(String querry) throws ParsingException {
-        return fromQuery(querry, new ArrayList<String>(0), "");
+        return fromQuery(querry, List.of(), "");
     }
 
     /**

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
@@ -6,12 +6,7 @@ import org.schabi.newpipe.extractor.comments.CommentsExtractor;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.kiosk.KioskList;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
-import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
-import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.linkhandler.*;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.media_ccc.extractors.MediaCCCConferenceExtractor;
@@ -26,13 +21,14 @@ import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.AUDIO;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
 
 public class MediaCCCService extends StreamingService {
     public MediaCCCService(final int id) {
-        super(id, "MediaCCC", asList(AUDIO, VIDEO));
+        super(id, "MediaCCC", List.of(AUDIO, VIDEO));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/PeertubeService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/PeertubeService.java
@@ -15,7 +15,8 @@ import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.COMMENTS;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
 
@@ -28,7 +29,7 @@ public class PeertubeService extends StreamingService {
     }
 
     public PeertubeService(int id, PeertubeInstance instance) {
-        super(id, "PeerTube", asList(VIDEO, COMMENTS));
+        super(id, "PeerTube", List.of(VIDEO, COMMENTS));
         this.instance = instance;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
@@ -22,12 +22,12 @@ public class PeertubeTrendingLinkHandlerFactory extends ListLinkHandlerFactory {
     public static final String KIOSK_LOCAL = "Local";
 
     static {
-        Map<String, String> map = new HashMap<>();
-        map.put(KIOSK_TRENDING, "%s/api/v1/videos?sort=-trending");
-        map.put(KIOSK_MOST_LIKED, "%s/api/v1/videos?sort=-likes");
-        map.put(KIOSK_RECENT, "%s/api/v1/videos?sort=-publishedAt");
-        map.put(KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&filter=local");
-        KIOSK_MAP = Collections.unmodifiableMap(map);
+        KIOSK_MAP = Map.of(
+                KIOSK_TRENDING, "%s/api/v1/videos?sort=-trending",
+                KIOSK_MOST_LIKED, "%s/api/v1/videos?sort=-likes",
+                KIOSK_RECENT, "%s/api/v1/videos?sort=-publishedAt",
+                KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&filter=local"
+        );
 
         Map<String, String> reverseMap = new HashMap<>();
         for (Map.Entry<String, String> entry : KIOSK_MAP.entrySet()) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -32,10 +32,9 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 import static org.schabi.newpipe.extractor.utils.JsonUtils.EMPTY_STRING;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
@@ -68,8 +67,7 @@ public class SoundcloudParsingHelper {
         // The one containing the client id will likely be the last one
         Collections.reverse(possibleScripts);
 
-        final HashMap<String, List<String>> headers = new HashMap<>();
-        headers.put("Range", singletonList("bytes=0-16384"));
+        final Map<String, List<String>> headers = Map.of("Range", List.of("bytes=0-16384"));
 
         for (Element element : possibleScripts) {
             final String srcUrl = element.attr("src");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudService.java
@@ -17,14 +17,13 @@ import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.AUDIO;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.COMMENTS;
 
 public class SoundcloudService extends StreamingService {
 
     public SoundcloudService(int id) {
-        super(id, "SoundCloud", asList(AUDIO, COMMENTS));
+        super(id, "SoundCloud", List.of(AUDIO, COMMENTS));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSubscriptionExtractor.java
@@ -10,16 +10,14 @@ import org.schabi.newpipe.extractor.subscription.SubscriptionItem;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * Extract the "followings" from a user in SoundCloud.
  */
 public class SoundcloudSubscriptionExtractor extends SubscriptionExtractor {
-
     public SoundcloudSubscriptionExtractor(SoundcloudService service) {
-        super(service, Collections.singletonList(ContentSource.CHANNEL_URL));
+        super(service, List.of(ContentSource.CHANNEL_URL));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -1,10 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
-import com.grack.nanojson.JsonArray;
-import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
-import com.grack.nanojson.JsonWriter;
+import com.grack.nanojson.*;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.downloader.Response;
@@ -25,16 +21,12 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.schabi.newpipe.extractor.NewPipe.getDownloader;
 import static org.schabi.newpipe.extractor.utils.JsonUtils.EMPTY_STRING;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
-import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.*;
 
 /*
  * Created by Christian Schabesberger on 02.03.16.
@@ -211,10 +203,10 @@ public class YoutubeParsingHelper {
     public static boolean isHardcodedClientVersionValid() throws IOException, ExtractionException {
         final String url = "https://www.youtube.com/results?search_query=test&pbj=1";
 
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version",
-                Collections.singletonList(HARDCODED_CLIENT_VERSION));
+        Map<String, List<String>> headers = Map.of(
+                "X-YouTube-Client-Name", List.of("1"),
+                "X-YouTube-Client-Version", List.of(HARDCODED_CLIENT_VERSION)
+        );
         final String response = getDownloader().get(url, headers).responseBody();
 
         return response.length() > 50; // ensure to have a valid response
@@ -337,12 +329,13 @@ public class YoutubeParsingHelper {
             .end().done().getBytes("UTF-8");
         // @formatter:on
 
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList(HARDCODED_YOUTUBE_MUSIC_KEYS[1]));
-        headers.put("X-YouTube-Client-Version", Collections.singletonList(HARDCODED_YOUTUBE_MUSIC_KEYS[2]));
-        headers.put("Origin", Collections.singletonList("https://music.youtube.com"));
-        headers.put("Referer", Collections.singletonList("music.youtube.com"));
-        headers.put("Content-Type", Collections.singletonList("application/json"));
+        Map<String, List<String>> headers = Map.of(
+                "X-YouTube-Client-Name", List.of(HARDCODED_YOUTUBE_MUSIC_KEYS[1]),
+                "X-YouTube-Client-Version", List.of(HARDCODED_YOUTUBE_MUSIC_KEYS[2]),
+                "Origin", List.of("https://music.youtube.com"),
+                "Referer", List.of("music.youtube.com"),
+                "Content-Type", List.of("application/json")
+        );
 
         String response = getDownloader().post(url, headers, json).responseBody();
 
@@ -517,9 +510,10 @@ public class YoutubeParsingHelper {
 
     public static JsonArray getJsonResponse(final String url, final Localization localization)
             throws IOException, ExtractionException {
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList("1"));
-        headers.put("X-YouTube-Client-Version", Collections.singletonList(getClientVersion()));
+        Map<String, List<String>> headers = Map.of(
+                "X-YouTube-Client-Name", List.of("1"),
+                "X-YouTube-Client-Version", List.of(getClientVersion())
+        );
         final Response response = getDownloader().get(url, headers, localization);
 
         final String responseBody = getValidJsonResponseBody(response);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -7,45 +7,21 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.feed.FeedExtractor;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.kiosk.KioskList;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
-import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
-import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
-import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.linkhandler.*;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeChannelExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeFeedExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeMusicSearchExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubePlaylistExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSearchExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSubscriptionExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeSuggestionExtractor;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeTrendingExtractor;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeCommentsLinkHandlerFactory;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory;
-import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeTrendingLinkHandlerFactory;
+import org.schabi.newpipe.extractor.services.youtube.extractors.*;
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.*;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-
-import static java.util.Arrays.asList;
-import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.AUDIO;
-import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.COMMENTS;
-import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.LIVE;
-import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
+import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.*;
 
 /*
  * Created by Christian Schabesberger on 23.08.15.
@@ -70,7 +46,7 @@ import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCap
 public class YoutubeService extends StreamingService {
 
     public YoutubeService(int id) {
-        super(id, "YouTube", asList(AUDIO, VIDEO, LIVE, COMMENTS));
+        super(id, "YouTube", List.of(AUDIO, VIDEO, LIVE, COMMENTS));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
-
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.comments.CommentsExtractor;
@@ -19,17 +18,14 @@ import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Parser;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nonnull;
-
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 public class YoutubeCommentsExtractor extends CommentsExtractor {
@@ -72,10 +68,11 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
     }
 
     private Page getNextPage(String continuation) throws ParsingException {
-        Map<String, String> params = new HashMap<>();
-        params.put("action_get_comments", "1");
-        params.put("pbj", "1");
-        params.put("ctoken", continuation);
+        Map<String, String> params = Map.of(
+                "action_get_comments", "1",
+                "pbj", "1",
+                "ctoken", continuation
+        );
         try {
             return new Page("https://m.youtube.com/watch_comment?" + getDataString(params));
         } catch (UnsupportedEncodingException e) {
@@ -126,21 +123,20 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
 
     @Override
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
-        final Map<String, List<String>> requestHeaders = new HashMap<>();
-        requestHeaders.put("User-Agent", singletonList(USER_AGENT));
+        final Map<String, List<String>> requestHeaders = Map.of("User-Agent", List.of(USER_AGENT));
         final Response response = downloader.get(getUrl(), requestHeaders, getExtractorLocalization());
         responseBody = response.responseBody();
         ytClientVersion = findValue(responseBody, "INNERTUBE_CONTEXT_CLIENT_VERSION\":\"", "\"");
         ytClientName = Parser.matchGroup1(YT_CLIENT_NAME_PATTERN, responseBody);
     }
 
-
     private String makeAjaxRequest(String siteUrl) throws IOException, ReCaptchaException {
-        Map<String, List<String>> requestHeaders = new HashMap<>();
-        requestHeaders.put("Accept", singletonList("*/*"));
-        requestHeaders.put("User-Agent", singletonList(USER_AGENT));
-        requestHeaders.put("X-YouTube-Client-Version", singletonList(ytClientVersion));
-        requestHeaders.put("X-YouTube-Client-Name", singletonList(ytClientName));
+        Map<String, List<String>> requestHeaders = Map.of(
+                "Accept", List.of("*/*"),
+                "User-Agent", List.of(USER_AGENT),
+                "X-YouTube-Client-Version", List.of(ytClientVersion),
+                "X-YouTube-Client-Name", List.of(ytClientName)
+        );
         return getDownloader().get(siteUrl, requestHeaders, getExtractorLocalization()).responseBody();
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -1,11 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
-import com.grack.nanojson.JsonArray;
-import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
-import com.grack.nanojson.JsonWriter;
-
+import com.grack.nanojson.*;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -22,20 +17,13 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nonnull;
-
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.*;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_ALBUMS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_ARTISTS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_PLAYLISTS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_SONGS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_VIDEOS;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.*;
 import static org.schabi.newpipe.extractor.utils.JsonUtils.EMPTY_STRING;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
@@ -105,12 +93,13 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
             .end().done().getBytes("UTF-8");
         // @formatter:on
 
-        final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList(youtubeMusicKeys[1]));
-        headers.put("X-YouTube-Client-Version", Collections.singletonList(youtubeMusicKeys[2]));
-        headers.put("Origin", Collections.singletonList("https://music.youtube.com"));
-        headers.put("Referer", Collections.singletonList("music.youtube.com"));
-        headers.put("Content-Type", Collections.singletonList("application/json"));
+        final Map<String, List<String>> headers = Map.of(
+                "X-YouTube-Client-Name", List.of(youtubeMusicKeys[1]),
+                "X-YouTube-Client-Version", List.of(youtubeMusicKeys[2]),
+                "Origin", List.of("https://music.youtube.com"),
+                "Referer", List.of("music.youtube.com"),
+                "Content-Type", List.of("application/json")
+        );
 
         final String responseBody = getValidJsonResponseBody(getDownloader().post(url, headers, json));
 
@@ -223,12 +212,13 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
             .end().done().getBytes("UTF-8");
         // @formatter:on
 
-        final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("X-YouTube-Client-Name", Collections.singletonList(youtubeMusicKeys[1]));
-        headers.put("X-YouTube-Client-Version", Collections.singletonList(youtubeMusicKeys[2]));
-        headers.put("Origin", Collections.singletonList("https://music.youtube.com"));
-        headers.put("Referer", Collections.singletonList("music.youtube.com"));
-        headers.put("Content-Type", Collections.singletonList("application/json"));
+        final Map<String, List<String>> headers = Map.of(
+                "X-YouTube-Client-Name", List.of(youtubeMusicKeys[1]),
+                "X-YouTube-Client-Version", List.of(youtubeMusicKeys[2]),
+                "Origin", List.of("https://music.youtube.com"),
+                "Referer", List.of("music.youtube.com"),
+                "Content-Type", List.of("application/json")
+        );
 
         final String responseBody = getValidJsonResponseBody(getDownloader().post(page.getUrl(), headers, json));
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -1,11 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
-import com.grack.nanojson.JsonArray;
-import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonParserException;
-import com.grack.nanojson.JsonWriter;
-
+import com.grack.nanojson.*;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -18,19 +13,12 @@ import org.schabi.newpipe.extractor.search.InfoItemsSearchCollector;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nonnull;
-
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getClientVersion;
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonResponse;
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getKey;
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getValidJsonResponseBody;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.*;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 /*
@@ -168,10 +156,11 @@ public class YoutubeSearchExtractor extends SearchExtractor {
                 .end().done().getBytes("UTF-8");
             // @formatter:on
 
-            final Map<String, List<String>> headers = new HashMap<>();
-            headers.put("Origin", Collections.singletonList("https://www.youtube.com"));
-            headers.put("Referer", Collections.singletonList(this.getUrl()));
-            headers.put("Content-Type", Collections.singletonList("application/json"));
+            final Map<String, List<String>> headers = Map.of(
+                    "Origin", List.of("https://www.youtube.com"),
+                    "Referer", List.of(getUrl()),
+                    "Content-Type", List.of("application/json")
+            );
 
             final String responseBody = getValidJsonResponseBody(getDownloader().post(page.getUrl(), headers, json));
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
@@ -4,18 +4,15 @@ import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
-
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeService;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionItem;
 
+import javax.annotation.Nonnull;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Nonnull;
 
 import static org.schabi.newpipe.extractor.subscription.SubscriptionExtractor.ContentSource.INPUT_STREAM;
 
@@ -26,7 +23,7 @@ public class YoutubeSubscriptionExtractor extends SubscriptionExtractor {
     private static final String BASE_CHANNEL_URL = "https://www.youtube.com/channel/";
 
     public YoutubeSubscriptionExtractor(final YoutubeService youtubeService) {
-        super(youtubeService, Collections.singletonList(INPUT_STREAM));
+        super(youtubeService, List.of(INPUT_STREAM));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/subscription/SubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/subscription/SubscriptionExtractor.java
@@ -8,7 +8,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class SubscriptionExtractor {
@@ -44,7 +43,7 @@ public abstract class SubscriptionExtractor {
 
     public SubscriptionExtractor(StreamingService service, List<ContentSource> supportedSources) {
         this.service = service;
-        this.supportedSources = Collections.unmodifiableList(supportedSources);
+        this.supportedSources = supportedSources;
     }
 
     public List<ContentSource> getSupportedSources() {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/search/MediaCCCSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/search/MediaCCCSearchExtractorTest.java
@@ -9,8 +9,8 @@ import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.ServiceList.MediaCCC;
 import static org.schabi.newpipe.extractor.services.media_ccc.linkHandler.MediaCCCSearchQueryHandlerFactory.CONFERENCES;
 import static org.schabi.newpipe.extractor.services.media_ccc.linkHandler.MediaCCCSearchQueryHandlerFactory.EVENTS;
@@ -46,7 +46,7 @@ public class MediaCCCSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = MediaCCC.getSearchExtractor(QUERY, singletonList(CONFERENCES), "");
+            extractor = MediaCCC.getSearchExtractor(QUERY, List.of(CONFERENCES), "");
             extractor.fetchPage();
         }
 
@@ -70,7 +70,7 @@ public class MediaCCCSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = MediaCCC.getSearchExtractor(QUERY, singletonList(EVENTS), "");
+            extractor = MediaCCC.getSearchExtractor(QUERY, List.of(EVENTS), "");
             extractor.fetchPage();
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/search/PeertubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/search/PeertubeSearchExtractorTest.java
@@ -12,8 +12,8 @@ import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeInstance;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.ServiceList.PeerTube;
 import static org.schabi.newpipe.extractor.services.DefaultTests.assertNoDuplicatedItems;
 import static org.schabi.newpipe.extractor.services.peertube.linkHandler.PeertubeSearchQueryHandlerFactory.VIDEOS;
@@ -47,7 +47,7 @@ public class PeertubeSearchExtractorTest {
         @Test
         public void duplicatedItemsCheck() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            final SearchExtractor extractor = PeerTube.getSearchExtractor("internet", singletonList(VIDEOS), "");
+            final SearchExtractor extractor = PeerTube.getSearchExtractor("internet", List.of(VIDEOS), "");
             extractor.fetchPage();
 
             final InfoItemsPage<InfoItem> page1 = extractor.getInitialPage();

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchExtractorTest.java
@@ -13,8 +13,8 @@ import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 import static org.schabi.newpipe.extractor.services.DefaultTests.assertNoDuplicatedItems;
 import static org.schabi.newpipe.extractor.services.soundcloud.linkHandler.SoundcloudSearchQueryHandlerFactory.*;
@@ -49,7 +49,7 @@ public class SoundcloudSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = SoundCloud.getSearchExtractor(QUERY, singletonList(TRACKS), "");
+            extractor = SoundCloud.getSearchExtractor(QUERY, List.of(TRACKS), "");
             extractor.fetchPage();
         }
 
@@ -72,7 +72,7 @@ public class SoundcloudSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = SoundCloud.getSearchExtractor(QUERY, singletonList(USERS), "");
+            extractor = SoundCloud.getSearchExtractor(QUERY, List.of(USERS), "");
             extractor.fetchPage();
         }
 
@@ -95,7 +95,7 @@ public class SoundcloudSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = SoundCloud.getSearchExtractor(QUERY, singletonList(PLAYLISTS), "");
+            extractor = SoundCloud.getSearchExtractor(QUERY, List.of(PLAYLISTS), "");
             extractor.fetchPage();
         }
 
@@ -115,7 +115,7 @@ public class SoundcloudSearchExtractorTest {
         @Test
         public void duplicatedItemsCheck() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            final SearchExtractor extractor = SoundCloud.getSearchExtractor("cirque du soleil", singletonList(TRACKS), "");
+            final SearchExtractor extractor = SoundCloud.getSearchExtractor("cirque du soleil", List.of(TRACKS), "");
             extractor.fetchPage();
 
             final InfoItemsPage<InfoItem> page1 = extractor.getInitialPage();

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQHTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/search/SoundcloudSearchQHTest.java
@@ -5,7 +5,8 @@ import org.junit.Test;
 import org.schabi.newpipe.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 import static org.schabi.newpipe.extractor.services.soundcloud.linkHandler.SoundcloudSearchQueryHandlerFactory.*;
@@ -39,21 +40,21 @@ public class SoundcloudSearchQHTest {
     @Test
     public void testGetContentFilter() throws Exception {
         assertEquals("tracks", SoundCloud.getSearchQHFactory()
-                .fromQuery("", asList(new String[]{"tracks"}), "").getContentFilters().get(0));
+                .fromQuery("", List.of("tracks"), "").getContentFilters().get(0));
         assertEquals("users", SoundCloud.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{"users"}), "").getContentFilters().get(0));
+                .fromQuery("asdf", List.of("users"), "").getContentFilters().get(0));
     }
 
     @Test
     public void testWithContentfilter() throws Exception {
         assertEquals("https://api-v2.soundcloud.com/search/tracks?q=asdf&limit=10&offset=0", removeClientId(SoundCloud.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{TRACKS}), "").getUrl()));
+                .fromQuery("asdf", List.of(TRACKS), "").getUrl()));
         assertEquals("https://api-v2.soundcloud.com/search/users?q=asdf&limit=10&offset=0", removeClientId(SoundCloud.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{USERS}), "").getUrl()));
+                .fromQuery("asdf", List.of(USERS), "").getUrl()));
         assertEquals("https://api-v2.soundcloud.com/search/playlists?q=asdf&limit=10&offset=0", removeClientId(SoundCloud.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{PLAYLISTS}), "").getUrl()));
+                .fromQuery("asdf", List.of(PLAYLISTS), "").getUrl()));
         assertEquals("https://api-v2.soundcloud.com/search?q=asdf&limit=10&offset=0", removeClientId(SoundCloud.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{"fjiijie"}), "").getUrl()));
+                .fromQuery("asdf", List.of("fjiijie"), "").getUrl()));
     }
 
     @Test

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeMusicSearchExtractorTest.java
@@ -10,11 +10,10 @@ import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory;
 
-import java.net.URLEncoder;
-
 import javax.annotation.Nullable;
+import java.net.URLEncoder;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 public class YoutubeMusicSearchExtractorTest {
@@ -25,7 +24,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
             extractor.fetchPage();
         }
 
@@ -47,7 +46,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_VIDEOS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_VIDEOS), "");
             extractor.fetchPage();
         }
 
@@ -69,7 +68,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_ALBUMS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_ALBUMS), "");
             extractor.fetchPage();
         }
 
@@ -91,7 +90,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_PLAYLISTS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_PLAYLISTS), "");
             extractor.fetchPage();
         }
 
@@ -114,7 +113,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_ARTISTS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_ARTISTS), "");
             extractor.fetchPage();
         }
 
@@ -136,7 +135,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
             extractor.fetchPage();
         }
 
@@ -159,7 +158,7 @@ public class YoutubeMusicSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(YoutubeSearchQueryHandlerFactory.MUSIC_SONGS), "");
             extractor.fetchPage();
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -11,17 +11,15 @@ import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.services.DefaultSearchExtractorTest;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertEmptyErrors;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.services.DefaultTests.assertNoDuplicatedItems;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.CHANNELS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.PLAYLISTS;
-import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.VIDEOS;
+import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.*;
 
 public class YoutubeSearchExtractorTest {
     public static class All extends DefaultSearchExtractorTest {
@@ -52,7 +50,7 @@ public class YoutubeSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(CHANNELS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(CHANNELS), "");
             extractor.fetchPage();
         }
 
@@ -75,7 +73,7 @@ public class YoutubeSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(PLAYLISTS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(PLAYLISTS), "");
             extractor.fetchPage();
         }
 
@@ -98,7 +96,7 @@ public class YoutubeSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(VIDEOS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(VIDEOS), "");
             extractor.fetchPage();
         }
 
@@ -122,7 +120,7 @@ public class YoutubeSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(VIDEOS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(VIDEOS), "");
             extractor.fetchPage();
         }
 
@@ -145,7 +143,7 @@ public class YoutubeSearchExtractorTest {
         @BeforeClass
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            extractor = YouTube.getSearchExtractor(QUERY, singletonList(VIDEOS), "");
+            extractor = YouTube.getSearchExtractor(QUERY, List.of(VIDEOS), "");
             extractor.fetchPage();
         }
 
@@ -202,7 +200,7 @@ public class YoutubeSearchExtractorTest {
         @Test
         public void duplicatedItemsCheck() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
-            final SearchExtractor extractor = YouTube.getSearchExtractor("cirque du soleil", singletonList(VIDEOS), "");
+            final SearchExtractor extractor = YouTube.getSearchExtractor("cirque du soleil", List.of(VIDEOS), "");
             extractor.fetchPage();
 
             final ListExtractor.InfoItemsPage<InfoItem> page1 = extractor.getInitialPage();

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchQHTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchQHTest.java
@@ -2,7 +2,8 @@ package org.schabi.newpipe.extractor.services.youtube.search;
 
 import org.junit.Test;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.*;
@@ -17,37 +18,37 @@ public class YoutubeSearchQHTest {
         assertEquals("https://www.youtube.com/results?search_query=G%C3%BCl%C3%BCm", YouTube.getSearchQHFactory().fromQuery("Gülüm").getUrl());
         assertEquals("https://www.youtube.com/results?search_query=%3Fj%24%29H%C2%A7B", YouTube.getSearchQHFactory().fromQuery("?j$)H§B").getUrl());
 
-        assertEquals("https://music.youtube.com/search?q=asdf", YouTube.getSearchQHFactory().fromQuery("asdf", asList(new String[]{MUSIC_SONGS}), "").getUrl());
-        assertEquals("https://music.youtube.com/search?q=hans", YouTube.getSearchQHFactory().fromQuery("hans", asList(new String[]{MUSIC_SONGS}), "").getUrl());
-        assertEquals("https://music.youtube.com/search?q=Poifj%26jaijf", YouTube.getSearchQHFactory().fromQuery("Poifj&jaijf", asList(new String[]{MUSIC_SONGS}), "").getUrl());
-        assertEquals("https://music.youtube.com/search?q=G%C3%BCl%C3%BCm", YouTube.getSearchQHFactory().fromQuery("Gülüm", asList(new String[]{MUSIC_SONGS}), "").getUrl());
-        assertEquals("https://music.youtube.com/search?q=%3Fj%24%29H%C2%A7B", YouTube.getSearchQHFactory().fromQuery("?j$)H§B", asList(new String[]{MUSIC_SONGS}), "").getUrl());
+        assertEquals("https://music.youtube.com/search?q=asdf", YouTube.getSearchQHFactory().fromQuery("asdf", List.of(MUSIC_SONGS), "").getUrl());
+        assertEquals("https://music.youtube.com/search?q=hans", YouTube.getSearchQHFactory().fromQuery("hans", List.of(MUSIC_SONGS), "").getUrl());
+        assertEquals("https://music.youtube.com/search?q=Poifj%26jaijf", YouTube.getSearchQHFactory().fromQuery("Poifj&jaijf", List.of(MUSIC_SONGS), "").getUrl());
+        assertEquals("https://music.youtube.com/search?q=G%C3%BCl%C3%BCm", YouTube.getSearchQHFactory().fromQuery("Gülüm", List.of(MUSIC_SONGS), "").getUrl());
+        assertEquals("https://music.youtube.com/search?q=%3Fj%24%29H%C2%A7B", YouTube.getSearchQHFactory().fromQuery("?j$)H§B", List.of(MUSIC_SONGS), "").getUrl());
     }
 
     @Test
     public void testGetContentFilter() throws Exception {
         assertEquals(VIDEOS, YouTube.getSearchQHFactory()
-                .fromQuery("", asList(new String[]{VIDEOS}), "").getContentFilters().get(0));
+                .fromQuery("", List.of(VIDEOS), "").getContentFilters().get(0));
         assertEquals(CHANNELS, YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{CHANNELS}), "").getContentFilters().get(0));
+                .fromQuery("asdf", List.of(CHANNELS), "").getContentFilters().get(0));
 
         assertEquals(MUSIC_SONGS, YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{MUSIC_SONGS}), "").getContentFilters().get(0));
+                .fromQuery("asdf", List.of(MUSIC_SONGS), "").getContentFilters().get(0));
     }
 
     @Test
     public void testWithContentfilter() throws Exception {
         assertEquals("https://www.youtube.com/results?search_query=asdf&sp=EgIQAQ%253D%253D", YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{VIDEOS}), "").getUrl());
+                .fromQuery("asdf", List.of(VIDEOS), "").getUrl());
         assertEquals("https://www.youtube.com/results?search_query=asdf&sp=EgIQAg%253D%253D", YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{CHANNELS}), "").getUrl());
+                .fromQuery("asdf", List.of(CHANNELS), "").getUrl());
         assertEquals("https://www.youtube.com/results?search_query=asdf&sp=EgIQAw%253D%253D", YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{PLAYLISTS}), "").getUrl());
+                .fromQuery("asdf", List.of(PLAYLISTS), "").getUrl());
         assertEquals("https://www.youtube.com/results?search_query=asdf", YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{"fjiijie"}), "").getUrl());
+                .fromQuery("asdf", List.of("fjiijie"), "").getUrl());
 
         assertEquals("https://music.youtube.com/search?q=asdf", YouTube.getSearchQHFactory()
-                .fromQuery("asdf", asList(new String[]{MUSIC_SONGS}), "").getUrl());
+                .fromQuery("asdf", List.of(MUSIC_SONGS), "").getUrl());
     }
 
     @Test

--- a/timeago-parser/src/main/java/org/schabi/newpipe/extractor/timeago/PatternsHolder.java
+++ b/timeago-parser/src/main/java/org/schabi/newpipe/extractor/timeago/PatternsHolder.java
@@ -3,9 +3,8 @@ package org.schabi.newpipe.extractor.timeago;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-
-import static java.util.Arrays.asList;
 
 public abstract class PatternsHolder {
     private final String wordSeparator;
@@ -34,8 +33,8 @@ public abstract class PatternsHolder {
 
     protected PatternsHolder(String wordSeparator, String[] seconds, String[] minutes, String[] hours, String[] days,
                              String[] weeks, String[] months, String[] years) {
-        this(wordSeparator, asList(seconds), asList(minutes), asList(hours), asList(days),
-                asList(weeks), asList(months), asList(years));
+        this(wordSeparator, List.of(seconds), List.of(minutes), List.of(hours), List.of(days),
+                List.of(weeks), List.of(months), List.of(years));
     }
 
     public String wordSeparator() {
@@ -81,15 +80,14 @@ public abstract class PatternsHolder {
     }
 
     public Map<ChronoUnit, Collection<String>> asMap() {
-        final Map<ChronoUnit, Collection<String>> returnMap = new LinkedHashMap<>();
-        returnMap.put(ChronoUnit.SECONDS, seconds());
-        returnMap.put(ChronoUnit.MINUTES, minutes());
-        returnMap.put(ChronoUnit.HOURS, hours());
-        returnMap.put(ChronoUnit.DAYS, days());
-        returnMap.put(ChronoUnit.WEEKS, weeks());
-        returnMap.put(ChronoUnit.MONTHS, months());
-        returnMap.put(ChronoUnit.YEARS, years());
-
-        return returnMap;
+        return Map.of(
+                ChronoUnit.SECONDS, seconds(),
+                ChronoUnit.MINUTES, minutes(),
+                ChronoUnit.HOURS, hours(),
+                ChronoUnit.DAYS, days(),
+                ChronoUnit.WEEKS, weeks(),
+                ChronoUnit.MONTHS, months(),
+                ChronoUnit.YEARS, years()
+        );
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

API level 30 added the immutable collection factory methods introduced in Java 9, and these are desugared to support API levels below 30:

![Screenshot 2020-11-05 095605](https://user-images.githubusercontent.com/31027858/98198936-1da30600-1f50-11eb-8576-5e4485c6f1cd.png)

