### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ NewPipe Extractor is available at JitPack's Maven repo.
 
 If you're using Gradle, you could add NewPipe Extractor as a dependency with the following steps:
 
+**Gradle older versions**
 1. Add `maven { url 'https://jitpack.io' }` to the `repositories` in your `build.gradle`.
-2. Add `implementation 'com.github.TeamNewPipe:NewPipeExtractor:INSERT_VERSION_HERE'` to the `dependencies` in your `build.gradle`. Replace `INSERT_VERSION_HERE` with the [latest release](https://github.com/TeamNewPipe/NewPipeExtractor/releases/latest).
+2. Add `implementation 'com.github.TeamNewPipe:NewPipeExtractor:INSERT_VERSION_HERE'` to the `dependencies` in your `build.gradle`.
+
+**Gradle v6.8 and above**
+1. Add `maven { url 'https://jitpack.io' }` to the `repositories` of `dependencyResolutionManagement` block in project's `settings.gradle`.
+2. Add `implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v<INSERT_VERSION_HERE>'` to the `dependencies` in your `build.gradle`.
+
+Replace `INSERT_VERSION_HERE` with the [latest release](https://github.com/TeamNewPipe/NewPipeExtractor/releases/latest).
 
 **Note:** To use NewPipe Extractor in projects with a `minSdkVersion` below 26, [API desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required.
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

**Why?**
I was adding NewPipeExtractor to my project and after adding maven repository I got `Failed to resolve: com.github.TeamNewPipe.NewPipeExtractor:0.22.1` error. After searching for some time I found out that the tag part of maven repository is changed and I updated the implementation URL according to [jitpack website](https://jitpack.io/#TeamNewPipe/NewPipeExtractor/v0.22.1), this fixed the problem. 

**Changes**
Most people copy and paste the implementation block from README, therefore updated it with [Gradle 6.8's dependency management improvements](https://docs.gradle.org/6.8/release-notes.html#dependency-management-improvements). and update implementation string.

Feel free to edit as you wish. 
Thanks