### PR TITLE
Fix YouTube player JavaScript URL redirection

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -842,8 +842,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             if (playerJsUrl.startsWith("//")) {
                 playerJsUrl = HTTPS + playerJsUrl;
             } else if (playerJsUrl.startsWith("/")) {
-                // sometimes https://youtube.com part has to be added manually
-                playerJsUrl = HTTPS + "//youtube.com" + playerJsUrl;
+                // sometimes https://www.youtube.com part has to be added manually
+                playerJsUrl = HTTPS + "//www.youtube.com" + playerJsUrl;
             }
 
             cachedDeobfuscationCode = loadDeobfuscationCode(playerJsUrl);


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe). - I don't think this is required because this PR just fix a redirection.

I noticed when NewPipe gets YouTube's player config, there is always a redirect to `www.youtube.com/url_to_js_player` from `youtube.com/url_to_js_player` like in the screenshot below:

![YT player config redirect](https://user-images.githubusercontent.com/74829229/103102619-28f3e300-461d-11eb-86f1-f10ad39e87aa.jpg)

This PR fixes it by directly request the player config at `www.youtube.com` instead of `youtube.com`.