### PR TITLE
[YouTube] Fix getting stream type of live streams

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -62,16 +62,21 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         }
 
         final JsonArray badges = videoInfo.getArray("badges");
-        for (Object badge : badges) {
-            if (((JsonObject) badge).getObject("metadataBadgeRenderer").getString("label", EMPTY_STRING).equals("LIVE NOW")) {
+        for (final Object badge : badges) {
+            if (((JsonObject) badge).getObject("metadataBadgeRenderer")
+                    .getString("label", EMPTY_STRING).equals("LIVE NOW")) {
                 return cachedStreamType = StreamType.LIVE_STREAM;
             }
         }
 
-        final String style = videoInfo.getArray("thumbnailOverlays").getObject(0)
-                .getObject("thumbnailOverlayTimeStatusRenderer").getString("style", EMPTY_STRING);
-        if (style.equalsIgnoreCase("LIVE")) {
-            return cachedStreamType = StreamType.LIVE_STREAM;
+        final JsonArray thumbnailOverlays = videoInfo.getArray("thumbnailOverlays");
+        for (final Object object : thumbnailOverlays) {
+            final JsonObject thumbnailOverlay = (JsonObject) object;
+            if (thumbnailOverlay.has("thumbnailOverlayNowPlayingRenderer")
+                    || thumbnailOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
+                    .getString("style", EMPTY_STRING).equalsIgnoreCase("LIVE")) {
+                return cachedStreamType = StreamType.LIVE_STREAM;
+            }
         }
 
         return cachedStreamType = StreamType.VIDEO_STREAM;


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Live streams are sometimes not recognized as such. That is causing the duration extraction to fail.

Fixes https://github.com/TeamNewPipe/NewPipeExtractor/runs/2769405487?check_suite_focus=true#step:5:169