### PR TITLE
Add MockOnlyRule to allow skipping specific tests based on downloader

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
@@ -6,6 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.annotation.Nonnull;
+
 /**
  * Marker annotation to skip test if it not run with mocks.
  *
@@ -15,4 +17,9 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Inherited
 public @interface MockOnly {
+
+    /**
+     * Explanation why this test shold only be run with mocks and not against real websites
+     */
+    @Nonnull String reason();
 }

--- a/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 import javax.annotation.Nonnull;
 
 /**
- * Marker annotation to skip test if it not run with mocks.
+ * Marker annotation to skip test in certain cases.
  *
  * {@link MockOnlyRule}
  */
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 public @interface MockOnly {
 
     /**
-     * Explanation why this test shold only be run with mocks and not against real websites
+     * Explanation why this test should be skipped
      */
     @Nonnull String reason();
 }

--- a/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnly.java
@@ -1,0 +1,18 @@
+package org.schabi.newpipe;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to skip test if it not run with mocks.
+ *
+ * {@link MockOnlyRule}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface MockOnly {
+}

--- a/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
@@ -33,13 +33,15 @@ public class MockOnlyRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                final boolean hasAnnotation = description.getAnnotation(MockOnly.class) == null;
-                final boolean isMockDownloader = downloader == null ||
-                        !downloader.equalsIgnoreCase(DownloaderType.REAL.toString());
-                Assume.assumeTrue(
-                        "The test is not reliable against a website and thus skipped",
-                        hasAnnotation && isMockDownloader
-                );
+                final MockOnly annotation = description.getAnnotation(MockOnly.class);
+                if (annotation != null) {
+                    final boolean isMockDownloader = downloader == null ||
+                            !downloader.equalsIgnoreCase(DownloaderType.REAL.toString());
+
+                    Assume.assumeTrue("The test is not reliable against real website. Reason: "
+                            + annotation.reason(), isMockDownloader);
+                }
+
 
                 base.evaluate();
             }

--- a/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
@@ -1,0 +1,48 @@
+package org.schabi.newpipe;
+
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.schabi.newpipe.downloader.DownloaderType;
+
+import javax.annotation.Nonnull;
+
+/**
+ * <p>
+ * Checks if the system variable "downloader" is set to "REAL" and skips the tests if it is.
+ * Otherwise execute the test.
+ * </p>
+ *
+ * <p>
+ * Use it by creating a public variable of this inside the test class and annotate it with
+ * {@link org.junit.Rule}. Then annotate the tests to be skipped with {@link MockOnly}
+ * </p>
+ *
+ * <p>
+ * Allows skipping unreliable or time sensitive tests in CI pipeline.
+ * </p>
+ */
+public class MockOnlyRule implements TestRule {
+
+    final String downloader = System.getProperty("downloader");
+
+    @Override
+    @Nonnull
+    public Statement apply(@Nonnull Statement base, @Nonnull Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                final boolean hasAnnotation = description.getAnnotation(MockOnly.class) == null;
+                final boolean isMockDownloader = downloader == null ||
+                        !downloader.equalsIgnoreCase(DownloaderType.REAL.toString());
+                Assume.assumeTrue(
+                        "The test is not reliable against a website and thus skipped",
+                        hasAnnotation && isMockDownloader
+                );
+
+                base.evaluate();
+            }
+        };
+    }
+}

--- a/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
+++ b/extractor/src/test/java/org/schabi/newpipe/MockOnlyRule.java
@@ -9,19 +9,21 @@ import org.schabi.newpipe.downloader.DownloaderType;
 import javax.annotation.Nonnull;
 
 /**
- * <p>
- * Checks if the system variable "downloader" is set to "REAL" and skips the tests if it is.
- * Otherwise execute the test.
- * </p>
- *
- * <p>
- * Use it by creating a public variable of this inside the test class and annotate it with
- * {@link org.junit.Rule}. Then annotate the tests to be skipped with {@link MockOnly}
- * </p>
  *
  * <p>
  * Allows skipping unreliable or time sensitive tests in CI pipeline.
  * </p>
+ *
+ * <p>
+ * Use it by creating a public variable of this inside the test class and annotate it with
+ * {@link org.junit.Rule}. Then annotate the specific tests to be skipped with {@link MockOnly}
+ * </p>
+ *
+ * <p>
+ * It works by checking if the system variable "downloader" is set to "REAL" and skips the tests if it is.
+ * Otherwise it executes the test.
+ * </p>
+
  */
 public class MockOnlyRule implements TestRule {
 
@@ -41,7 +43,6 @@ public class MockOnlyRule implements TestRule {
                     Assume.assumeTrue("The test is not reliable against real website. Reason: "
                             + annotation.reason(), isMockDownloader);
                 }
-
 
                 base.evaluate();
             }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

### -
- addresses point 7 of #481
- from https://github.com/junit-team/junit4/issues/116


### showcase
- changes: https://github.com/XiangRongLin/NewPipeExtractor/commits/flaky_test_showcase
- Run that branch locally with `gradle check -Ddownloader=REAL` and gradle check -Ddownloader=MOCK`
  - Mock will fail because failing test is not skipped
  - REAL will succeed because failing test is skipped