### PR TITLE
[YouTube] Parse and execute deobfuscation code without JavaScript

### DIFF
--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
     implementation 'org.jsoup:jsoup:1.13.1'
-    implementation 'org.mozilla:rhino:1.7.12'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.0.2'
     implementation 'org.nibor.autolink:autolink:0.10.0'
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [not needed] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

See https://github.com/TeamNewPipe/NewPipeExtractor/issues/520#issuecomment-768593498

I don't know if this can be merged safely, it is more of an experiment. @FireMasterK 

This is the JS this PR parses, which is built by `loadDeobfuscationCode()`:

```js
var Aw = {
	bQ: function(a,b) {
		var c = a[0];
		a[0] = a[b%a.length];
		a[b%a.length] = c
	},
	RY: function(a) {
		a.reverse()
	},
	aD: function(a,b) {
		a.splice(0,b)
	}
};
var Bw = function(a) {
	a = a.split("");
	Aw.bQ(a,35);
	Aw.aD(a,3);
	Aw.RY(a,30);
	Aw.bQ(a,44);
	Aw.aD(a,1);
	return a.join("")
};
```

Debug APK: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/5886382/app-debug.zip)
