### PR TITLE
Changes for "Show Replies"

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -4,8 +4,6 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 public class CommentsInfoItem extends InfoItem {
@@ -26,8 +24,6 @@ public class CommentsInfoItem extends InfoItem {
     private int streamPosition;
     @Nullable
     private Page replies;
-    @Nullable
-    private List<CommentsInfoItem> repliesInfoList;
     private boolean repliesOpen = false;
 
     public static final int NO_LIKE_COUNT = -1;
@@ -154,13 +150,6 @@ public class CommentsInfoItem extends InfoItem {
     public void setReplies(@Nullable Page replies) { this.replies = replies; }
 
     public Page getReplies() { return this.replies; }
-
-    public void setRepliesInfoList(@Nullable List<CommentsInfoItem> repliesInfoList) {
-        this.repliesInfoList = repliesInfoList;
-    }
-
-    @Nullable
-    public List<CommentsInfoItem> getRepliesInfoList() {return this.repliesInfoList; }
 
     public void setRepliesOpen(boolean repliesOpen) {
         this.repliesOpen = repliesOpen;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -4,6 +4,8 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 public class CommentsInfoItem extends InfoItem {
@@ -24,6 +26,8 @@ public class CommentsInfoItem extends InfoItem {
     private int streamPosition;
     @Nullable
     private Page replies;
+    @Nullable
+    private List<CommentsInfoItem> repliesInfoList;
 
     public static final int NO_LIKE_COUNT = -1;
     public static final int NO_STREAM_POSITION = -1;
@@ -149,4 +153,11 @@ public class CommentsInfoItem extends InfoItem {
     public void setReplies(@Nullable Page replies) { this.replies = replies; }
 
     public Page getReplies() { return this.replies; }
+
+    public void setRepliesInfoList(@Nullable List<CommentsInfoItem> repliesInfoList) {
+        this.repliesInfoList = repliesInfoList;
+    }
+
+    @Nullable
+    public List<CommentsInfoItem> getRepliesInfoList() {return this.repliesInfoList; }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -28,6 +28,7 @@ public class CommentsInfoItem extends InfoItem {
     private Page replies;
     @Nullable
     private List<CommentsInfoItem> repliesInfoList;
+    private boolean repliesOpen = false;
 
     public static final int NO_LIKE_COUNT = -1;
     public static final int NO_STREAM_POSITION = -1;
@@ -160,4 +161,10 @@ public class CommentsInfoItem extends InfoItem {
 
     @Nullable
     public List<CommentsInfoItem> getRepliesInfoList() {return this.repliesInfoList; }
+
+    public void setRepliesOpen(boolean repliesOpen) {
+        this.repliesOpen = repliesOpen;
+    }
+
+    public boolean getRepliesOpen() {return this.repliesOpen; }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -1,11 +1,8 @@
 package org.schabi.newpipe.extractor.comments;
 
-import static org.schabi.newpipe.extractor.ServiceList.YouTube;
-
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.InfoItemsCollector;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -98,19 +95,6 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
 
         try {
             resultItem.setReplies(extractor.getReplies());
-        } catch (Exception e) {
-            addError(e);
-        }
-
-        try {
-            if (resultItem.getReplies() != null && serviceId == YouTube.getServiceId()) {
-                    final YoutubeCommentsExtractor youtubeCommentsExtractor =
-                            (YoutubeCommentsExtractor) YouTube.getCommentsExtractor(
-                                    resultItem.getReplies().getUrl());
-
-                    resultItem.setRepliesInfoList(
-                            youtubeCommentsExtractor.getPage(extractor.getReplies()).getItems());
-            }
         } catch (Exception e) {
             addError(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -1,8 +1,11 @@
 package org.schabi.newpipe.extractor.comments;
 
+import static org.schabi.newpipe.extractor.ServiceList.YouTube;
+
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.InfoItemsCollector;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,6 +98,19 @@ public class CommentsInfoItemsCollector extends InfoItemsCollector<CommentsInfoI
 
         try {
             resultItem.setReplies(extractor.getReplies());
+        } catch (Exception e) {
+            addError(e);
+        }
+
+        try {
+            if (resultItem.getReplies() != null && serviceId == YouTube.getServiceId()) {
+                    final YoutubeCommentsExtractor youtubeCommentsExtractor =
+                            (YoutubeCommentsExtractor) YouTube.getCommentsExtractor(
+                                    resultItem.getReplies().getUrl());
+
+                    resultItem.setRepliesInfoList(
+                            youtubeCommentsExtractor.getPage(extractor.getReplies()).getItems());
+            }
         } catch (Exception e) {
             addError(e);
         }


### PR DESCRIPTION
A small change needed for the associated pull request in NewPipe (https://github.com/TeamNewPipe/NewPipe/pull/7244), which stores whether or not the replies have been cached to prevent re-downloading

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.


