### PR TITLE
Add streamPosition for comments

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -20,6 +20,9 @@ public class CommentsInfoItem extends InfoItem {
     private String textualLikeCount;
     private boolean heartedByUploader;
     private boolean pinned;
+    private int streamPosition;
+
+    public static final int NO_STREAM_POSITION = -1;
 
     public CommentsInfoItem(int serviceId, String url, String name) {
         super(InfoType.COMMENT, serviceId, url, name);
@@ -120,5 +123,18 @@ public class CommentsInfoItem extends InfoItem {
 
     public boolean isUploaderVerified() {
         return uploaderVerified;
+    }
+
+    public void setStreamPosition(final int streamPosition) {
+        this.streamPosition = streamPosition;
+    }
+
+    /**
+     * Get the playback position of the stream to which this comment belongs.
+     * This is not supported by all services.
+     * @return the playback position in seconds or {@link #NO_STREAM_POSITION} if not available
+     */
+    public int getStreamPosition() {
+        return streamPosition;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -22,6 +22,7 @@ public class CommentsInfoItem extends InfoItem {
     private boolean pinned;
     private int streamPosition;
 
+    public static final int NO_LIKE_COUNT = -1;
     public static final int NO_STREAM_POSITION = -1;
 
     public CommentsInfoItem(int serviceId, String url, String name) {
@@ -85,6 +86,10 @@ public class CommentsInfoItem extends InfoItem {
         this.uploadDate = uploadDate;
     }
 
+    /**
+     * @return the comment's like count
+     *         or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable
+     */
     public int getLikeCount() {
         return likeCount;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -12,15 +12,20 @@ import javax.annotation.Nullable;
 public interface CommentsInfoItemExtractor extends InfoItemExtractor {
 
     /**
-     * Return the like count of the comment, or -1 if it's unavailable
+     * Return the like count of the comment,
+     * or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable.
+     *
      * <br>
+     *
      * NOTE: Currently only implemented for YT {@link YoutubeCommentsInfoItemExtractor#getLikeCount()}
      * with limitations (only approximate like count is returned)
      *
      * @see StreamExtractor#getLikeCount()
+     * @return the comment's like count
+     * or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable
      */
     default int getLikeCount() throws ParsingException {
-        return -1;
+        return CommentsInfoItem.NO_LIKE_COUNT;
     }
 
     /**

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -94,4 +94,12 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
     default boolean isUploaderVerified() throws ParsingException {
         return false;
     }
+
+    /**
+     * The playback position of the stream to which this comment belongs.
+     * @see CommentsInfoItem#getStreamPosition()
+     */
+    default int getStreamPosition() throws ParsingException {
+        return CommentsInfoItem.NO_STREAM_POSITION;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -87,6 +87,12 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
             addError(e);
         }
 
+        try {
+            resultItem.setStreamPosition(extractor.getStreamPosition());
+        } catch (Exception e) {
+            addError(e);
+        }
+
         return resultItem;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
@@ -44,6 +44,11 @@ public class SoundcloudCommentsInfoItemExtractor implements CommentsInfoItemExtr
     }
 
     @Override
+    public int getStreamPosition() throws ParsingException {
+        return json.getInt("timestamp") / 1000; // convert milliseconds to seconds
+    }
+
+    @Override
     public String getUploaderUrl() {
         return json.getObject("user").getString("permalink_url");
     }
@@ -65,7 +70,7 @@ public class SoundcloudCommentsInfoItemExtractor implements CommentsInfoItemExtr
     }
 
     @Override
-    public String getUrl() throws ParsingException {
+    public String getUrl() {
         return url;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -184,7 +184,7 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
         return json.has("pinnedCommentBadge");
     }
 
-    public boolean isUploaderVerified() throws ParsingException {
+    public boolean isUploaderVerified() {
         // impossible to get this information from the mobile layout
         return false;
     }


### PR DESCRIPTION
SoundCloud is the only service which supports adding comments at a specific timestamp in the stream.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API. __Not sure if this is necessary__

Add `CommentsInfoItem.NO_LIKE_COUNT` and `CommentsInfoItem.NO_STREAM_POSITION`.
