### PR TITLE
Rename getRelatedStreams to getRelatedItems and change return type

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
@@ -245,7 +245,7 @@ public class BandcampStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() {
+    public StreamInfoItemsCollector getRelatedItems() {
         return null;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
@@ -240,7 +240,7 @@ public class MediaCCCLiveStreamExtractor extends StreamExtractor {
 
     @Nullable
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() {
+    public StreamInfoItemsCollector getRelatedItems() {
         return null;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
@@ -219,7 +219,7 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
 
     @Nullable
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() {
+    public StreamInfoItemsCollector getRelatedItems() {
         return null;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
@@ -263,7 +263,7 @@ public class PeertubeStreamExtractor extends StreamExtractor {
 
     @Nullable
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() throws IOException, ExtractionException {
+    public StreamInfoItemsCollector getRelatedItems() throws IOException, ExtractionException {
         final List<String> tags = getTags();
         final String apiUrl;
         if (tags.isEmpty()) {
@@ -271,7 +271,7 @@ public class PeertubeStreamExtractor extends StreamExtractor {
                     + "@" + JsonUtils.getString(json, "account.host") +
                     "/videos?start=0&count=8";
         } else {
-            apiUrl = getRelatedStreamsUrl(tags);
+            apiUrl = getRelatedItemsUrl(tags);
         }
 
         if (Utils.isBlank(apiUrl)) {
@@ -311,7 +311,7 @@ public class PeertubeStreamExtractor extends StreamExtractor {
         return Collections.emptyList();
     }
 
-    private String getRelatedStreamsUrl(final List<String> tags) throws UnsupportedEncodingException {
+    private String getRelatedItemsUrl(final List<String> tags) throws UnsupportedEncodingException {
         final String url = baseUrl + PeertubeSearchQueryHandlerFactory.SEARCH_ENDPOINT;
         final StringBuilder params = new StringBuilder();
         params.append("start=0&count=8&sort=-createdAt");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -353,7 +353,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Nullable
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() throws IOException, ExtractionException {
+    public StreamInfoItemsCollector getRelatedItems() throws IOException, ExtractionException {
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
 
         final String apiUrl = "https://api-v2.soundcloud.com/tracks/" + urlEncode(getId())

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -643,7 +643,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     @Nullable
     @Override
-    public StreamInfoItemsCollector getRelatedStreams() throws ExtractionException {
+    public StreamInfoItemsCollector getRelatedItems() throws ExtractionException {
         assertPageFetched();
 
         if (getAgeLimit() != NO_AGE_LIMIT) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -338,6 +338,22 @@ public abstract class StreamExtractor extends Extractor {
     getRelatedItems() throws IOException, ExtractionException;
 
     /**
+     * @deprecated Use {@link #getRelatedItems()}. May be removed in a future version.
+     * @return The result of {@link #getRelatedItems()} if it is a
+     *         StreamInfoItemsCollector, null otherwise
+     * @throws IOException
+     * @throws ExtractionException
+     */
+    @Deprecated
+    @Nullable
+    public StreamInfoItemsCollector getRelatedStreams() throws IOException, ExtractionException {
+        InfoItemsCollector<?, ?> collector = getRelatedItems();
+        if (collector instanceof StreamInfoItemsCollector) {
+            return (StreamInfoItemsCollector) collector;
+        } else return null;
+    }
+
+    /**
      * Should return a list of Frameset object that contains preview of stream frames
      *
      * @return list of preview frames or empty list if frames preview is not supported or not found for specified stream

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -20,6 +20,9 @@ package org.schabi.newpipe.extractor.stream;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.InfoItemsCollector;
+import org.schabi.newpipe.extractor.InfoItemExtractor;
 import org.schabi.newpipe.extractor.Extractor;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.MetaInfo;
@@ -331,7 +334,8 @@ public abstract class StreamExtractor extends Extractor {
      * @throws ExtractionException
      */
     @Nullable
-    public abstract StreamInfoItemsCollector getRelatedStreams() throws IOException, ExtractionException;
+    public abstract InfoItemsCollector<? extends InfoItem, ? extends InfoItemExtractor>
+    getRelatedItems() throws IOException, ExtractionException;
 
     /**
      * Should return a list of Frameset object that contains preview of stream frames

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -606,8 +606,24 @@ public class StreamInfo extends Info {
         return relatedItems;
     }
 
+    /**
+     * @deprecated Use {@link #getRelatedItems()}
+     */
+    @Deprecated
+    public List<InfoItem> getRelatedStreams() {
+        return getRelatedItems();
+    }
+
     public void setRelatedItems(List<InfoItem> relatedItems) {
         this.relatedItems = relatedItems;
+    }
+
+    /**
+     * @deprecated Use {@link #setRelatedItems(List)}
+     */
+    @Deprecated
+    public void setRelatedStreams(List<InfoItem> relatedItems) {
+        setRelatedItems(relatedItems);
     }
 
     public long getStartPosition() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -334,7 +334,7 @@ public class StreamInfo extends Info {
             streamInfo.addError(e);
         }
 
-        streamInfo.setRelatedStreams(ExtractorHelper.getRelatedVideosOrLogError(streamInfo, extractor));
+        streamInfo.setRelatedItems(ExtractorHelper.getRelatedItemsOrLogError(streamInfo, extractor));
 
         return streamInfo;
     }
@@ -370,7 +370,7 @@ public class StreamInfo extends Info {
 
 
     private String hlsUrl = "";
-    private List<InfoItem> relatedStreams = new ArrayList<>();
+    private List<InfoItem> relatedItems = new ArrayList<>();
 
     private long startPosition = 0;
     private List<SubtitlesStream> subtitles = new ArrayList<>();
@@ -602,12 +602,12 @@ public class StreamInfo extends Info {
         this.hlsUrl = hlsUrl;
     }
 
-    public List<InfoItem> getRelatedStreams() {
-        return relatedStreams;
+    public List<InfoItem> getRelatedItems() {
+        return relatedItems;
     }
 
-    public void setRelatedStreams(List<InfoItem> relatedStreams) {
-        this.relatedStreams = relatedStreams;
+    public void setRelatedItems(List<InfoItem> relatedItems) {
+        this.relatedItems = relatedItems;
     }
 
     public long getStartPosition() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/ExtractorHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/ExtractorHelper.java
@@ -27,9 +27,9 @@ public class ExtractorHelper {
     }
 
 
-    public static List<InfoItem> getRelatedVideosOrLogError(StreamInfo info, StreamExtractor extractor) {
+    public static List<InfoItem> getRelatedItemsOrLogError(StreamInfo info, StreamExtractor extractor) {
         try {
-            InfoItemsCollector<? extends InfoItem, ?> collector = extractor.getRelatedStreams();
+            InfoItemsCollector<? extends InfoItem, ?> collector = extractor.getRelatedItems();
             if (collector == null) return Collections.emptyList();
             info.addAllErrors(collector.getErrors());
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/ExtractorHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/ExtractorHelper.java
@@ -41,4 +41,12 @@ public class ExtractorHelper {
         }
     }
 
+    /**
+     * @deprecated Use {@link #getRelatedItemsOrLogError(StreamInfo, StreamExtractor)}
+     */
+    @Deprecated
+    public static List<InfoItem> getRelatedVideosOrLogError(StreamInfo info, StreamExtractor extractor) {
+        return getRelatedItemsOrLogError(info, extractor);
+    }
+
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/BaseStreamExtractorTest.java
@@ -17,7 +17,7 @@ public interface BaseStreamExtractorTest extends BaseExtractorTest {
     void testTextualUploadDate() throws Exception;
     void testLikeCount() throws Exception;
     void testDislikeCount() throws Exception;
-    void testRelatedStreams() throws Exception;
+    void testRelatedItems() throws Exception;
     void testAgeLimit() throws Exception;
     void testErrorMessage() throws Exception;
     void testAudioStreams() throws Exception;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/DefaultStreamExtractorTest.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor.services;
 
 import org.junit.Test;
+import org.schabi.newpipe.extractor.InfoItemsCollector;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.MetaInfo;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -8,7 +9,6 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.Frameset;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
-import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.SubtitlesStream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
@@ -57,7 +57,7 @@ public abstract class DefaultStreamExtractorTest extends DefaultExtractorTest<St
     @Nullable public abstract String expectedTextualUploadDate();
     public abstract long expectedLikeCountAtLeast(); // return -1 if ratings are disabled
     public abstract long expectedDislikeCountAtLeast(); // return -1 if ratings are disabled
-    public boolean expectedHasRelatedStreams() { return true; } // default: there are related videos
+    public boolean expectedHasRelatedItems() { return true; } // default: there are related videos
     public int expectedAgeLimit() { return StreamExtractor.NO_AGE_LIMIT; } // default: no limit
     @Nullable public String expectedErrorMessage() { return null; } // default: no error message
     public boolean expectedHasVideoStreams() { return true; } // default: there are video streams
@@ -223,10 +223,10 @@ public abstract class DefaultStreamExtractorTest extends DefaultExtractorTest<St
 
     @Test
     @Override
-    public void testRelatedStreams() throws Exception {
-        final StreamInfoItemsCollector relatedStreams = extractor().getRelatedStreams();
+    public void testRelatedItems() throws Exception {
+        final InfoItemsCollector<?, ?> relatedStreams = extractor().getRelatedItems();
 
-        if (expectedHasRelatedStreams()) {
+        if (expectedHasRelatedItems()) {
             assertNotNull(relatedStreams);
             defaultTestListOfItems(extractor().getService(), relatedStreams.getItems(),
                     relatedStreams.getErrors());

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampRadioStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampRadioStreamExtractorTest.java
@@ -50,7 +50,7 @@ public class BandcampRadioStreamExtractorTest extends DefaultStreamExtractorTest
     @Override public boolean expectedHasVideoStreams() { return false; }
     @Override public boolean expectedHasSubtitles() { return false; }
     @Override public boolean expectedHasFrames() { return false; }
-    @Override public boolean expectedHasRelatedStreams() { return false; }
+    @Override public boolean expectedHasRelatedItems() { return false; }
     @Override public StreamType expectedStreamType() { return StreamType.AUDIO_STREAM; }
     @Override public StreamingService expectedService() { return Bandcamp; }
     @Override public String expectedUploaderName() { return "Andrew Jervis"; }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
@@ -125,7 +125,7 @@ public class BandcampStreamExtractorTest extends DefaultStreamExtractorTest {
     }
 
     @Override
-    public boolean expectedHasRelatedStreams() {
+    public boolean expectedHasRelatedItems() {
         return false;
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
@@ -54,7 +54,7 @@ public class MediaCCCStreamExtractorTest {
         @Nullable @Override public String expectedTextualUploadDate() { return "2018-05-11T02:00:00.000+02:00"; }
         @Override public long expectedLikeCountAtLeast() { return -1; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
-        @Override public boolean expectedHasRelatedStreams() { return false; }
+        @Override public boolean expectedHasRelatedItems() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public List<String> expectedTags() { return Arrays.asList("gpn18", "105"); }
@@ -125,7 +125,7 @@ public class MediaCCCStreamExtractorTest {
         @Nullable @Override public String expectedTextualUploadDate() { return "2020-01-11T01:00:00.000+01:00"; }
         @Override public long expectedLikeCountAtLeast() { return -1; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
-        @Override public boolean expectedHasRelatedStreams() { return false; }
+        @Override public boolean expectedHasRelatedItems() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public List<String> expectedTags() { return Arrays.asList("36c3", "10565", "2019", "Security", "Main"); }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
@@ -70,7 +70,7 @@ public class SoundcloudStreamExtractorTest {
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public int expectedStreamSegmentsCount() { return 0; }
-        @Override public boolean expectedHasRelatedStreams() { return false; }
+        @Override public boolean expectedHasRelatedItems() { return false; }
         @Override public String expectedLicence() { return "all-rights-reserved"; }
         @Override public String expectedCategory() { return "Pop"; }
     }
@@ -115,7 +115,7 @@ public class SoundcloudStreamExtractorTest {
         @Override public long expectedDislikeCountAtLeast() { return -1; }
         @Override public boolean expectedHasAudioStreams() { return false; }
         @Override public boolean expectedHasVideoStreams() { return false; }
-        @Override public boolean expectedHasRelatedStreams() { return false; }
+        @Override public boolean expectedHasRelatedItems() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public int expectedStreamSegmentsCount() { return 0; }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorAgeRestrictedTest.java
@@ -50,7 +50,7 @@ public class YoutubeStreamExtractorAgeRestrictedTest extends DefaultStreamExtrac
     @Nullable @Override public String expectedTextualUploadDate() { return "2017-01-25"; }
     @Override public long expectedLikeCountAtLeast() { return 149000; }
     @Override public long expectedDislikeCountAtLeast() { return 38000; }
-    @Override public boolean expectedHasRelatedStreams() { return false; } // no related videos (!)
+    @Override public boolean expectedHasRelatedItems() { return false; } // no related videos (!)
     @Override public int expectedAgeLimit() { return 18; }
     @Nullable @Override public String expectedErrorMessage() { return "Sign in to confirm your age"; }
     @Override public boolean expectedHasSubtitles() { return false; }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Preparations for #593.

* Change return type of the previous `getRelatedStreams()` calls from `StreamInfoItemsCollector` to `InfoItemsCollector`
* Rename all occurrences of "related streams" to "related items"

This works without any major changes to the NewPipe app for these reasons:
* `ExtractorHelper.getRelatedVideosOrLogError` is the only caller of `StreamExtrctor.getRelatedItems()` and already returns a more generic `List<InfoItem>`
* NewPipe's `StreamInfo` object has the value `List<InfoItem> relatedStreams`, which is also generic.
* `PlayerHelper.autoQueueOf` already tests whether the items it handels are `StreamInfoItems`. (We might later want to change this to also support playlists in some form.)
* `RelatedStreamInfo extends ListInfo<InfoItem>`
* `RelatedVideosFragment extends BaseListInfoFragment<RelatedStreamInfo>`

I tried it with Streams, Channels and Playlist, and all were displayed correctly.

This NewPipe PR changes the NewPipe code to keep naming entirely consistent (and to remove inconsistencies like "related videos"): TeamNewPipe/NewPipe#5974