### PR TITLE
[YouTube] Fetch the ANDROID client for ended/post livestreams

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -823,11 +823,16 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 .getBytes(StandardCharsets.UTF_8);
         nextResponse = getJsonPostResponse(NEXT, body, localization);
 
-        if ((!isAgeRestricted && streamType == StreamType.VIDEO_STREAM)
+        // streamType can only have LIVE_STREAM, POST_LIVE_STREAM and VIDEO_STREAM values (see
+        // setStreamType()), so this block will be run only for POST_LIVE_STREAM and VIDEO_STREAM
+        // values if fetching of the ANDROID client is not forced
+        if ((!isAgeRestricted && streamType != StreamType.LIVE_STREAM)
                 || isAndroidClientFetchForced) {
             try {
                 fetchAndroidMobileJsonPlayer(contentCountry, localization, videoId);
             } catch (final Exception ignored) {
+                // Ignore exceptions related to ANDROID client fetch or parsing, as it is not
+                // compulsory to play contents
             }
         }
 
@@ -836,6 +841,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             try {
                 fetchIosMobileJsonPlayer(contentCountry, localization, videoId);
             } catch (final Exception ignored) {
+                // Ignore exceptions related to IOS client fetch or parsing, as it is not
+                // compulsory to play contents
             }
         }
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

By default, the `ANDROID` client was only fetched for video contents, where it can be useful on ended/post livestreams, if the `n` parameter of the `WEB` client cannot be decrypted, to avoid throttling issues (because the `WEB` client was only used before for ended/post livestreams). With this PR, it is now fetched for ended/post livestreams by default too.

Note that this client doesn't return 720p streams where 720p60 streams are present, and these missing streams will so be still the ones from the `WEB` client.

It also provides an exclusive 48kbps M4A audio format in the `adaptiveFormats` array of the JSON player response (itag 139), like other mobile clients (which can be also extracted from the response of the DASH manifest URL returned into the `WEB` client player's response, but the DASH manifest is not used and parsed anymore by the extractor since #810 for performance purposes and to avoid NewPipe crashes due to `TransactionTooLargeException`s which would be created if DASH manifest parsing would be kept and used).

This change should have been made in #810, but I forgot to do so.