### PR TITLE
Regex error when parsing the Youtube JavaScript code

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -36,7 +36,7 @@ public class YoutubeThrottlingDecrypter {
 
     private static final Pattern N_PARAM_PATTERN = Pattern.compile("[&?]n=([^&]+)");
     private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile(
-            "b=a\\.get\\(\"n\"\\)\\)&&\\(b=(\\w+)\\(b\\),a\\.set\\(\"n\",b\\)");
+            "b=a\\.get\\(\"n\"\\)\\)&&\\(b=(\\S+)\\(b\\),a\\.set\\(\"n\",b\\)");
 
     private static final Map<String, String> nParams = new HashMap<>();
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -67,15 +67,17 @@ public class YoutubeThrottlingDecrypter {
     private String parseDecodeFunctionName(final String playerJsCode)
             throws Parser.RegexException {
             String functionName = Parser.matchGroup1(FUNCTION_NAME_PATTERN, playerJsCode);
-            int arrayStartBrace = functionName.indexOf("[");
+            final int arrayStartBrace = functionName.indexOf("[");
             
             if (arrayStartBrace > 0) {
-                String arrayVarName = functionName.substring(0, arrayStartBrace);
-                String order = functionName.substring(arrayStartBrace+1, functionName.indexOf("]"));
-                int arrayNum = Integer.parseInt(order);
-                Pattern ARRAY_PATTERN = Pattern.compile(String.format("var %s=\\[(.+?)\\];", arrayVarName));
-                String arrayStr = Parser.matchGroup1(ARRAY_PATTERN, playerJsCode);
-                String names[] = arrayStr.split(",");
+                final String arrayVarName = functionName.substring(0, arrayStartBrace);
+                final String order = functionName.substring(
+                        arrayStartBrace + 1, functionName.indexOf("]"));
+                final int arrayNum = Integer.parseInt(order);
+                final Pattern arrayPattern = Pattern.compile(
+                        String.format("var %s=\\[(.+?)\\];", arrayVarName));
+                final String arrayStr = Parser.matchGroup1(arrayPattern, playerJsCode);
+                final String[] names = arrayStr.split(",");
                 functionName = names[arrayNum];
             }
             return functionName;
@@ -99,15 +101,15 @@ public class YoutubeThrottlingDecrypter {
 
     @Nonnull
     private String parseWithRegex(final String playerJsCode, final String functionName) throws Parser.RegexException {
-        Pattern functionPattern = Pattern.compile(functionName + "=function(.*?}};)\n",
+        final Pattern functionPattern = Pattern.compile(functionName + "=function(.*?}};)\n",
                 Pattern.DOTALL);
         return "function " + functionName + Parser.matchGroup1(functionPattern, playerJsCode);
     }
 
     public String apply(final String url) throws Parser.RegexException {
         if (containsNParam(url)) {
-            String oldNParam = parseNParam(url);
-            String newNParam = decryptNParam(oldNParam);
+            final String oldNParam = parseNParam(url);
+            final String newNParam = decryptNParam(oldNParam);
             return replaceNParam(url, oldNParam, newNParam);
         } else {
             return url;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -66,7 +66,19 @@ public class YoutubeThrottlingDecrypter {
 
     private String parseDecodeFunctionName(final String playerJsCode)
             throws Parser.RegexException {
-        return Parser.matchGroup1(FUNCTION_NAME_PATTERN, playerJsCode);
+            String functionName = Parser.matchGroup1(FUNCTION_NAME_PATTERN, playerJsCode);
+            int arrayStartBrace = functionName.indexOf("[");
+            
+            if (arrayStartBrace > 0) {
+                String arrayVarName = functionName.substring(0, arrayStartBrace);
+                String order = functionName.substring(arrayStartBrace+1, functionName.indexOf("]"));
+                int arrayNum = Integer.parseInt(order);
+                Pattern ARRAY_PATTERN = Pattern.compile(String.format("var %s=\\[(.+?)\\];", arrayVarName));
+                String arrayStr = Parser.matchGroup1(ARRAY_PATTERN, playerJsCode);
+                String names[] = arrayStr.split(",");
+                functionName = names[arrayNum];
+            }
+            return functionName;
     }
 
     @Nonnull


### PR DESCRIPTION
Changed the regex to account for nonword characters

Fixes: https://github.com/TeamNewPipe/NewPipe/issues/7734

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
