### PR TITLE
Extract related bandcamp items

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioStreamExtractor.java
@@ -14,6 +14,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemsCollector;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamSegment;
@@ -164,5 +165,11 @@ public class BandcampRadioStreamExtractor extends BandcampStreamExtractor {
     @Override
     public Privacy getPrivacy() {
         return Privacy.PUBLIC;
+    }
+
+    @Override
+    public PlaylistInfoItemsCollector getRelatedItems() {
+        // Contrary to other Bandcamp streams, radio streams don't have related items
+        return null;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRelatedPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRelatedPlaylistInfoItemExtractor.java
@@ -1,0 +1,45 @@
+// Created by Fynn Godau 2021, licensed GNU GPL version 3 or later
+
+package org.schabi.newpipe.extractor.services.bandcamp.extractors;
+
+import org.jsoup.nodes.Element;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Extracts recommended albums from tracks' website
+ */
+public class BandcampRelatedPlaylistInfoItemExtractor implements PlaylistInfoItemExtractor {
+    private final Element relatedAlbum;
+
+    public BandcampRelatedPlaylistInfoItemExtractor(@Nonnull Element relatedAlbum) {
+        this.relatedAlbum = relatedAlbum;
+    }
+
+    @Override
+    public String getName() throws ParsingException {
+        return relatedAlbum.getElementsByClass("release-title").text();
+    }
+
+    @Override
+    public String getUrl() throws ParsingException {
+        return relatedAlbum.getElementsByClass("title-and-artist").attr("abs:href");
+    }
+
+    @Override
+    public String getThumbnailUrl() throws ParsingException {
+        return relatedAlbum.getElementsByClass("album-art").attr("src");
+    }
+
+    @Override
+    public String getUploaderName() throws ParsingException {
+        return relatedAlbum.getElementsByClass("by-artist").text().replace("by ", "");
+    }
+
+    @Override
+    public long getStreamCount() throws ParsingException {
+        return -1;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
@@ -16,6 +16,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemsCollector;
 import org.schabi.newpipe.extractor.stream.*;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -245,8 +246,17 @@ public class BandcampStreamExtractor extends StreamExtractor {
     }
 
     @Override
-    public StreamInfoItemsCollector getRelatedItems() {
-        return null;
+    public PlaylistInfoItemsCollector getRelatedItems() {
+
+        PlaylistInfoItemsCollector collector = new PlaylistInfoItemsCollector(getServiceId());
+
+        Elements recommendedAlbums = document.getElementsByClass("recommended-album");
+
+        for (Element album : recommendedAlbums) {
+            collector.commit(new BandcampRelatedPlaylistInfoItemExtractor(album));
+        }
+
+        return collector;
     }
 
     @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
@@ -126,7 +126,7 @@ public class BandcampStreamExtractorTest extends DefaultStreamExtractorTest {
 
     @Override
     public boolean expectedHasRelatedItems() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Extracts recommended playlists as recommended playlists in NewPipeExtractor. Fixes #593.

| Recommended row on bandcamp website | Related items in NewPipe app |
|---|---|
| ![image](https://user-images.githubusercontent.com/16943720/114584457-fc72de00-9c82-11eb-8022-80609bdb6f40.png) | ![Screenshot_1618329234](https://user-images.githubusercontent.com/16943720/114584041-853d4a00-9c82-11eb-9d54-7d24dc4fc9b4.png) |
