### PR TITLE
Add if-else statement to run tests against real website on schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  schedule:
+      # once per day
+    - cron: 0 0 * * *
   push:
     branches:
       - dev
@@ -25,5 +28,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+        # See gradle file for difference between downloaders
       - name: Build and run Tests
-        run: ./gradlew check --stacktrace -Ddownloader=MOCK
+        run: |
+          if [[ $GITHUB_EVENT_NAME == 'schedule' ]]; then
+            ./gradlew check --stacktrace -Ddownloader=REAL
+          else
+            ./gradlew check --stacktrace -Ddownloader=MOCK
+          fi


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

I realized that running the tests against real website is basically just copying the ci.yml and changing one value.
Which can also be done with an if condition.

Because github actions `if` has no `else`, the shell script ones are used