### PR TITLE
[SoundCloud] Fix getting more comments

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudStreamLinkHandlerFactory.java
@@ -11,7 +11,8 @@ public final class SoundcloudStreamLinkHandlerFactory extends LinkHandlerFactory
             = new SoundcloudStreamLinkHandlerFactory();
     private static final String URL_PATTERN = "^https?://(www\\.|m\\.)?soundcloud.com/[0-9a-z_-]+"
             + "/(?!(tracks|albums|sets|reposts|followers|following)/?$)[0-9a-z_-]+/?([#?].*)?$";
-
+    private static final String API_URL_PATTERN = "^https?://api-v2\\.soundcloud.com"
+            + "/(tracks|albums|sets|reposts|followers|following)/([0-9a-z_-]+)/";
     private SoundcloudStreamLinkHandlerFactory() {
     }
 
@@ -31,6 +32,9 @@ public final class SoundcloudStreamLinkHandlerFactory extends LinkHandlerFactory
 
     @Override
     public String getId(final String url) throws ParsingException {
+        if (Parser.isMatch(API_URL_PATTERN, url)) {
+            return Parser.matchGroup1(API_URL_PATTERN, url);
+        }
         Utils.checkUrl(URL_PATTERN, url);
 
         try {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Previously, trying to fetch the second page of comments resulted in errors like the one below:
## Exception
* __User Action:__ requested comments
* __Request:__ Loading more items: https://soundcloud.com/nba-youngboy/youngboy-never-broke-696650513
* __Content Country:__ US
* __Content Language:__ en-US
* __App Language:__ en_US
* __Service:__ SoundCloud
* __Version:__ 0.24.0
* __OS:__ Linux Android 13 - 33
<details><summary><b>Crash log </b></summary><p>

```
org.schabi.newpipe.extractor.exceptions.ParsingException: URL not accepted: https://api-v2.soundcloud.com/tracks/1358538436/comments?client_id=0B4jtZF6rFh5TG0eiQ1nuJfbsGk9FZFg&threaded=0&filter_replies=1
	at org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory.fromUrl(LinkHandlerFactory.java:79)
	at org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory.fromUrl(ListLinkHandlerFactory.java:40)
	at org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory.fromUrl(ListLinkHandlerFactory.java:34)
	at org.schabi.newpipe.extractor.StreamingService.getCommentsExtractor(StreamingService.java:278)
	at org.schabi.newpipe.extractor.comments.CommentsInfo.getMoreItems(CommentsInfo.java:74)
	at org.schabi.newpipe.extractor.comments.CommentsInfo.getMoreItems(CommentsInfo.java:67)
	at org.schabi.newpipe.util.ExtractorHelper.lambda$getMoreCommentItems$8(ExtractorHelper.java:167)
	at org.schabi.newpipe.util.ExtractorHelper.$r8$lambda$DLEFpIAjy5YVZt97lKfLttNB3h4(Unknown Source:0)
	at org.schabi.newpipe.util.ExtractorHelper$$ExternalSyntheticLambda14.call(Unknown Source:6)
	at io.reactivex.rxjava3.internal.operators.single.SingleFromCallable.subscribeActual(SingleFromCallable.java:43)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4813)
	at io.reactivex.rxjava3.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
	at io.reactivex.rxjava3.core.Scheduler$DisposeTask.run(Scheduler.java:644)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:65)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:56)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:307)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at java.lang.Thread.run(Thread.java:1012)

```
</details>
<hr>
