### PR TITLE
Downgrade Rhino since it uses a class not available on Android

### DIFF
--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -27,9 +27,12 @@ dependencies {
 
     implementation "com.github.TeamNewPipe:nanojson:$nanojsonVersion"
     implementation 'org.jsoup:jsoup:1.15.3'
-    implementation 'org.mozilla:rhino:1.7.14'
     implementation "com.github.spotbugs:spotbugs-annotations:$spotbugsVersion"
     implementation 'org.nibor.autolink:autolink:0.10.0'
+
+    // do not upgrade to 1.7.14, since in 1.7.14 Rhino uses the `SourceVersion` class, which is not
+    // available on Android (even when using desugaring), and `NoClassDefFoundError` is thrown
+    implementation 'org.mozilla:rhino:1.7.13'
 
     checkstyle "com.puppycrawl.tools:checkstyle:$checkstyleVersion"
 


### PR DESCRIPTION
Reverts #774
Fixes TeamNewPipe/NewPipe#8876
See https://github.com/mozilla/rhino/issues/1149 for why this is needed