### PR TITLE
Remove the need for a CommentsInfo instance in CommentsInfo.getMoreItems and fix PeertubeCommentsExtractorTest.Default test

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
@@ -56,18 +56,21 @@ public class CommentsInfo extends ListInfo<CommentsInfoItem> {
     public static InfoItemsPage<CommentsInfoItem> getMoreItems(
             final CommentsInfo commentsInfo,
             final Page page) throws ExtractionException, IOException {
-        return getMoreItems(NewPipe.getService(commentsInfo.getServiceId()), commentsInfo, page);
+        return getMoreItems(NewPipe.getService(commentsInfo.getServiceId()), commentsInfo.getUrl(), page);
     }
 
     public static InfoItemsPage<CommentsInfoItem> getMoreItems(
             final StreamingService service,
             final CommentsInfo commentsInfo,
             final Page page) throws IOException, ExtractionException {
-        if (commentsInfo.getCommentsExtractor() == null) {
-            commentsInfo.setCommentsExtractor(service.getCommentsExtractor(commentsInfo.getUrl()));
-            commentsInfo.getCommentsExtractor().fetchPage();
-        }
-        return commentsInfo.getCommentsExtractor().getPage(page);
+        return getMoreItems(service, commentsInfo.getUrl(), page);
+    }
+
+    public static InfoItemsPage<CommentsInfoItem> getMoreItems(
+            final StreamingService service,
+            final String url,
+            final Page page) throws IOException, ExtractionException {
+        return service.getCommentsExtractor(url).getPage(page);
     }
 
     private transient CommentsExtractor commentsExtractor;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
@@ -28,17 +28,17 @@ public class PeertubeCommentsExtractorTest {
         public static void setUp() throws Exception {
             NewPipe.init(DownloaderTestImpl.getInstance());
             extractor = (PeertubeCommentsExtractor) PeerTube
-                    .getCommentsExtractor("https://framatube.org/videos/watch/04af977f-4201-4697-be67-a8d8cae6fa7a");
+                    .getCommentsExtractor("https://framatube.org/videos/watch/9c9de5e8-0a1e-484a-b099-e80766180a6d");
         }
 
         @Test
         public void testGetComments() throws IOException, ExtractionException {
             InfoItemsPage<CommentsInfoItem> comments = extractor.getInitialPage();
-            boolean result = findInComments(comments, "@root A great documentary on a great guy.");
+            boolean result = findInComments(comments, "Cool.");
 
             while (comments.hasNextPage() && !result) {
                 comments = extractor.getPage(comments.getNextPage());
-                result = findInComments(comments, "@root A great documentary on a great guy.");
+                result = findInComments(comments, "Cool.");
             }
 
             assertTrue(result);
@@ -46,16 +46,16 @@ public class PeertubeCommentsExtractorTest {
 
         @Test
         public void testGetCommentsFromCommentsInfo() throws IOException, ExtractionException {
-            CommentsInfo commentsInfo = CommentsInfo.getInfo("https://framatube.org/videos/watch/a8ea95b8-0396-49a6-8f30-e25e25fb2828");
+            CommentsInfo commentsInfo = CommentsInfo.getInfo("https://framatube.org/videos/watch/217eefeb-883d-45be-b7fc-a788ad8507d3");
             assertEquals("Comments", commentsInfo.getName());
 
-            boolean result = findInComments(commentsInfo.getRelatedItems(), "Loved it!!!");
+            boolean result = findInComments(commentsInfo.getRelatedItems(), "Cool");
 
             Page nextPage = commentsInfo.getNextPage();
             InfoItemsPage<CommentsInfoItem> moreItems = new InfoItemsPage<>(null, nextPage, null);
             while (moreItems.hasNextPage() && !result) {
                 moreItems = CommentsInfo.getMoreItems(PeerTube, commentsInfo, nextPage);
-                result = findInComments(moreItems.getItems(), "Loved it!!!");
+                result = findInComments(moreItems.getItems(), "Cool");
                 nextPage = moreItems.getNextPage();
             }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

I also fixed the Peertube comments test.

Closes #697, this is important for Piped since these instances are currently cached in memory