### PR TITLE
Fixes missing comments under videos

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -46,7 +46,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
 
     @Override
     public InfoItemsPage<CommentsInfoItem> getInitialPage() throws IOException, ExtractionException {
-        String commentsTokenInside;
+        final String commentsTokenInside;
         if (responseBody.contains("commentSectionRenderer")) {
             commentsTokenInside = findValue(responseBody, "commentSectionRenderer", "}");
         } else {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -49,7 +49,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         String commentsTokenInside;
         if (responseBody.contains("commentSectionRenderer")) {
             commentsTokenInside = findValue(responseBody, "commentSectionRenderer", "}");
-        } else{
+        } else {
             commentsTokenInside = findValue(responseBody, "sectionListRenderer", "}");
         }
         final String commentsToken = findValue(commentsTokenInside, "continuation\":\"", "\"");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -46,7 +46,12 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
 
     @Override
     public InfoItemsPage<CommentsInfoItem> getInitialPage() throws IOException, ExtractionException {
-        final String commentsTokenInside = findValue(responseBody, "commentSectionRenderer", "}");
+        String commentsTokenInside;
+        if (responseBody.contains("commentSectionRenderer")) {
+            commentsTokenInside = findValue(responseBody, "commentSectionRenderer", "}");
+        } else{
+            commentsTokenInside = findValue(responseBody, "sectionListRenderer", "}");
+        }
         final String commentsToken = findValue(commentsTokenInside, "continuation\":\"", "\"");
         return getPage(getNextPage(commentsToken));
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Fixes TeamNewPipe/NewPipe#5585, TeamNewPipe/NewPipe#5757, TeamNewPipe/NewPipe#5759.

It seems youtube is in the process of slightly changing their API, and the comment extractor could no longer find the ctoken. Based on reports that the old way sometimes worked, I left it in as an option. I have tested it on my phone and the app works correctly with this change.