### PR TITLE
[YouTube] Fix trending getName()

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -571,6 +571,16 @@ public class YoutubeParsingHelper {
         return getTextFromObject(textObject, false);
     }
 
+    @Nullable
+    public static String getTextAtKey(final JsonObject jsonObject, final String key)
+            throws ParsingException {
+        if (jsonObject.isString(key)) {
+            return jsonObject.getString(key);
+        } else {
+            return getTextFromObject(jsonObject.getObject(key));
+        }
+    }
+
     public static String fixThumbnailUrl(String thumbnailUrl) {
         if (thumbnailUrl.startsWith("//")) {
             thumbnailUrl = thumbnailUrl.substring(2);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonResponse;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextAtKey;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
@@ -70,18 +71,17 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     @Override
     public String getName() throws ParsingException {
         final JsonObject header = initialData.getObject("header");
-        JsonObject title = null;
+        String name = null;
         if (header.has("feedTabbedHeaderRenderer")) {
-            title = header.getObject("feedTabbedHeaderRenderer").getObject("title");
+            name = getTextAtKey(header.getObject("feedTabbedHeaderRenderer"), "title");
         } else if (header.has("c4TabbedHeaderRenderer")) {
-            title = header.getObject("c4TabbedHeaderRenderer").getObject("title");
+            name = getTextAtKey(header.getObject("c4TabbedHeaderRenderer"), "title");
         }
 
-        String name = getTextFromObject(title);
-        if (!isNullOrEmpty(name)) {
-            return name;
+        if (isNullOrEmpty(name)) {
+            throw new ParsingException("Could not get Trending name");
         }
-        throw new ParsingException("Could not get Trending name");
+        return name;
     }
 
     @Nonnull


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Previously the title was nested inside a `JsonObject`, so calling `getTextFromObject()` was needed; now it is just provided as a raw `String`. Just to be sure I added a `getTextAtKey()` function that checks the data type at a specific key, and if it is `String` then `getString(key)` is returned, otherwise `getTextFromObject(getObject(key))` is returned.

Fixes TeamNewPipe/NewPipe#5893
Fixes TeamNewPipe/NewPipe#5895
Fixes #581