### PR TITLE
Add utility method getService() to Info object 

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/Info.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/Info.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor;
 
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 
 import java.io.Serializable;
@@ -70,6 +71,15 @@ public abstract class Info implements Serializable {
 
     public int getServiceId() {
         return serviceId;
+    }
+
+    public StreamingService getService() {
+        try {
+            return NewPipe.getService(serviceId);
+        } catch (final ExtractionException e) {
+            // this should be unreachable, as serviceId certainly refers to a valid service
+            throw new RuntimeException("Info object has invalid service id", e);
+        }
     }
 
     public String getId() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/NewPipe.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/NewPipe.java
@@ -99,7 +99,6 @@ public class NewPipe {
 
     public static int getIdOfService(String serviceName) {
         try {
-            //noinspection ConstantConditions
             return getService(serviceName).getServiceId();
         } catch (ExtractionException ignored) {
             return -1;
@@ -108,7 +107,6 @@ public class NewPipe {
 
     public static String getNameOfService(int id) {
         try {
-            //noinspection ConstantConditions
             return getService(id).getServiceInfo().getName();
         } catch (Exception e) {
             System.err.println("Service id not known");


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

In the client, it often happens that the `StreamingService` for an `Info` object needs to be obtained. Before, this could not be done inline and required 6 lines of code:
```java
final StreamingService service;
try {
    service = NewPipe.getService(infoObject.getServiceId());
} catch (ExtractionException e) {
    // unreachable code
}
```
I added a shortand `getService()` method to the `Info` object, so now that whole lot of code is just replaced by `infoObject.getService()`.