### PR TITLE
Add getMixUrl method to StreamExtractors

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
@@ -349,7 +349,22 @@ public class BandcampStreamExtractor extends StreamExtractor {
 
     @Nonnull
     @Override
-    public List<MetaInfo> getMetaInfo() throws ParsingException {
+    public List<MetaInfo> getMetaInfo() {
         return Collections.emptyList();
+    }
+
+    @Nullable
+    @Override
+    public String getMixUrl(final MixType mixType) throws ParsingException {
+        if (mixType == MixType.ALBUM) {
+            final Element albumHref = document.getElementsByClass("fromAlbum").first();
+            if (albumHref == null) {
+                return null;
+            }
+
+            return getUrl().split("bandcamp\\.com/")[0] + "bandcamp.com"
+                    + albumHref.parent().attr("href");
+        }
+        return null;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
@@ -302,4 +302,10 @@ public class MediaCCCLiveStreamExtractor extends StreamExtractor {
     public List<MetaInfo> getMetaInfo() {
         return Collections.emptyList();
     }
+
+    @Nullable
+    @Override
+    public String getMixUrl(MixType mixType) {
+        return null;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCStreamExtractor.java
@@ -305,4 +305,10 @@ public class MediaCCCStreamExtractor extends StreamExtractor {
     public List<MetaInfo> getMetaInfo() {
         return Collections.emptyList();
     }
+
+    @Nullable
+    @Override
+    public String getMixUrl(final MixType mixType) {
+        return null;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeStreamExtractor.java
@@ -489,4 +489,10 @@ public class PeertubeStreamExtractor extends StreamExtractor {
             return null;
         }
     }
+
+    @Nullable
+    @Override
+    public String getMixUrl(final MixType mixType) {
+        return null;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -450,4 +450,14 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
     public List<MetaInfo> getMetaInfo() {
         return Collections.emptyList();
     }
+
+    @Nullable
+    @Override
+    public String getMixUrl(final MixType mixType) {
+        /* SoundCloud stations are not yet supported
+        if (mixType == MixType.MUSIC) {
+            return getUrl().replace("soundcloud.com/", "soundcloud.com/stations/track/");
+        }*/
+        return null;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1217,4 +1217,25 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 initialData.getObject("contents").getObject("twoColumnWatchNextResults")
                         .getObject("results").getObject("results").getArray("contents"));
     }
+
+    @Nullable
+    @Override
+    public String getMixUrl(final MixType mixType) throws ParsingException {
+        switch (mixType) {
+            case VIDEO:
+                return getUrl() + "&list=RD" + getId();
+            case MUSIC:
+                return "https://music.youtube.com/watch?v=" + getId() + "&list=RDAMVM" + getId();
+            case CHANNEL:
+                final String channelId;
+                try {
+                    channelId = YoutubeChannelLinkHandlerFactory.getInstance()
+                            .getId(getUploaderUrl());
+                } catch (final ParsingException e) {
+                    return null; // apparently the uploader could not be parsed
+                }
+                return getUrl() + "&list=RDCM" + channelId;
+        }
+        return null;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -529,11 +529,31 @@ public abstract class StreamExtractor extends Extractor {
      */
     @Nonnull
     public abstract List<MetaInfo> getMetaInfo() throws ParsingException;
+
+    /**
+     * Generate a mix (i.e. auto-generated playlist) url of the provided type based on the stream
+     * info.
+     *
+     * @param mixType the type of mix url to obtain
+     * @return a mix url, or {@code null} if mixes of the provided type are not supported
+     * @throws ParsingException
+     */
+    @Nullable
+    public abstract String getMixUrl(MixType mixType) throws ParsingException;
+
+
     public enum Privacy {
         PUBLIC,
         UNLISTED,
         PRIVATE,
         INTERNAL,
         OTHER
+    }
+
+    public enum MixType {
+        VIDEO,
+        MUSIC,
+        CHANNEL,
+        ALBUM
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

I added the `getMixUrl(MixType)` method to every `StreamExtractor`, along with an `enum` for mix types (video, music, channel, album), following https://github.com/TeamNewPipe/NewPipe/issues/3583#issuecomment-876712109. This PR is a draft and still needs work, also the frontend UI is still a TODO, but feel free to give feedback ;-).

- Youtube video with mix: https://www.youtube.com/watch?v=l-mPoJe8wZQ
- Youtube video mix: https://www.youtube.com/watch?v=l-mPoJe8wZQ&list=RDl-mPoJe8wZQ
- Youtube music mix: https://music.youtube.com/watch?v=l-mPoJe8wZQ&list=RDAMVMl-mPoJe8wZQ
- Youtube channel mix: ~~https://www.youtube.com/watch?v=l-mPoJe8wZQ&list=RDCMUCf5q0cbFOLbphljteZ9d4Pw~~ (I don't know why it doesn't work, this needs investigation) https://www.youtube.com/watch?v=9iHM6X6uUH8&list=RDCMUC_aEa8K-EOJ3D6gOs7HcyNg
- Soundcloud track with station (click the More button): https://soundcloud.com/jim-yosef/jim-yosef-firefly-ncs-release
- Soundcloud station (still unsupported by the extractor): https://soundcloud.com/stations/track/jim-yosef/jim-yosef-firefly-ncs-release
- Bandcamp track with related album (in NewPipe just considered as a playlist): https://jimyosef.bandcamp.com/track/dawn

Fixes https://github.com/TeamNewPipe/NewPipe/issues/3583
Fixes https://github.com/TeamNewPipe/NewPipe/issues/3250
