### PR TITLE
[YouTube] parse timestamps with >3 digits correctly

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -301,8 +301,10 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      */
     @Override
     public long getTimeStamp() throws ParsingException {
+        // Yes, I know this regex can capture an empty timestamp (as in
+        // `&t=`), but `getTimestampSeconds` handles that.
         final long timestamp =
-                getTimestampSeconds("((#|&|\\?)t=\\d{0,3}h?\\d{0,3}m?\\d{1,3}s?)");
+                getTimestampSeconds("((#|&|\\?)t=\\d*h?\\d*m?\\d+s?)");
 
         if (timestamp == -2) {
             // Regex for timestamp was not found

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -301,8 +301,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      */
     @Override
     public long getTimeStamp() throws ParsingException {
-        // Yes, I know this regex can capture an empty timestamp (as in
-        // `&t=`), but `getTimestampSeconds` handles that.
         final long timestamp =
                 getTimestampSeconds("((#|&|\\?)t=\\d*h?\\d*m?\\d+s?)");
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -441,9 +441,9 @@ public abstract class StreamExtractor extends Extractor {
                 String minutesString = "";
                 String hoursString = "";
                 try {
-                    secondsString = Parser.matchGroup1("(\\d{1,3})s", timeStamp);
-                    minutesString = Parser.matchGroup1("(\\d{1,3})m", timeStamp);
-                    hoursString = Parser.matchGroup1("(\\d{1,3})h", timeStamp);
+                    secondsString = Parser.matchGroup1("(\\d+)s", timeStamp);
+                    minutesString = Parser.matchGroup1("(\\d+)m", timeStamp);
+                    hoursString = Parser.matchGroup1("(\\d+)h", timeStamp);
                 } catch (Exception e) {
                     //it could be that time is given in another method
                     if (secondsString.isEmpty() //if nothing was got,

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -112,8 +112,8 @@ public class YoutubeStreamExtractorDefaultTest {
 
     public static class DescriptionTestPewdiepie extends DefaultStreamExtractorTest {
         private static final String ID = "7PIMiDcwNvc";
-        private static final int TIMESTAMP = 17;
-        private static final String URL = BASE_URL + ID + "&t=" + TIMESTAMP;
+        private static final int TIMESTAMP = 7483;
+        private static final String URL = BASE_URL + ID + "&t=" + TIMESTAMP + "s";
         private static StreamExtractor extractor;
 
         @BeforeClass


### PR DESCRIPTION
Fixes https://github.com/TeamNewPipe/NewPipe/issues/7530; check the issue for details.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] (API was not changed) I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

[NewPipe.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/7841278/NewPipe.zip)

