### PR TITLE
[YouTube] Add comment reply count support

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -29,6 +29,8 @@ public class CommentsInfoItem extends InfoItem {
     public static final int NO_LIKE_COUNT = -1;
     public static final int NO_STREAM_POSITION = -1;
 
+    public static final int UNKNOWN_REPLY_COUNT = -1;
+
     public CommentsInfoItem(final int serviceId, final String url, final String name) {
         super(InfoType.COMMENT, serviceId, url, name);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -22,8 +22,8 @@ public class CommentsInfoItem extends InfoItem {
     private boolean heartedByUploader;
     private boolean pinned;
     private int streamPosition;
-    @Nullable
     private int replyCount;
+    @Nullable
     private Page replies;
 
     public static final int NO_LIKE_COUNT = -1;
@@ -155,7 +155,7 @@ public class CommentsInfoItem extends InfoItem {
     }
 
     public int getReplyCount() {
-        return this.replyCount;
+        return replyCount;
     }
 
     public void setReplies(@Nullable final Page replies) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -23,6 +23,7 @@ public class CommentsInfoItem extends InfoItem {
     private boolean pinned;
     private int streamPosition;
     @Nullable
+    private int replyCount;
     private Page replies;
 
     public static final int NO_LIKE_COUNT = -1;
@@ -91,7 +92,7 @@ public class CommentsInfoItem extends InfoItem {
 
     /**
      * @return the comment's like count
-     *         or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable
+     * or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable
      */
     public int getLikeCount() {
         return likeCount;
@@ -140,10 +141,19 @@ public class CommentsInfoItem extends InfoItem {
     /**
      * Get the playback position of the stream to which this comment belongs.
      * This is not supported by all services.
+     *
      * @return the playback position in seconds or {@link #NO_STREAM_POSITION} if not available
      */
     public int getStreamPosition() {
         return streamPosition;
+    }
+
+    public void setReplyCount(final int replyCount) {
+        this.replyCount = replyCount;
+    }
+
+    public int getReplyCount() {
+        return this.replyCount;
     }
 
     public void setReplies(@Nullable final Page replies) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -114,10 +114,11 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
     /**
      * The count of comment replies.
      *
-     * @return the count of the replies, or -1 if replies are not supported
+     * @return the count of the replies
+     * or {@link CommentsInfoItem#UNKNOWN_REPLY_COUNT} if replies are not supported
      */
     default int getReplyCount() throws ParsingException {
-        return -1;
+        return CommentsInfoItem.UNKNOWN_REPLY_COUNT;
     }
 
     /**

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -16,14 +16,14 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
      * or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable.
      *
      * <br>
-     *
+     * <p>
      * NOTE: Currently only implemented for YT {@link
      * YoutubeCommentsInfoItemExtractor#getLikeCount()}
      * with limitations (only approximate like count is returned)
      *
-     * @see StreamExtractor#getLikeCount()
      * @return the comment's like count
      * or {@link CommentsInfoItem#NO_LIKE_COUNT} if it is unavailable
+     * @see StreamExtractor#getLikeCount()
      */
     default int getLikeCount() throws ParsingException {
         return CommentsInfoItem.NO_LIKE_COUNT;
@@ -103,14 +103,26 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
 
     /**
      * The playback position of the stream to which this comment belongs.
+     *
      * @see CommentsInfoItem#getStreamPosition()
      */
     default int getStreamPosition() throws ParsingException {
         return CommentsInfoItem.NO_STREAM_POSITION;
     }
 
+
+    /**
+     * The count of comment replies.
+     *
+     * @return the count of the replies, or -1 if replies are not supported
+     */
+    default int getReplyCount() throws ParsingException {
+        return -1;
+    }
+
     /**
      * The continuation page which is used to get comment replies from.
+     *
      * @return the continuation Page for the replies, or null if replies are not supported
      */
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -110,7 +110,6 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
         return CommentsInfoItem.NO_STREAM_POSITION;
     }
 
-
     /**
      * The count of comment replies.
      *

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemsCollector.java
@@ -90,6 +90,12 @@ public final class CommentsInfoItemsCollector
         }
 
         try {
+            resultItem.setReplyCount(extractor.getReplyCount());
+        } catch (final Exception e) {
+            addError(e);
+        }
+
+        try {
             resultItem.setReplies(extractor.getReplies());
         } catch (final Exception e) {
             addError(e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -251,9 +251,9 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
 
     @Override
     public int getReplyCount() throws ParsingException {
-        final JsonObject cr = getCommentRenderer();
-        if (cr.has("replyCount")) {
-            return cr.getInt("replyCount");
+        final JsonObject commentRenderer = getCommentRenderer();
+        if (commentRenderer.has("replyCount")) {
+            return commentRenderer.getInt("replyCount");
         }
         return UNKNOWN_REPLY_COUNT;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -249,6 +249,15 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
     }
 
     @Override
+    public int getReplyCount() throws ParsingException {
+        try {
+            return JsonUtils.getNumber(json, "comment.commentRenderer.replyCount").intValue();
+        } catch (final Exception e) {
+            return -1;
+        }
+    }
+
+    @Override
     public Page getReplies() throws ParsingException {
         try {
             final String id = JsonUtils.getString(

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import static org.schabi.newpipe.extractor.comments.CommentsInfoItem.UNKNOWN_REPLY_COUNT;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 
 import com.grack.nanojson.JsonArray;
@@ -250,7 +251,11 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
 
     @Override
     public int getReplyCount() throws ParsingException {
-        return JsonUtils.getNumber(json, "comment.commentRenderer.replyCount").intValue();
+        final JsonObject cr = getCommentRenderer();
+        if (cr.has("replyCount")) {
+            return cr.getInt("replyCount");
+        }
+        return UNKNOWN_REPLY_COUNT;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
-import static org.schabi.newpipe.extractor.comments.CommentsInfoItem.UNKNOWN_REPLY_COUNT;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 
 import com.grack.nanojson.JsonArray;
@@ -251,11 +250,7 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
 
     @Override
     public int getReplyCount() throws ParsingException {
-        try {
-            return JsonUtils.getNumber(json, "comment.commentRenderer.replyCount").intValue();
-        } catch (final Exception e) {
-            return UNKNOWN_REPLY_COUNT;
-        }
+        return JsonUtils.getNumber(json, "comment.commentRenderer.replyCount").intValue();
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
+import static org.schabi.newpipe.extractor.comments.CommentsInfoItem.UNKNOWN_REPLY_COUNT;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 
 import com.grack.nanojson.JsonArray;
@@ -253,7 +254,7 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
         try {
             return JsonUtils.getNumber(json, "comment.commentRenderer.replyCount").intValue();
         } catch (final Exception e) {
-            return -1;
+            return UNKNOWN_REPLY_COUNT;
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -339,7 +339,8 @@ public class YoutubeCommentsExtractorTest {
             CommentsInfoItem firstComment = comments.getItems().get(0);
 
             assertNotEquals(-1, firstComment.getReplyCount(), "First reply comment can't get count");
-            assertNotEquals(0, firstComment.getReplyCount(), "First reply comment count is zero");
+            assertGreater(300, firstComment.getReplyCount(), "First reply comment count is smaller than the expected 300 comments");
+
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -338,10 +338,10 @@ public class YoutubeCommentsExtractorTest {
 
             DefaultTests.defaultTestListOfItems(YouTube, comments.getItems(), comments.getErrors());
 
-            CommentsInfoItem firstComment = comments.getItems().get(0);
+            final CommentsInfoItem firstComment = comments.getItems().get(0);
 
-            assertNotEquals(UNKNOWN_REPLY_COUNT, firstComment.getReplyCount(), "First reply comment can't get count");
-            assertGreater(300, firstComment.getReplyCount(), "First reply comment count is smaller than the expected 300 comments");
+            assertNotEquals(UNKNOWN_REPLY_COUNT, firstComment.getReplyCount(), "Could not get the reply count of the first comment");
+            assertGreater(300, firstComment.getReplyCount());
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.services.youtube;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
@@ -327,6 +328,18 @@ public class YoutubeCommentsExtractorTest {
 
             assertEquals("First", replies.getItems().get(0).getCommentText(),
                     "First reply comment did not match");
+        }
+
+        @Test
+        public void testGetCommentsReplyCount() throws IOException, ExtractionException {
+            final InfoItemsPage<CommentsInfoItem> comments = extractor.getInitialPage();
+
+            DefaultTests.defaultTestListOfItems(YouTube, comments.getItems(), comments.getErrors());
+
+            CommentsInfoItem firstComment = comments.getItems().get(0);
+
+            assertNotEquals(-1, firstComment.getReplyCount(), "First reply comment can't get count");
+            assertNotEquals(0, firstComment.getReplyCount(), "First reply comment count is zero");
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeCommentsExtractorTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertGreater;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
+import static org.schabi.newpipe.extractor.comments.CommentsInfoItem.UNKNOWN_REPLY_COUNT;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -338,9 +340,8 @@ public class YoutubeCommentsExtractorTest {
 
             CommentsInfoItem firstComment = comments.getItems().get(0);
 
-            assertNotEquals(-1, firstComment.getReplyCount(), "First reply comment can't get count");
+            assertNotEquals(UNKNOWN_REPLY_COUNT, firstComment.getReplyCount(), "First reply comment can't get count");
             assertGreater(300, firstComment.getReplyCount(), "First reply comment count is smaller than the expected 300 comments");
-
         }
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Add comment reply count support, just like youtube.

Fix #935