### PR TITLE
[YouTube] Return mqdefault thumbnails in fast feed

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedInfoItemExtractor.java
@@ -91,6 +91,10 @@ public class YoutubeFeedInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Override
     public String getThumbnailUrl() {
-        return entryElement.getElementsByTag("media:thumbnail").first().attr("url");
+        // The hqdefault thumbnail has some black bars at the top and at the bottom, while the
+        // mqdefault doesn't, so return the mqdefault one. It should always exist, according to
+        // https://stackoverflow.com/a/20542029/9481500.
+        return entryElement.getElementsByTag("media:thumbnail").first().attr("url")
+                .replace("hqdefault", "mqdefault");
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

The `hqdefault` thumbnails, which are returned by default by the fast feed extractor, have black bars at the top and at the bottom, and are thus not optimal. So this PR just replaces `hqdefault` with `mqdefault`: it seems to work well without issues after some testing, and unlike `highresdefault` the `mqdefault` thumbnail always exists according to [this SO](https://stackoverflow.com/a/20542029/9481500). This fixes the problem with black bands in NewPipe: https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1236708859

Debug apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/9557474/app-debug.zip)
Both me (Stypox) and [a user](https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1245467976) tested the apk and it works. All thumbnails load.
