### PR TITLE
Add durationPerFrame to Frameset

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -992,7 +992,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             for (int i = 1; i < spec.length; ++i) {
                 final String[] parts = spec[i].split("#");
-                if (parts.length != 8) {
+                if (parts.length != 8 || Integer.parseInt(parts[5]) == 0) {
                     continue;
                 }
                 final int frameWidth = Integer.parseInt(parts[0]);
@@ -1016,6 +1016,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         frameWidth,
                         frameHeight,
                         totalCount,
+                        Integer.parseInt(parts[5]),
                         framesPerPageX,
                         framesPerPageY
                 ));

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/Frameset.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/Frameset.java
@@ -8,12 +8,14 @@ public final class Frameset {
     private int frameWidth;
     private int frameHeight;
     private int totalCount;
+    private int durationPerFrame;
     private int framesPerPageX;
     private int framesPerPageY;
 
-    public Frameset(List<String> urls, int frameWidth, int frameHeight, int totalCount, int framesPerPageX, int framesPerPageY) {
+    public Frameset(List<String> urls, int frameWidth, int frameHeight, int totalCount, int durationPerFrame, int framesPerPageX, int framesPerPageY) {
         this.urls = urls;
         this.totalCount = totalCount;
+        this.durationPerFrame = durationPerFrame;
         this.frameWidth = frameWidth;
         this.frameHeight = frameHeight;
         this.framesPerPageX = framesPerPageX;
@@ -60,5 +62,49 @@ public final class Frameset {
      */
     public int getFrameHeight() {
         return frameHeight;
+    }
+
+    /**
+     * @return duration per frame in milliseconds
+     */
+    public int getDurationPerFrame() {
+        return durationPerFrame;
+    }
+
+    /**
+     * Returns the information for the frame at stream position.
+     *
+     * @param position Position in milliseconds
+     * @return An <code>int</code>-array containing the bounds and URL where the indexes are specified as
+     * followed:
+     *
+     * <ul>
+     *     <li><code>0</code>: Index of the URL</li>
+     *     <li><code>1</code>: Left bound</li>
+     *     <li><code>2</code>: Top bound</li>
+     *     <li><code>3</code>: Right bound</li>
+     *     <li><code>4</code>: Bottom bound</li>
+     * </ul>
+     */
+    public int[] getFrameBoundsAt(long position) {
+        if (position < 0 || position > ((totalCount + 1) * durationPerFrame)) {
+            // Return the first frame as fallback
+            return new int[] { 0, 0, 0, frameWidth, frameHeight };
+        }
+
+        final int framesPerStoryboard = framesPerPageX * framesPerPageY;
+        final int absoluteFrameNumber = Math.min((int) (position / durationPerFrame), totalCount);
+
+        final int relativeFrameNumber = absoluteFrameNumber % framesPerStoryboard;
+
+        final int rowIndex = Math.floorDiv(relativeFrameNumber, framesPerPageX);
+        final int columnIndex = relativeFrameNumber % framesPerPageY;
+
+        return new int[] {
+                /* storyboardIndex */ Math.floorDiv(absoluteFrameNumber, framesPerStoryboard),
+                /* left */ columnIndex * frameWidth,
+                /* top */ rowIndex * frameHeight,
+                /* right */ columnIndex * frameWidth + frameWidth,
+                /* bottom */ rowIndex * frameHeight + frameHeight };
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultStreamExtractorTest.java
@@ -338,6 +338,8 @@ public abstract class DefaultStreamExtractorTest extends DefaultExtractorTest<St
                     assertIsValidUrl(url);
                     assertIsSecureUrl(url);
                 }
+                assertTrue(f.getDurationPerFrame() > 0);
+                assertEquals(f.getFrameBoundsAt(0)[3], f.getFrameWidth());
             }
         } else {
             assertTrue(frames.isEmpty());


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This PR adds `durationPerFrame` field to the existing `Frameset` class. This property is necessary to calculate the correct frame depending on the timestamp.  Before there was no way to crop the correct frame bounds from the storyboard ("`framesPerPageX` x `framesPerPageY`"-matrix). 

#### Short example with this change to calculate the correct frame coordinates (pseudo code):
-- Goal: get frame bounds for 3:25:500 (= 180.500 milliseconds)´
-- Given: storyboard-Urls in 5x5-matrix, duration per frame = 5.000, frame height = 160 and frame width = 90

=> `180.500 / 5.000` = 36.1 => 37. Frame
=> `(37 - 1 * 25)` = 12 => 12. frame in 2. storyboard
=> `(12 - 2 * 5)` = 2 => 3. row, 2. column => row index = 2, column index = 1

=> Bounds / rectangle of the frame at the position: `left top (x, y) = (0 + 1 * 160 = 160, 0 + 2 * 90 = 180)`
=> `(left, top, right, bottom) = (160, 180, 320, 270)`