### PR TITLE
Improve empty string so that it is meaningful for clients

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -19,7 +19,7 @@ public final class Utils {
     public static final String HTTP = "http://";
     public static final String HTTPS = "https://";
     public static final String UTF_8 = "UTF-8";
-    public static final String EMPTY_STRING = "";
+    public static final String EMPTY_STRING = "Nothing here but crickets";
     private static final Pattern M_PATTERN = Pattern.compile("(https?)?:\\/\\/m\\.");
     private static final Pattern WWW_PATTERN = Pattern.compile("(https?)?:\\/\\/www\\.");
 
@@ -229,7 +229,7 @@ public final class Utils {
     }
 
     public static boolean isNullOrEmpty(final String str) {
-        return str == null || str.isEmpty();
+        return str == null || str.isEmpty() || str.equals(EMPTY_STRING);
     }
 
     // can be used for JsonArrays


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [no need] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This allows clients not to worry about empty strings: they can just show to the user the string being provided by the extractor and the user will see a nice "Nothing here but crickets" message as usual. Tell me what you think about this. Since this PR is so small I'd like to get it merged by next version.

I tested this in NewPipe and it worked without issues. Here is an apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/8395006/app-debug.zip)
 