### PR TITLE
Adjust CI workflow to run tests with mocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build and run Tests
-        run: ./gradlew check --stacktrace
+        run: ./gradlew check --stacktrace -Ddownloader=MOCK


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This means that all tests that are already using mocks (currently only `YoutubeMixPlaylistExtractorTest`) will not test against the real Websites anymore. For that a new job needs to be added.