### PR TITLE
Pass on gradle JVM system property to test JVM

### DIFF
--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -1,3 +1,10 @@
+test {
+//  Pass on downloader type to tests for different CI jobs. See DownloaderFactory.java and ci.yml
+    if (System.properties.containsKey('downloader')) {
+        systemProperty('downloader', System.getProperty('downloader'))
+    }
+}
+
 dependencies {
     implementation project(':timeago-parser')
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Seems like i misunderstood how gradle system properties work and somehow even missed it.
Now the system property is actually accessable from inside the tests, meaning CI jobs with a different downloader passed in via CLI, will actually use those downloaders