### PR TITLE
[YouTube] Extract replies to YouTube comments

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentReplyExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentReplyExtractor.java
@@ -1,0 +1,30 @@
+package org.schabi.newpipe.extractor.comments;
+
+import org.schabi.newpipe.extractor.Page;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+public abstract class CommentReplyExtractor extends CommentsExtractor {
+
+    public CommentReplyExtractor(final StreamingService service,
+                                 final ListLinkHandler linkHandler) {
+        super(service, linkHandler);
+    }
+
+    public abstract Page getNextPage();
+
+    public abstract void extractReplies() throws ParsingException;
+
+    public abstract List<CommentsInfoItem> getReplies() throws ParsingException;
+
+    @Nonnull
+    @Override
+    public String getName() throws ParsingException {
+        return "Replies";
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -24,6 +24,8 @@ public class CommentsInfoItem extends InfoItem {
 
     public static final int NO_LIKE_COUNT = -1;
     public static final int NO_STREAM_POSITION = -1;
+    private CommentReplyExtractor replies;
+    private boolean isReply = false;
 
     public CommentsInfoItem(int serviceId, String url, String name) {
         super(InfoType.COMMENT, serviceId, url, name);
@@ -129,11 +131,11 @@ public class CommentsInfoItem extends InfoItem {
     public boolean isUploaderVerified() {
         return uploaderVerified;
     }
-
+	
     public void setStreamPosition(final int streamPosition) {
         this.streamPosition = streamPosition;
     }
-
+	
     /**
      * Get the playback position of the stream to which this comment belongs.
      * This is not supported by all services.
@@ -141,5 +143,21 @@ public class CommentsInfoItem extends InfoItem {
      */
     public int getStreamPosition() {
         return streamPosition;
+    }
+	
+    public CommentReplyExtractor getReplies() {
+        return this.replies;
+    }
+
+    public void setReplies(CommentReplyExtractor replies) {
+        this.replies = replies;
+    }
+
+    public boolean isReply() {
+        return this.isReply;
+    }
+
+    public void setIsReply(boolean reply) {
+        this.isReply = reply;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -107,4 +107,15 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
     default int getStreamPosition() throws ParsingException {
         return CommentsInfoItem.NO_STREAM_POSITION;
     }
+
+    /**
+     * Get the reply extractor
+     */
+    @Nullable
+    CommentReplyExtractor getReplies() throws ParsingException;
+
+    /**
+     * Whether comment is a reply to another comment
+     */
+    boolean isReply() throws ParsingException;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -93,6 +93,18 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
             addError(e);
         }
 
+        try {
+            resultItem.setReplies(extractor.getReplies());
+        } catch (Exception e) {
+            addError(e);
+        }
+
+        try {
+            resultItem.setIsReply(extractor.isReply());
+        } catch (Exception e) {
+            addError(e);
+        }
+
         return resultItem;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsReplyInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsReplyInfo.java
@@ -1,0 +1,49 @@
+package org.schabi.newpipe.extractor.comments;
+
+import org.schabi.newpipe.extractor.ListExtractor;
+import org.schabi.newpipe.extractor.Page;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.utils.ExtractorHelper;
+
+import java.io.IOException;
+
+public class CommentsReplyInfo extends CommentsInfo {
+
+    CommentReplyExtractor commentsExtractor;
+
+    private CommentsReplyInfo(CommentReplyExtractor commentReplyExtractor)
+            throws ParsingException {
+        super(commentReplyExtractor.getServiceId(),
+                commentReplyExtractor.getLinkHandler(), commentReplyExtractor.getName());
+    }
+
+    public static CommentsReplyInfo getInfo(CommentReplyExtractor commentReplyExtractor)
+            throws IOException, ExtractionException {
+        commentReplyExtractor.fetchPage();
+        CommentsReplyInfo commentsReplyInfo = new CommentsReplyInfo(commentReplyExtractor);
+        commentsReplyInfo.setCommentsExtractor(commentReplyExtractor);
+        ListExtractor.InfoItemsPage<CommentsInfoItem> initialCommentsPage
+                = ExtractorHelper.getItemsPageOrLogError(commentsReplyInfo, commentReplyExtractor);
+        commentsReplyInfo.setRelatedItems(initialCommentsPage.getItems());
+        commentsReplyInfo.setNextPage(initialCommentsPage.getNextPage());
+
+        return commentsReplyInfo;
+    }
+
+    public static ListExtractor.InfoItemsPage<CommentsInfoItem>
+    getMoreItems(CommentReplyExtractor commentReplyExtractor)
+            throws IOException, ExtractionException {
+        Page nextRepliesPage = commentReplyExtractor.getNextPage();
+        return commentReplyExtractor.getPage(nextRepliesPage);
+    }
+
+    public CommentReplyExtractor getCommentsExtractor() {
+        return this.commentsExtractor;
+    }
+
+    public void setCommentsExtractor(CommentReplyExtractor commentsExtractor) {
+        this.commentsExtractor = commentsExtractor;
+    }
+
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsInfoItemExtractor.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor.services.bandcamp.extractors;
 
 import org.jsoup.nodes.Element;
+import org.schabi.newpipe.extractor.comments.CommentReplyExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 
@@ -42,5 +43,17 @@ public class BandcampCommentsInfoItemExtractor implements CommentsInfoItemExtrac
     @Override
     public String getUploaderAvatarUrl() {
         return writing.getElementsByClass("thumb").attr("src");
+    }
+
+    //Unimplemented
+    @Override
+    public CommentReplyExtractor getReplies() throws ParsingException {
+        return null;
+    }
+
+    //Unimplemented
+    @Override
+    public boolean isReply() throws ParsingException {
+        return false;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -1,9 +1,11 @@
 package org.schabi.newpipe.extractor.services.peertube.extractors;
 
 import com.grack.nanojson.JsonObject;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.comments.CommentReplyExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -82,6 +84,33 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             value = "/client/assets/images/default-avatar.png";
         }
         return baseUrl + value;
+    }
+
+    @Override
+    public boolean isHeartedByUploader() throws ParsingException {
+        return false;
+    }
+
+    @Override
+    public boolean isPinned() throws ParsingException {
+        return false;
+    }
+
+    @Override
+    public boolean isUploaderVerified() throws ParsingException {
+        return false;
+    }
+
+    //Unimplemented
+    @Override
+    public CommentReplyExtractor getReplies() throws ParsingException {
+        return null;
+    }
+
+    //Unimplemented
+    @Override
+    public boolean isReply() throws ParsingException {
+        return false;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.soundcloud.extractors;
 
 import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.comments.CommentReplyExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -8,6 +10,7 @@ import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
+
 
 public class SoundcloudCommentsInfoItemExtractor implements CommentsInfoItemExtractor {
     private final JsonObject json;
@@ -46,6 +49,18 @@ public class SoundcloudCommentsInfoItemExtractor implements CommentsInfoItemExtr
     @Override
     public int getStreamPosition() throws ParsingException {
         return json.getInt("timestamp") / 1000; // convert milliseconds to seconds
+    }
+
+    //Unimplemented
+    @Override
+    public CommentReplyExtractor getReplies() throws ParsingException {
+        return null;
+    }
+
+    //Unimplemented
+    @Override
+    public boolean isReply() throws ParsingException {
+        return false;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -23,6 +23,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentReplyExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentReplyExtractor.java
@@ -1,0 +1,143 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.extractor.ListExtractor;
+import org.schabi.newpipe.extractor.Page;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.comments.CommentReplyExtractor;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItemsCollector;
+import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.utils.JsonUtils;
+import org.schabi.newpipe.extractor.utils.Utils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+public class YoutubeCommentReplyExtractor extends CommentReplyExtractor {
+    Map<String, List<String>> requestHeaders;
+    private Page repliesPage;
+    private Page nextPage;
+    private CommentsInfoItemsCollector repliesCollector;
+    private List<CommentsInfoItem> replies;
+    private JsonObject ajaxJson;
+
+    public YoutubeCommentReplyExtractor(final StreamingService service,
+                                        final ListLinkHandler replyHandler) {
+        super(service, replyHandler);
+        this.repliesPage = new Page(replyHandler.getUrl());
+        this.replies = Collections.emptyList();
+    }
+
+    @Override
+    public void extractReplies() throws ParsingException {
+        final JsonObject comment_replies = JsonUtils.getObject(this.ajaxJson,
+                "response.continuationContents.commentRepliesContinuation");
+
+
+        // Get the next page of replies, if it exists
+        if (comment_replies.has("continuations")) {
+            final JsonArray continuations
+                    = JsonUtils.getArray(comment_replies, "continuations");
+
+            final String continuationContents = continuations
+                    .getObject(0)
+                    .getString("nextContinuationData.continuation");
+            if (Utils.isNullOrEmpty(continuationContents)) {
+                this.nextPage = null;
+            } else {
+                final String contUrl = YoutubeParsingHelper.getRepliesUrl(continuationContents);
+                this.nextPage = new Page(contUrl);
+            }
+        } else {
+            this.nextPage = null;
+        }
+
+        // get the reply info, if it exists
+        if (comment_replies.has("contents")) {
+            final JsonArray contents = JsonUtils.getArray(comment_replies, "contents");
+            List<Object> comments = JsonUtils.getValues(contents, "commentRenderer");
+            final CommentsInfoItemsCollector collector
+                    = new CommentsInfoItemsCollector(getServiceId());
+
+            for (Object c : comments) {
+                if (c instanceof JsonObject) {
+                    YoutubeCommentsInfoItemExtractor extractor
+                            = new YoutubeCommentsInfoItemExtractor((JsonObject) c,
+                            this.repliesPage.getUrl(), getTimeAgoParser());
+                    //The replies don't have replies
+                    extractor.setReplyExtractor(null);
+                    //But they are replies
+                    extractor.setReplyState(true);
+                    collector.commit(extractor);
+                }
+            }
+            this.repliesCollector = collector;
+            this.replies = collector.getCommentsInfoItemList();
+        }
+    }
+
+    public void setRequestHeaders(Map<String, List<String>> requestHeaders) {
+        this.requestHeaders = requestHeaders;
+    }
+
+    @Override
+    public Page getNextPage() {
+        return this.nextPage;
+    }
+
+    @Nonnull
+    @Override
+    public InfoItemsPage getInitialPage() throws IOException, ExtractionException {
+        return getInfoItemsPage();
+    }
+
+    @Override
+    public InfoItemsPage getPage(Page page) throws IOException, ExtractionException {
+        if (page == null) {
+            return new ListExtractor.InfoItemsPage<CommentsInfoItem>(
+                    new CommentsInfoItemsCollector(getServiceId()), null);
+        }
+        this.repliesPage = page;
+        fetchPage();
+        return new InfoItemsPage<CommentsInfoItem>(this.repliesCollector, this.nextPage);
+    }
+
+    @Override
+    public List<CommentsInfoItem> getReplies() throws ParsingException {
+        if (this.replies.isEmpty()) {
+            extractReplies();
+        }
+        return this.replies;
+    }
+
+    public InfoItemsPage getInfoItemsPage() throws IOException, ExtractionException {
+        return new InfoItemsPage<CommentsInfoItem>(this.repliesCollector, nextPage);
+    }
+
+    @Override
+    public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
+        final Response response = downloader.get(this.repliesPage.getUrl(),
+                requestHeaders, getExtractorLocalization());
+        String responseBody = YoutubeParsingHelper.unescapeDocument(response.responseBody());
+        try {
+            this.ajaxJson = JsonParser.array().from(responseBody).getObject(1);
+        } catch (JsonParserException e) {
+            throw new ExtractionException(e.getMessage(), e);
+        }
+        extractReplies();
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 
+import org.schabi.newpipe.extractor.comments.CommentReplyExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -20,6 +21,9 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     private final JsonObject json;
     private final String url;
     private final TimeAgoParser timeAgoParser;
+    private boolean isReply;
+
+    private CommentReplyExtractor replyExtractor;
 
     public YoutubeCommentsInfoItemExtractor(final JsonObject json,
                                             final String url,
@@ -27,6 +31,10 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
         this.json = json;
         this.url = url;
         this.timeAgoParser = timeAgoParser;
+    }
+
+    public void setReplyState(boolean replyState) {
+        this.isReply = replyState;
     }
 
     @Override
@@ -210,6 +218,20 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
 
     public boolean isUploaderVerified() {
         return json.has("authorCommentBadge");
+    }
+
+    public void setReplyExtractor(CommentReplyExtractor replyExtractor) {
+        this.replyExtractor = replyExtractor;
+    }
+
+    @Override
+    public CommentReplyExtractor getReplies() throws ParsingException {
+        return replyExtractor;
+    }
+
+    @Override
+    public boolean isReply() throws ParsingException {
+        return this.isReply;
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

A pull request which pulls the ctoken for replies to comments, downloads it, and turns them into NewPipeExtractor objects which is then attached to the original comment using a new object called CommentReplyExtractor. 
The associated NewPipe repository is found here: https://github.com/golfinq/NewPipe/tree/comment-replies ; currently is able to download, and display replies to comments. Though due to the messiness of the implementation I will create a draft PR once this extractor is merged instead of an open PR.

EDIT: added additional info