### PR TITLE
Fix Peertube account subscribers extraction

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
@@ -79,7 +79,6 @@ public class PeertubeAccountExtractor extends ChannelExtractor {
         } catch (final IOException | JsonParserException | ReCaptchaException ignored) {
             // something went wrong during video channels extraction, only return subscribers of ownerAccount
         }
-        System.out.println(subscribersCount);
         return subscribersCount;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
@@ -59,6 +59,9 @@ public class PeertubeAccountExtractor extends ChannelExtractor {
 
     @Override
     public long getSubscriberCount() throws ParsingException {
+        // The subscriber count cannot be retrieved directly. It needs to be calculated.
+        // An accounts subscriber count is the number of the channel owner's subscriptions
+        // plus the sum of all sub channels subscriptions.
         long subscribersCount = json.getLong("followersCount");
         String accountVideoChannelUrl = baseUrl + PeertubeChannelLinkHandlerFactory.API_ENDPOINT;
         if (getId().contains(ACCOUNTS)) {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
@@ -102,7 +102,7 @@ public class PeertubeAccountExtractorTest {
 
         @Test
         public void testSubscriberCount() throws ParsingException {
-            assertTrue("Wrong subscriber count", extractor.getSubscriberCount() >= 500);
+            assertTrue("Wrong subscriber count", extractor.getSubscriberCount() >= 425);
         }
 
         @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
@@ -102,7 +102,7 @@ public class PeertubeAccountExtractorTest {
 
         @Test
         public void testSubscriberCount() throws ParsingException {
-            assertTrue("Wrong subscriber count", extractor.getSubscriberCount() >= 425);
+            assertTrue("Wrong subscriber count", extractor.getSubscriberCount() >= 750);
         }
 
         @Override


### PR DESCRIPTION
Fix Peertube account subscribers extraction by adding the subscribers of all channels of an account to the subscribers of this account.

Minimal subscriber count for Framasoft account has been increased to 750 in the test.
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.