### PR TITLE
[YouTube] Fix throttling decryption function regex

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -38,7 +38,9 @@ public final class YoutubeThrottlingDecrypter {
 
     private static final Pattern N_PARAM_PATTERN = Pattern.compile("[&?]n=([^&]+)");
     private static final Pattern DECRYPT_FUNCTION_NAME_PATTERN = Pattern.compile(
-            "\\.get\\(\"n\"\\)\\)&&\\(b=([a-zA-Z0-9$]+)(?:\\[(\\d+)])?\\([a-zA-Z0-9]\\)");
+            // CHECKSTYLE:OFF
+            "\\.get\\(\"n\"\\)\\)&&\\([a-zA-Z0-9$_]=([a-zA-Z0-9$_]+)(?:\\[(\\d+)])?\\([a-zA-Z0-9$_]\\)");
+            // CHECKSTYLE:ON
 
     // Escape the curly end brace to allow compatibility with Android's regex engine
     // See https://stackoverflow.com/q/45074813


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

This PR fixes the regex used to get the throttling decryption function code, utilized as a fallback when the lexer fails to parse the function (this should not happen). To do so, the following changes have been made to the regex:

- the function name is now quoted, as it may contain special regex symbols, such as dollar;
- the support of multiple lines in the function has been added;
- what looks like the end of the function is used as the end of the regex (this part is inspired from [yt-dlp's throttling parameter decryption regex](https://github.com/yt-dlp/yt-dlp/blob/5c8b2ee9ecf8773eb463b4ae218f8313a6626b2f/yt_dlp/extractor/youtube.py#L2860-L2863));
- the throttling function body regex has been moved into a private and static constant, allowing easier modifications in the future.

I also made changes on the function used to get the variable representing an array containing the throttling parameter decryption function, which doesn't rely on a specific letter anymore (`b`), but on alphanumeric characters instead (+`$` and `_`) (this change has been applied on all the regex).