### PR TITLE
Support SoundCloud HLS-only tracks by using a workaround

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -200,9 +200,9 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
             boolean mp3ProgressiveStreamInTranscodings = false;
 
             for (final Object transcoding : transcodings) {
-                final JsonObject t = (JsonObject) transcoding;
-                if (t.getString("preset").contains("mp3") &&
-                    t.getObject("format").getString("protocol").equals("progressive")) {
+                final JsonObject transcodingJsonObject = (JsonObject) transcoding;
+                if (transcodingJsonObject.getString("preset").contains("mp3") &&
+                    transcodingJsonObject.getObject("format").getString("protocol").equals("progressive")) {
                     mp3ProgressiveStreamInTranscodings = true;
                     break;
                 }
@@ -210,11 +210,11 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
             // Get information about what stream formats are available
             for (final Object transcoding : transcodings) {
-                final JsonObject t = (JsonObject) transcoding;
+                final JsonObject transcodingJsonObject = (JsonObject) transcoding;
                 final String mediaUrl;
-                final String preset = t.getString("preset");
-                final String protocol = t.getObject("format").getString("protocol");
-                String url = t.getString("url");
+                final String preset = transcodingJsonObject.getString("preset");
+                final String protocol = transcodingJsonObject.getObject("format").getString("protocol");
+                String url = transcodingJsonObject.getString("url");
                 final MediaFormat mediaFormat;
                 final int bitrate;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -37,6 +37,7 @@ import static org.schabi.newpipe.extractor.utils.Utils.*;
 
 public class SoundcloudStreamExtractor extends StreamExtractor {
     private JsonObject track;
+    private boolean isAvailable = true;
 
     public SoundcloudStreamExtractor(StreamingService service, LinkHandler linkHandler) {
         super(service, linkHandler);
@@ -48,6 +49,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
         final String policy = track.getString("policy", EMPTY_STRING);
         if (!policy.equals("ALLOW") && !policy.equals("MONETIZE")) {
+            isAvailable = false;
             if (policy.equals("SNIP")) {
                 throw new SoundCloudGoPlusContentException();
             }
@@ -190,7 +192,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
         // Streams can be streamable and downloadable - or explicitly not.
         // For playing the track, it is only necessary to have a streamable track.
         // If this is not the case, this track might not be published yet.
-        if (!track.getBoolean("streamable")) return audioStreams;
+        if (!track.getBoolean("streamable") || !isAvailable) return audioStreams;
 
         try {
             final JsonArray transcodings = track.getObject("media").getArray("transcodings");

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
@@ -6,7 +6,6 @@ import org.schabi.newpipe.downloader.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
-import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException;
 import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException;
 import org.schabi.newpipe.extractor.services.DefaultStreamExtractorTest;
@@ -62,6 +61,7 @@ public class SoundcloudStreamExtractorTest {
         @Nullable @Override public String expectedTextualUploadDate() { return "2019-05-16 16:28:45"; }
         @Override public long expectedLikeCountAtLeast() { return -1; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
+        @Override public boolean expectedHasAudioStreams() { return false; }
         @Override public boolean expectedHasVideoStreams() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
@@ -103,7 +103,9 @@ public class SoundcloudStreamExtractorTest {
         @Nullable @Override public String expectedTextualUploadDate() { return "2016-11-11 01:16:37"; }
         @Override public long expectedLikeCountAtLeast() { return -1; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
+        @Override public boolean expectedHasAudioStreams() { return false; }
         @Override public boolean expectedHasVideoStreams() { return false; }
+        @Override public boolean expectedHasRelatedStreams() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public int expectedStreamSegmentsCount() { return 0; }


### PR DESCRIPTION
Support SoundCloud HLS-only streams by parsing M3U manifests, get the last segment URL (in order to get track length) and request a segment URL equals to track's duration so it's a single URL (`0/track_length/`).

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Related issue: #273

Test APK: [app.zip](https://github.com/TiA4f8R/NewPipe/suites/2255244146/artifacts/46920150) (from my fork with GitHub CI, app based on dev branch)

**To do**: add tests, if there is no risk of takedown of this repo by RIAA or by other music rights management companies by the use of SoundCloud HLS-only tracks.