### PR TITLE
Avoid possible NullPointerException in MediaCCCRecentKiosk.

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCRecentKiosk.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCRecentKiosk.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.kiosk.KioskExtractor;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
@@ -49,12 +50,12 @@ public class MediaCCCRecentKiosk extends KioskExtractor<StreamInfoItem> {
 
         // Streams in the recent kiosk are not ordered by the release date.
         // Sort them to have the latest stream at the beginning of the list.
-        Comparator<StreamInfoItem> comparator = Comparator.comparing(
-                streamInfoItem -> streamInfoItem.getUploadDate().offsetDateTime());
-        comparator = comparator.reversed();
-
-        final StreamInfoItemsCollector collector =
-                new StreamInfoItemsCollector(getServiceId(), comparator);
+        final Comparator<StreamInfoItem> comparator = Comparator
+                .comparing(StreamInfoItem::getUploadDate, Comparator
+                        .nullsLast(Comparator.comparing(DateWrapper::offsetDateTime)))
+                .reversed();
+        final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId(),
+                comparator);
 
         events.stream()
                 .filter(JsonObject.class::isInstance)


### PR DESCRIPTION
Since `StreamInfoItem#getUploadDate()` is annotated as `Nullable`, this avoids any potential issues if `null` is returned in `MediaCCCRecentKiosk`.

----

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
