### PR TITLE
make getInfo from Extractor public

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
@@ -25,7 +25,7 @@ public class CommentsInfo extends ListInfo<CommentsInfoItem> {
         return getInfo(serviceByUrl.getCommentsExtractor(url));
     }
 
-    private static CommentsInfo getInfo(CommentsExtractor commentsExtractor) throws IOException, ExtractionException {
+    public static CommentsInfo getInfo(CommentsExtractor commentsExtractor) throws IOException, ExtractionException {
         // for services which do not have a comments extractor
         if (null == commentsExtractor) {
             return null;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -64,7 +64,7 @@ public class StreamInfo extends Info {
         return getInfo(service.getStreamExtractor(url));
     }
 
-    private static StreamInfo getInfo(StreamExtractor extractor) throws ExtractionException, IOException {
+    public static StreamInfo getInfo(StreamExtractor extractor) throws ExtractionException, IOException {
         extractor.fetchPage();
         StreamInfo streamInfo;
         try {


### PR DESCRIPTION
In StreamInfo and CommentsInfo

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

no need

``StreamInfo.getInfo(StreamExtractor extractor)`` was public before [this commit](https://github.com/TeamNewPipe/NewPipeExtractor/commit/9a469922850d2997676e53a959f7ba351e6e1935)

`SearchInfo.getInfo(SearchExtractor extractor)` is public
`PlaylistInfo.getInfo(PlaylistExtractor extractor)` is public
`ChannelInfo getInfo(ChannelExtractor extractor)` is public
`FeedInfo getInfo(FeedExtractor extractor)` is public
`KioskInfo getInfo(KioskExtractor extractor)` is public

``CommentsInfo.getInfo(CommentsExtractor extractor)`` is private, but it's probably a copy paste from StreamInfo because it was created after this change.
but it's probably a copy paste from StreamInfo because it was created in 2018, after that change