### PR TITLE
Fix minor typos in Javadoc

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSubscriptionExtractor.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 import static org.schabi.newpipe.extractor.subscription.SubscriptionExtractor.ContentSource.INPUT_STREAM;
 
 /**
- * Extract subscriptions from a Google takout export (the user has to get the JSON out of the zip)
+ * Extract subscriptions from a Google takeout export (the user has to get the JSON out of the zip)
  */
 public class YoutubeSubscriptionExtractor extends SubscriptionExtractor {
     private static final String BASE_CHANNEL_URL = "https://www.youtube.com/channel/";

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -291,7 +291,7 @@ public abstract class StreamExtractor extends Extractor {
     /**
      * This will return a list of available
      * <a href="https://teamnewpipe.github.io/NewPipeExtractor/javadoc/org/schabi/newpipe/extractor/stream/Subtitles.html">Subtitles</a>s.
-     * If no subtitles are available an empty list can returned.
+     * If no subtitles are available an empty list can be returned.
      *
      * @return a list of available subtitles or an empty list
      * @throws IOException
@@ -304,7 +304,7 @@ public abstract class StreamExtractor extends Extractor {
      * This will return a list of available
      * <a href="https://teamnewpipe.github.io/NewPipeExtractor/javadoc/org/schabi/newpipe/extractor/stream/Subtitles.html">Subtitles</a>s.
      * given by a specific type.
-     * If no subtitles in that specific format are available an empty list can returned.
+     * If no subtitles in that specific format are available an empty list can be returned.
      *
      * @param format the media format by which the subtitles should be filtered
      * @return a list of available subtitles or an empty list


### PR DESCRIPTION
- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Fixed some minor mistakes in documentation. I noticed them while trying to implement a [TikTok extractor](https://github.com/gardenappl/NewPipeExtractor/tree/tiktok-sucks), but I quickly gave up on that because [TikTok is stupid](https://github.com/TeamNewPipe/NewPipeExtractor/issues/695).