### PR TITLE
[YouTube] Fix extraction of more complex nsig functions

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -602,15 +602,21 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     /**
-     * Try to decrypt url and fallback to given url, because decryption is not
-     * always needed.
+     * Try to decrypt a streaming URL and fallback to the given URL, because decryption may fail if
+     * YouTube do breaking changes.
+     *
+     * <p>
      * This way a breaking change from YouTube does not result in a broken extractor.
+     * </p>
+     *
+     * @param streamingUrl the streaming URL to decrypt with {@link YoutubeThrottlingDecrypter}
+     * @param videoId      the video ID to use when extracting JavaScript player code, if needed
      */
-    private String tryDecryptUrl(final String url, final String videoId) {
+    private String tryDecryptUrl(final String streamingUrl, final String videoId) {
         try {
-            return YoutubeThrottlingDecrypter.apply(url, videoId);
+            return YoutubeThrottlingDecrypter.apply(streamingUrl, videoId);
         } catch (final ParsingException e) {
-            return url;
+            return streamingUrl;
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/StringUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/StringUtils.java
@@ -23,14 +23,13 @@ public final class StringUtils {
         }
 
         startIndex += start.length();
-        int endIndex = startIndex;
-        while (string.charAt(endIndex) != '{') {
-            ++endIndex;
-        }
+        int endIndex = findNextParenthesis(string, startIndex, true);
         ++endIndex;
 
         int openParenthesis = 1;
         while (openParenthesis > 0) {
+            endIndex = findNextParenthesis(string, endIndex, false);
+
             switch (string.charAt(endIndex)) {
                 case '{':
                     ++openParenthesis;
@@ -45,5 +44,48 @@ public final class StringUtils {
         }
 
         return string.substring(startIndex, endIndex);
+    }
+
+    private static int findNextParenthesis(@Nonnull final String string,
+                                           final int offset,
+                                           final boolean onlyOpen) {
+        boolean lastEscaped = false;
+        char quote = ' ';
+
+        for (int i = offset; i < string.length(); i++) {
+            boolean thisEscaped = false;
+            final char c = string.charAt(i);
+
+            switch (c) {
+                case '{':
+                    if (quote == ' ') {
+                        return i;
+                    }
+                    break;
+                case '}':
+                    if (!onlyOpen && quote == ' ') {
+                        return i;
+                    }
+                    break;
+                case '\\':
+                    if (!lastEscaped) {
+                        thisEscaped = true;
+                    }
+                    break;
+                case '\'':
+                case '"':
+                    if (!lastEscaped) {
+                        if (quote == ' ') {
+                            quote = c;
+                        } else if (quote == c) {
+                            quote = ' ';
+                        }
+                    }
+            }
+
+            lastEscaped = thisEscaped;
+        }
+
+        return -1;
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/utils/StringUtilsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/utils/StringUtilsTest.java
@@ -58,4 +58,14 @@ public class StringUtilsTest {
 
         assertEquals(expected, substring);
     }
+
+    @Test
+    void find_closing_with_quotes() {
+        final String expected = "{return \",}\\\"/\"}";
+        final String string = "function(d){return \",}\\\"/\"}";
+
+        final String substring = matchToClosingParenthesis(string, "function(d)");
+
+        assertEquals(expected, substring);
+    }
 }


### PR DESCRIPTION
I fixed the "Could not get any stream" error that occurred after a YouTube update on 12.08.2022.

The issue was that the more complex nsig decryption function now includes curly braces inside strings, which the findNextParenthesis function could not handle. This resulted in the extraction of broken js and an interpreter error.

Fixes https://github.com/TeamNewPipe/NewPipe/issues/8760.

Test APK: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/9320681/app-debug.zip)

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
  (no API changes)
