### PR TITLE
Fix comments parsing

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -160,8 +160,15 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
     }
 
     private String findValue(String doc, String start, String end) {
-        final int beginIndex = doc.indexOf(start) + start.length();
-        final int endIndex = doc.indexOf(end, beginIndex);
-        return doc.substring(beginIndex, endIndex);
+        final String unescaped = doc
+                .replaceAll("\\\\x22", "\"")
+                .replaceAll("\\\\x7b", "{")
+                .replaceAll("\\\\x7d", "}")
+                .replaceAll("\\\\x5b", "[")
+                .replaceAll("\\\\x5d", "]");
+
+        final int beginIndex = unescaped.indexOf(start) + start.length();
+        final int endIndex = unescaped.indexOf(end, beginIndex);
+        return unescaped.substring(beginIndex, endIndex);
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This PR should fix the annoying comments parsing error discussed in #455  in NewPipe by converting the `responseBody` into a "valid" format by escaping specific characters. When using the mobile user-agent the `ytInitialData` is formatted with chars as `\x`, which can't be parsed correctly.

Test NewPipe apk (just changed the implementation link to this PR's branch): [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/5666415/app-debug.zip)

PS: Out of some reason I can't reply to the linked issue, so I'm responding to your question here, @TobiGr  : 

>is it possible to convert the unicode characters to utf-8 automatically? Who knows whether they decide to encode other special chars, too.
It there is no simple solution to this, I'd go with your proposed changes,

I've done some research on the headers and so. As said above the reason for this character mess-up is the mobile User-Agent which is required to get the necessary token - without or normal/desktop User-Agent it's formatted well but does contain a different token used for the desktop way, explained in detail in #457 (but the desktop version has also its problems because of POST and CORS protection).