### PR TITLE
Fix/live stream duration

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -72,10 +72,14 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         final JsonArray thumbnailOverlays = videoInfo.getArray("thumbnailOverlays");
         for (final Object object : thumbnailOverlays) {
             final JsonObject thumbnailOverlay = (JsonObject) object;
-            if (thumbnailOverlay.has("thumbnailOverlayNowPlayingRenderer")
-                    && thumbnailOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
-                    .getString("style", EMPTY_STRING).equalsIgnoreCase("LIVE")) {
-                return cachedStreamType = StreamType.LIVE_STREAM;
+            if (thumbnailOverlay.has("thumbnailOverlayNowPlayingRenderer")) {
+                final String overlayText = thumbnailOverlay
+                        .getObject("thumbnailOverlayTimeStatusRenderer")
+                        .getString("style", EMPTY_STRING);
+                if (overlayText.equalsIgnoreCase("LIVE")
+                        || overlayText.equalsIgnoreCase("NOW PLAYING")) {
+                    return cachedStreamType = StreamType.LIVE_STREAM;
+                }
             }
         }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -73,7 +73,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         for (final Object object : thumbnailOverlays) {
             final JsonObject thumbnailOverlay = (JsonObject) object;
             if (thumbnailOverlay.has("thumbnailOverlayNowPlayingRenderer")
-                    || thumbnailOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
+                    && thumbnailOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
                     .getString("style", EMPTY_STRING).equalsIgnoreCase("LIVE")) {
                 return cachedStreamType = StreamType.LIVE_STREAM;
             }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Follow up of #651

Fixed recognizing all streams as live streams
Also recognize streams with "NOW PLAYING" thumbnail overlay as live streams

Thanks to @litetex for noticing the regression introduced in #651. 