### PR TITLE
Fix extraction of some properties in ItagItems for YouTube livestreams and post-live streams and remove completely SoundCloud HLS workaround

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1358,13 +1358,20 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         if (streamType == StreamType.LIVE_STREAM || streamType == StreamType.POST_LIVE_STREAM) {
             itagItem.setTargetDurationSec(formatData.getInt("targetDurationSec"));
-        } else if (itagType == ItagItem.ItagType.VIDEO
-                || itagType == ItagItem.ItagType.VIDEO_ONLY) {
+        }
+
+        if (itagType == ItagItem.ItagType.VIDEO || itagType == ItagItem.ItagType.VIDEO_ONLY) {
             itagItem.setFps(formatData.getInt("fps"));
         } else if (itagType == ItagItem.ItagType.AUDIO) {
             // YouTube return the audio sample rate as a string
             itagItem.setSampleRate(Integer.parseInt(formatData.getString("audioSampleRate")));
-            itagItem.setAudioChannels(formatData.getInt("audioChannels"));
+            itagItem.setAudioChannels(formatData.getInt("audioChannels",
+                    // Most audio streams have two audio channels, so use this value if the real
+                    // count cannot be extracted
+                    // Doing this prevents an exception when generating the
+                    // AudioChannelConfiguration element of DASH manifests of audio streams in
+                    // YoutubeDashManifestCreatorUtils
+                    2));
         }
 
         // YouTube return the content length and the approximate duration as strings


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API. -> See TeamNewPipe/NewPipe#8153

This PR fixes an issue, when adding `ItagItem`'s properties on livestreams and post livestreams, where the `fps`, `audioSampleRate` and `audioChannels` values were not set for these stream types (and so only set for video streams, thanks to a `else` introduced by @Stypox in c8a77da2abd419b9ca2b581722a8a19a36010610).

This caused exceptions when creating DASH manifests of audio streams (because a valid number of audio channels is required in the `AudioChannelConfiguration` element of DASH manifests). To prevent it again, if this value is unknown, a fallback to `2` has been added (because most YouTube audio streams have 2 channels).

This PR also removes completely the SoundCloud HLS workaround which is being removed progressively by SoundCloud for MP3 streams too. Unfortunately, it means for UMG tracks (which have now a faster loading time because no HLS manifest is now fetched) that no progressive stream will be available for download in NewPipe.