### PR TITLE
Disabled ``SoundcloudStreamExtractorTest#SoundcloudGeoRestrictedTrack#testRelatedItems`` as it's unreliable

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
@@ -71,9 +71,15 @@ public class SoundcloudStreamExtractorTest {
         @Override public boolean expectedHasSubtitles() { return false; }
         @Override public boolean expectedHasFrames() { return false; }
         @Override public int expectedStreamSegmentsCount() { return 0; }
-        @Override public boolean expectedHasRelatedItems() { return true; } // One stream is returned
         @Override public String expectedLicence() { return "all-rights-reserved"; }
         @Override public String expectedCategory() { return "Pop"; }
+
+        @Test
+        @Override
+        @Ignore("Unreliable, sometimes it has related items, sometimes it does not")
+        public void testRelatedItems() throws Exception {
+            super.testRelatedItems();
+        }
     }
 
     public static class SoundcloudGoPlusTrack extends DefaultStreamExtractorTest {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

The test is unreliable so I disabled it, see:
* https://github.com/TeamNewPipe/NewPipeExtractor/runs/4492636540?check_suite_focus=true vs
* https://github.com/TeamNewPipe/NewPipeExtractor/runs/4463019929?check_suite_focus=true

These workflows were run on the same code.