### PR TITLE
Set extractor encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ allprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven'
 
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
+
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 


### PR DESCRIPTION
When compiling the extractor on Windows, you get more than 100 errors with the error message: `error: unmappable character for encoding Cp1252`, especially in timeago-parser tasks. This PR fixes it by setting the encoding for all compileJava and compileTestJava tasks to UTF-8.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.