### PR TITLE
Fix Checkstyle error in YoutubeCommentsInfoItemExtractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -251,9 +251,9 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
 
     @Override
     public int getReplyCount() throws ParsingException {
-        final JsonObject commentRenderer = getCommentRenderer();
-        if (commentRenderer.has("replyCount")) {
-            return commentRenderer.getInt("replyCount");
+        final JsonObject commentRendererJsonObject = getCommentRenderer();
+        if (commentRendererJsonObject.has("replyCount")) {
+            return commentRendererJsonObject.getInt("replyCount");
         }
         return UNKNOWN_REPLY_COUNT;
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

When reviewing #936, [I suggested to use an object that is used as a field name](https://github.com/TeamNewPipe/NewPipeExtractor/pull/936#discussion_r990652672). I apologize for suggesting that.

As the PR has been merged with this change, extractor compiling fails due to the violation of a Checkstyle rule, `HiddenField`, in [`YoutubeCommentsInfoItemExtractor`](https://github.com/TeamNewPipe/NewPipeExtractor/blob/9ffdd0948b2ecd82655f5ff2a3e127b2b7695d5b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java#L254). This PR fixes this by using a different name for the object.