### PR TITLE
Fix extraction of YouTube chapters

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1079,7 +1079,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             // Search for correct panel containing the data
             for (int i = 0; i < panels.size(); i++) {
-                final String panelIdentifier = panels.getObject("engagementPanelSectionListRenderer")
+                final String panelIdentifier = panels.getObject(i).getObject("engagementPanelSectionListRenderer")
                         .getString("panelIdentifier");
                 if (panelIdentifier.equals("engagement-panel-macro-markers-description-chapters")
                         || panelIdentifier.equals("engagement-panel-macro-markers")) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1079,8 +1079,10 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             // Search for correct panel containing the data
             for (int i = 0; i < panels.size(); i++) {
-                if (panels.getObject(i).getObject("engagementPanelSectionListRenderer")
-                        .getString("panelIdentifier").equals("engagement-panel-macro-markers")) {
+                final String panelIdentifier = panels.getObject("engagementPanelSectionListRenderer")
+                        .getString("panelIdentifier")
+                if (panelIdentifier.equals("engagement-panel-macro-markers-description-chapters")
+                        || panelIdentifier.equals("engagement-panel-macro-markers")) {
                     segmentsArray = panels.getObject(i).getObject("engagementPanelSectionListRenderer")
                             .getObject("content").getObject("macroMarkersListRenderer").getArray("contents");
                     break;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1080,7 +1080,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             // Search for correct panel containing the data
             for (int i = 0; i < panels.size(); i++) {
                 final String panelIdentifier = panels.getObject("engagementPanelSectionListRenderer")
-                        .getString("panelIdentifier")
+                        .getString("panelIdentifier");
                 if (panelIdentifier.equals("engagement-panel-macro-markers-description-chapters")
                         || panelIdentifier.equals("engagement-panel-macro-markers")) {
                     segmentsArray = panels.getObject(i).getObject("engagementPanelSectionListRenderer")

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -259,7 +259,6 @@ public class YoutubeStreamExtractorDefaultTest {
 
         @Override public int expectedStreamSegmentsCount() { return 7; }
         @Test
-        @Ignore("TODO fix")
         public void testStreamSegment() throws Exception {
             final StreamSegment segment = extractor.getStreamSegments().get(1);
             assertEquals(164, segment.getStartTimeSeconds());


### PR DESCRIPTION
YouTube changed the name of the chapters in the JSON data from `engagement-panel-macro-markers` to `engagement-panel-macro-markers-description-chapters`, so extracting chapters don't work. This PR fixes it by changing the name in the extractor.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).