### PR TITLE
Fix name of media.ccc.de service

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following sites are currently supported:
 
 - YouTube
 - SoundCloud
-- MediaCCC
+- media.ccc.de
 - PeerTube (no P2P)
 
 ## License

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
@@ -32,7 +32,7 @@ import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCap
 
 public class MediaCCCService extends StreamingService {
     public MediaCCCService(final int id) {
-        super(id, "MediaCCC", asList(AUDIO, VIDEO));
+        super(id, "media.ccc.de", asList(AUDIO, VIDEO));
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

(Well, arguably, the last point makes little sense, unless we also change the class names.)

This fixes the name of the service for https://media.ccc.de. Nobody other than NewPipe ever used the term "MediaCCC". I've seen _some_ software around the site use "CCC-TV", but CCC themselves seem just to use the domain.

This is the least invasive method, as it merely changes the service's name string, which is then rendered in the app.

I am open to changing all the class names, but it'll be hard to find a new naming scheme. `MediaCccDe` might work, though.