### PR TITLE
Use minimum required permissions for GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  # The generated docs are written to the `gh-pages` branch.
+  contents: write
+
 jobs:
   build-and-deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reduces the attack surface if the workflows are ever compromised.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.