### PR TITLE
[YouTube] Consolidate the regular expressions used to find the cipher decryption function

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -279,12 +279,12 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             return Long.parseLong(duration);
         } catch (final Exception e) {
             if (desktopStreamingData != null) {
-                final JsonArray adaptiveFormats = desktopStreamingData.getArray("adaptiveFormats");
+                final JsonArray adaptiveFormats = desktopStreamingData.getArray(ADAPTIVE_FORMATS);
                 final String durationMs = adaptiveFormats.getObject(0)
                         .getString("approxDurationMs");
                 return Math.round(Long.parseLong(durationMs) / 1000f);
             } else if (mobileStreamingData != null) {
-                final JsonArray adaptiveFormats = mobileStreamingData.getArray("adaptiveFormats");
+                final JsonArray adaptiveFormats = mobileStreamingData.getArray(ADAPTIVE_FORMATS);
                 final String durationMs = adaptiveFormats.getObject(0)
                         .getString("approxDurationMs");
                 return Math.round(Long.parseLong(durationMs) / 1000f);
@@ -685,9 +685,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private static final String DEOBFUSCATION_FUNC_NAME = "deobfuscate";
 
     private static final String[] REGEXES = {
-            "(?:\\b|[^a-zA-Z0-9$])([a-zA-Z0-9$]{2})\\s*=\\s*function\\(\\s*a\\s*\\)\\s*\\{\\s*a\\s*=\\s*a\\.split\\(\\s*\"\"\\s*\\)",
+            "(?:\\b|[^a-zA-Z0-9$])([a-zA-Z0-9$]{2,})\\s*=\\s*function\\(\\s*a\\s*\\)\\s*\\{\\s*a\\s*=\\s*a\\.split\\(\\s*\"\"\\s*\\)",
+            "\\bm=([a-zA-Z0-9$]{2,})\\(decodeURIComponent\\(h\\.s\\)\\)",
+            "\\bc&&\\(c=([a-zA-Z0-9$]{2,})\\(decodeURIComponent\\(c\\)\\)",
             "([\\w$]+)\\s*=\\s*function\\((\\w+)\\)\\{\\s*\\2=\\s*\\2\\.split\\(\"\"\\)\\s*;",
-            "\\b([\\w$]{2})\\s*=\\s*function\\((\\w+)\\)\\{\\s*\\2=\\s*\\2\\.split\\(\"\"\\)\\s*;",
+            "\\b([\\w$]{2,})\\s*=\\s*function\\((\\w+)\\)\\{\\s*\\2=\\s*\\2\\.split\\(\"\"\\)\\s*;",
             "\\bc\\s*&&\\s*d\\.set\\([^,]+\\s*,\\s*(:encodeURIComponent\\s*\\()([a-zA-Z0-9$]+)\\("
     };
     private static final String STS_REGEX = "signatureTimestamp[=:](\\d+)";
@@ -931,8 +933,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     private boolean isCipherProtectedContent() {
         if (desktopStreamingData != null) {
-            if (desktopStreamingData.has("adaptiveFormats")) {
-                final JsonArray adaptiveFormats = desktopStreamingData.getArray("adaptiveFormats");
+            if (desktopStreamingData.has(ADAPTIVE_FORMATS)) {
+                final JsonArray adaptiveFormats = desktopStreamingData.getArray(ADAPTIVE_FORMATS);
                 if (!isNullOrEmpty(adaptiveFormats)) {
                     for (final Object adaptiveFormat : adaptiveFormats) {
                         final JsonObject adaptiveFormatJsonObject = ((JsonObject) adaptiveFormat);
@@ -943,8 +945,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                     }
                 }
             }
-            if (desktopStreamingData.has("formats")) {
-                final JsonArray formats = desktopStreamingData.getArray("formats");
+            if (desktopStreamingData.has(FORMATS)) {
+                final JsonArray formats = desktopStreamingData.getArray(FORMATS);
                 if (!isNullOrEmpty(formats)) {
                     for (final Object format : formats) {
                         final JsonObject formatJsonObject = ((JsonObject) format);


### PR DESCRIPTION
See yt-dlp/yt-dlp#641 for more details.

Also use `ADAPTIVE_FORMATS` and `FORMATS` strings constants instead of the corresponding strings in `YoutubeStreamExtractor`.

Fixes TeamNewPipe/NewPipe#6910

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Test APK: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/6982792/app-debug.zip)

Note: The extractor in this APK only uses the streams returned on the `WEB` client to check if the decryption of contents protected with `signatureCiphers` is working or not.