### PR TITLE
Bandcamp: extract stream length

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
@@ -162,6 +162,12 @@ public class BandcampStreamExtractor extends StreamExtractor {
     }
 
     @Override
+    public long getLength() throws ParsingException {
+        return (long) albumJson.getArray("trackinfo").getObject(0)
+                .getDouble("duration");
+    }
+
+    @Override
     public List<VideoStream> getVideoStreams() {
         return Collections.emptyList();
     }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampStreamExtractorTest.java
@@ -91,7 +91,7 @@ public class BandcampStreamExtractorTest extends DefaultStreamExtractorTest {
 
     @Override
     public long expectedLength() {
-        return 0;
+        return 124;
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

`getLength()` was previously not implemented for `BandcampStreamExtractor` due to an oversight.

Test APK: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/8550388/app-debug.zip)

Fixes https://github.com/TeamNewPipe/NewPipe/issues/7064: duration is extracted and displayed correctly, thereby also fixes https://github.com/TeamNewPipe/NewPipe/issues/6417 as seeking then works again.

![Screenshot_1650828796](https://user-images.githubusercontent.com/16943720/164993348-8363aa1b-322e-4ea4-b36d-d293caddddf3.png)
