### PR TITLE
Correct PeertubePlaylistExtractorTest unit tests

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubePlaylistExtractorTest.java
@@ -43,7 +43,7 @@ public class PeertubePlaylistExtractorTest {
 
         @Test
         public void testGetUploaderAvatarUrl() throws ParsingException {
-            assertEquals("https://framatube.org/lazy-static/avatars/cd0f781d-0287-4be2-94f1-24cd732337b2.jpg", extractor.getUploaderAvatarUrl());
+            assertEquals("https://framatube.org/lazy-static/avatars/c6801ff9-cb49-42e6-b2db-3db623248115.jpg", extractor.getUploaderAvatarUrl());
         }
 
         @Test
@@ -68,7 +68,7 @@ public class PeertubePlaylistExtractorTest {
 
         @Test
         public void testGetSubChannelAvatarUrl() throws ParsingException {
-            assertEquals("https://framatube.org/lazy-static/avatars/f1dcd0e8-e651-42ed-ae81-bb3bd4aff2bc.png",
+            assertEquals("https://framatube.org/lazy-static/avatars/e801ccce-8694-4309-b0ab-e6f0e552ef77.png",
                     extractor.getSubChannelAvatarUrl());
         }
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

https://github.com/TeamNewPipe/NewPipeExtractor/runs/6944735436?check_suite_focus=true

```
PeertubePlaylistExtractorTest$Shocking > testGetSubChannelAvatarUrl() FAILED
    org.opentest4j.AssertionFailedError: expected: <https://framatube.org/lazy-static/avatars/f1dcd0e8-e651-42ed-ae81-bb3bd4aff2bc.png> but was: <https://framatube.org/lazy-static/avatars/e801ccce-8694-4309-b0ab-e6f0e552ef77.png>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
        at org.schabi.newpipe.extractor.services.peertube.PeertubePlaylistExtractorTest$Shocking.testGetSubChannelAvatarUrl(PeertubePlaylistExtractorTest.java:71)
PeertubePlaylistExtractorTest$Shocking > testGetUploaderAvatarUrl() FAILED
    org.opentest4j.AssertionFailedError: expected: <https://framatube.org/lazy-static/avatars/cd0f781d-0287-4be2-94f1-24cd732337b2.jpg> but was: <https://framatube.org/lazy-static/avatars/c6801ff9-cb49-42e6-b2db-3db623248115.jpg>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
        at org.schabi.newpipe.extractor.services.peertube.PeertubePlaylistExtractorTest$Shocking.testGetUploaderAvatarUrl(PeertubePlaylistExtractorTest.java:46)
```
