### PR TITLE
Specify UTF-8 file encoding in RecordingDownloader and MockDownloader

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
@@ -7,8 +7,10 @@ import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,14 +26,15 @@ class MockDownloader extends Downloader {
     private final String path;
     private final Map<Request, Response> mocks;
 
-    public MockDownloader(@Nonnull String path) throws IOException {
+    public MockDownloader(@Nonnull final String path) throws IOException {
         this.path = path;
         this.mocks = new HashMap<>();
         final File[] files = new File(path).listFiles();
         if (files != null) {
-            for (File file : files) {
+            for (final File file : files) {
                 if (file.getName().startsWith(RecordingDownloader.FILE_NAME_PREFIX)) {
-                    final FileReader reader = new FileReader(file);
+                    final InputStreamReader reader = new InputStreamReader(new FileInputStream(
+                            file), StandardCharsets.UTF_8);
                     final TestRequestResponse response = new GsonBuilder()
                             .create()
                             .fromJson(reader, TestRequestResponse.class);
@@ -43,12 +46,12 @@ class MockDownloader extends Downloader {
     }
 
     @Override
-    public Response execute(@Nonnull Request request) {
-        Response result = mocks.get(request);
+    public Response execute(@Nonnull final Request request) {
+        final Response result = mocks.get(request);
         if (result == null) {
-            throw new NullPointerException("No mock response for request with url '" + request.url()
-                    + "' exists in path '" + path + "'.\nPlease make sure to run the tests with " +
-                    "the RecordingDownloader first after changes.");
+            throw new NullPointerException("No mock response for request with url '" + request
+                    .url() + "' exists in path '" + path + "'.\nPlease make sure to run the tests "
+                    + "with the RecordingDownloader first after changes.");
         }
         return result;
     }

--- a/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
@@ -8,8 +8,10 @@ import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -18,7 +20,8 @@ import javax.annotation.Nonnull;
 
 /**
  * <p>
- * Relays requests to {@link DownloaderTestImpl} and saves the request/response pair into a json file.
+ * Relays requests to {@link DownloaderTestImpl} and saves the request/response pair into a json
+ * file.
  * </p>
  * <p>
  * Those files are used by {@link MockDownloader}.
@@ -44,12 +47,12 @@ class RecordingDownloader extends Downloader {
      * Deletes existing files starting with {@link RecordingDownloader#FILE_NAME_PREFIX}.
      * @param stringPath Path to the folder where the json files will be saved to.
      */
-    public RecordingDownloader(String stringPath) throws IOException {
+    public RecordingDownloader(final String stringPath) throws IOException {
         this.path = stringPath;
-        Path path = Paths.get(stringPath);
-        File folder = path.toFile();
+        final Path path = Paths.get(stringPath);
+        final File folder = path.toFile();
         if (folder.exists()) {
-            for (File file : folder.listFiles()) {
+            for (final File file : folder.listFiles()) {
                 if (file.getName().startsWith(RecordingDownloader.FILE_NAME_PREFIX)) {
                     file.delete();
                 }
@@ -60,14 +63,17 @@ class RecordingDownloader extends Downloader {
     }
 
     @Override
-    public Response execute(@Nonnull Request request) throws IOException, ReCaptchaException {
-        Downloader downloader = DownloaderTestImpl.getInstance();
-        Response response = downloader.execute(request);
+    public Response execute(@Nonnull final Request request) throws IOException,
+            ReCaptchaException {
+        final Downloader downloader = DownloaderTestImpl.getInstance();
+        final Response response = downloader.execute(request);
 
-        File outputFile = new File(path + File.separator + FILE_NAME_PREFIX + index + ".json");
+        final File outputFile = new File(path + File.separator + FILE_NAME_PREFIX + index
+                + ".json");
         index++;
         outputFile.createNewFile();
-        FileWriter writer = new FileWriter(outputFile);
+        final OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(outputFile),
+                StandardCharsets.UTF_8);
         new GsonBuilder()
                 .setPrettyPrinting()
                 .create()


### PR DESCRIPTION
On Windows, mocks are recorded and read with the Cp1252 encoding so it breaks the mocks for non ASCII characters on Linux OS (and so the CI).
The project is in Java 8, so we can't use `FileReader(File, Charset)` and `FileReader(File, Charset)` because these constructors require Java 11. Instead of changing the Java version of the extractor, use `OutputStreamWriter` and `FileOutputStream` objets instead of `FileWriter` objects and use `InputStreamReader` and `FileInputStream` objects instead of `FileReader` objects.

Fixes #643.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
