### PR TITLE
[YouTube] Fix throttling parameter decryption on Android

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -137,7 +137,10 @@ public final class YoutubeThrottlingDecrypter {
     @Nonnull
     private static String parseWithRegex(final String playerJsCode, final String functionName)
             throws Parser.RegexException {
-        final Pattern functionPattern = Pattern.compile(functionName + "=function(.*?};)\n",
+        // Escape the curly end brace to allow compatibility with Android's regex engine
+        // See https://stackoverflow.com/q/45074813
+        //noinspection RegExpRedundantEscape
+        final Pattern functionPattern = Pattern.compile(functionName + "=function(.*?\\};)\n",
                 Pattern.DOTALL);
         return validateFunction("function "
                 + functionName


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- no API changes

I finally found out why the ThrottlingDecryptor keeps failing on NewPipe, while all extractor tests are passing.
Android apparently uses a different regex engine than regular java (see this SO thread https://stackoverflow.com/questions/45074813/regex-pattern-error-in-android-when-matching-closing-brace).

That's why the regex used to extract the nsig function fails to compile with a syntax error on android, unless you escape the curly brace with a slash.