### PR TITLE
[YouTube] Fix extracting YouTube Music client version and key in the EU

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -853,7 +853,7 @@ public final class YoutubeParsingHelper {
                 musicKey = getStringResultFromRegexArray(response, INNERTUBE_API_KEY_REGEXES, 1);
                 musicClientName = Parser.matchGroup1(INNERTUBE_CLIENT_NAME_REGEX, response);
         } catch (final Exception e) {
-            final String url = "https://music.youtube.com/";
+            final String url = "https://music.youtube.com/?ucbcb=1";
             final Map<String, List<String>> headers = new HashMap<>();
             addCookieHeader(headers);
             final String html = getDownloader().get(url, headers).responseBody();


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Google returns now the consent page of YouTube when accessing YouTube Music in EU, which can be avoided by adding the `ucbcb` parameter to the URL with the value `1` (`?ucbcb=1`/`&ucbcb=1`), like on YouTube.

This extraction of the website is used as a last resort to get the client version and the API key of YouTube Music (which should not happen because the hardcoded client version and API key are always valid, and the JavaScript service worker is fetch first in order to try to get them), but is broken in the EU because of these changes. This PR fixes it by addding the parameter above with its value.