### PR TITLE
[YouTube] Improve duration parsing

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -318,38 +318,16 @@ public final class YoutubeParsingHelper {
                 ? input.split(":")
                 : input.split("\\.");
 
-        String days = "0";
-        String hours = "0";
-        String minutes = "0";
-        final String seconds;
-
-        switch (splitInput.length) {
-            case 4:
-                days = splitInput[0];
-                hours = splitInput[1];
-                minutes = splitInput[2];
-                seconds = splitInput[3];
-                break;
-            case 3:
-                hours = splitInput[0];
-                minutes = splitInput[1];
-                seconds = splitInput[2];
-                break;
-            case 2:
-                minutes = splitInput[0];
-                seconds = splitInput[1];
-                break;
-            case 1:
-                seconds = splitInput[0];
-                break;
-            default:
-                throw new ParsingException("Error duration string with unknown format: " + input);
+        final int[] units = {24, 60, 60, 1};
+        final int offset = units.length - splitInput.length;
+        if (offset < 0) {
+            throw new ParsingException("Error duration string with unknown format: " + input);
         }
-
-        return ((convertDurationToInt(days) * 24
-                + convertDurationToInt(hours)) * 60
-                + convertDurationToInt(minutes)) * 60
-                + convertDurationToInt(seconds);
+        int duration = 0;
+        for (int i = 0; i < splitInput.length; i++) {
+            duration = units[i + offset] * (duration + convertDurationToInt(splitInput[i]));
+        }
+        return duration;
     }
 
     /**


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

(No API change tho)

I have simplified ad optimized the code to parse the duration of YouTube videos.
In the previous version, the parsing method `parseDurationString` was a bit redundant, making some extra (useless) method calls for short videos.
In particular, there were calls to "sanitize" and check the "0" strings, added within the method.
This code is not only more compact, but only makes the necessary calls to `convertDurationToInt`: e.g., for short videos (<1h), this approach seems twice faster on my device(s).