### PR TITLE
Removed hardcoded soundcloud HARDCODED_CLIENT_ID

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -1,9 +1,17 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
+import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
+import static org.schabi.newpipe.extractor.utils.Utils.EMPTY_STRING;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
+import static java.util.Collections.singletonList;
+
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -23,7 +31,6 @@ import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Parser.RegexException;
 import org.schabi.newpipe.extractor.utils.Utils;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,13 +42,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
-import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
-import static org.schabi.newpipe.extractor.utils.Utils.*;
+import javax.annotation.Nonnull;
 
 public class SoundcloudParsingHelper {
-    static final String HARDCODED_CLIENT_ID =
-            "0vyDB4rxVEprGutWT0xQ2VZhYpVZxku4"; // Updated on 2022-02-11
     private static String clientId;
     public static final String SOUNDCLOUD_API_V2_URL = "https://api-v2.soundcloud.com/";
 
@@ -52,12 +55,6 @@ public class SoundcloudParsingHelper {
         if (!isNullOrEmpty(clientId)) return clientId;
 
         final Downloader dl = NewPipe.getDownloader();
-        clientId = HARDCODED_CLIENT_ID;
-        if (checkIfHardcodedClientIdIsValid()) {
-            return clientId;
-        } else {
-            clientId = null;
-        }
 
         final Response download = dl.get("https://soundcloud.com");
         final String responseBody = download.responseBody();
@@ -87,14 +84,6 @@ public class SoundcloudParsingHelper {
 
         // Officially give up
         throw new ExtractionException("Couldn't extract client id");
-    }
-
-    static boolean checkIfHardcodedClientIdIsValid() throws IOException, ReCaptchaException {
-        final int responseCode = NewPipe.getDownloader().get(SOUNDCLOUD_API_V2_URL + "?client_id="
-                + HARDCODED_CLIENT_ID).responseCode();
-        // If the response code is 404, it means that the client_id is valid; otherwise,
-        // it should be not valid
-        return responseCode == 404;
     }
 
     public static OffsetDateTime parseDateFrom(final String textualUploadDate)

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelperTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelperTest.java
@@ -1,39 +1,20 @@
 package org.schabi.newpipe.extractor.services.soundcloud;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.schabi.newpipe.downloader.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-
-public class SoundcloudParsingHelperTest {
+class SoundcloudParsingHelperTest {
     @BeforeAll
     public static void setUp() {
         NewPipe.init(DownloaderTestImpl.getInstance());
     }
 
     @Test
-    public void assertThatHardcodedClientIdIsValid() throws Exception {
-        assertTrue(SoundcloudParsingHelper.checkIfHardcodedClientIdIsValid(),
-                "Hardcoded client id is not valid anymore");
-    }
-
-    @Test
-    public void assertHardCodedClientIdMatchesCurrentClientId() throws IOException, ExtractionException {
-        assertEquals(
-                SoundcloudParsingHelper.HARDCODED_CLIENT_ID,
-                SoundcloudParsingHelper.clientId(),
-                "Hardcoded client doesn't match extracted clientId");
-    }
-
-    @Test
-    public void resolveUrlWithEmbedPlayerTest() throws Exception {
+    void resolveUrlWithEmbedPlayerTest() throws Exception {
         assertEquals("https://soundcloud.com/trapcity", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/26057743"));
         assertEquals("https://soundcloud.com/nocopyrightsounds", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api.soundcloud.com/users/16069159"));
         assertEquals("https://soundcloud.com/trapcity", SoundcloudParsingHelper.resolveUrlWithEmbedPlayer("https://api-v2.soundcloud.com/users/26057743"));
@@ -41,7 +22,7 @@ public class SoundcloudParsingHelperTest {
     }
 
     @Test
-    public void resolveIdWithWidgetApiTest() throws Exception {
+    void resolveIdWithWidgetApiTest() throws Exception {
         assertEquals("26057743", SoundcloudParsingHelper.resolveIdWithWidgetApi("https://soundcloud.com/trapcity"));
         assertEquals("16069159", SoundcloudParsingHelper.resolveIdWithWidgetApi("https://soundcloud.com/nocopyrightsounds"));
     }


### PR DESCRIPTION
It never works (long enough) so let's simply remove it...

More why we should remove it points:
1. It always fails after a month (because new id)
2. We always have to update it and it breaks our tests
3. No one benefits from this not even the users - maybe for ~2 weeks (since we usually have a 2 week pre-release testing period) but then it's useless as it's not up-to-date anymore...

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes #781
