### PR TITLE
Use OkHttp's HttpUrl.

### DIFF
--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // available on Android (even when using desugaring), and `NoClassDefFoundError` is thrown
     implementation 'org.mozilla:rhino:1.7.13'
 
+    //noinspection GradleDependency --> do not update OkHttp to keep supporting Android 4.x users
+    implementation 'com.squareup.okhttp3:okhttp:3.12.13'
+
     checkstyle "com.puppycrawl.tools:checkstyle:$checkstyleVersion"
 
     testImplementation platform("org.junit:junit-bom:$junitVersion")

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/linkHandler/BandcampSearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/linkHandler/BandcampSearchQueryHandlerFactory.java
@@ -6,20 +6,20 @@ import static org.schabi.newpipe.extractor.services.bandcamp.extractors.Bandcamp
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
-import org.schabi.newpipe.extractor.utils.Utils;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
+
+import okhttp3.HttpUrl;
 
 public class BandcampSearchQueryHandlerFactory extends SearchQueryHandlerFactory {
     @Override
     public String getUrl(final String query,
                          final List<String> contentFilter,
                          final String sortFilter) throws ParsingException {
-        try {
-            return BASE_URL + "/search?q=" + Utils.encodeUrlUtf8(query) + "&page=1";
-        } catch (final UnsupportedEncodingException e) {
-            throw new ParsingException("query \"" + query + "\" could not be encoded", e);
-        }
+        return HttpUrl.get(BASE_URL).newBuilder()
+                .addPathSegment("search")
+                .addQueryParameter("q", query)
+                .addQueryParameter("page", "1")
+                .toString();
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudParsingHelper.java
@@ -40,9 +40,14 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import okhttp3.HttpUrl;
+
 public final class SoundcloudParsingHelper {
     private static String clientId;
-    public static final String SOUNDCLOUD_API_V2_URL = "https://api-v2.soundcloud.com/";
+    public static final HttpUrl SOUNDCLOUD_API_V2_URL = new HttpUrl.Builder()
+            .scheme("https")
+            .host("api-v2.soundcloud.com")
+            .build();
 
     private SoundcloudParsingHelper() {
     }
@@ -106,9 +111,11 @@ public final class SoundcloudParsingHelper {
      */
     public static JsonObject resolveFor(@Nonnull final Downloader downloader, final String url)
             throws IOException, ExtractionException {
-        final String apiUrl = SOUNDCLOUD_API_V2_URL + "resolve"
-                + "?url=" + Utils.encodeUrlUtf8(url)
-                + "&client_id=" + clientId();
+        final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("resolve")
+                .addQueryParameter("url", url)
+                .addQueryParameter("client_id", clientId())
+                .toString();
 
         try {
             final String response = downloader.get(apiUrl, SoundCloud.getLocalization())

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudChannelExtractor.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 public class SoundcloudChannelExtractor extends ChannelExtractor {
     private String userId;
     private JsonObject user;
-    private static final String USERS_ENDPOINT = SOUNDCLOUD_API_V2_URL + "users/";
 
     public SoundcloudChannelExtractor(final StreamingService service,
                                       final ListLinkHandler linkHandler) {
@@ -35,10 +34,12 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     @Override
     public void onFetchPage(@Nonnull final Downloader downloader) throws IOException,
             ExtractionException {
-
         userId = getLinkHandler().getId();
-        final String apiUrl = USERS_ENDPOINT + userId + "?client_id="
-                + SoundcloudParsingHelper.clientId();
+        final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("users")
+                .addPathSegment(userId)
+                .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                .toString();
 
         final String response = downloader.get(apiUrl, getExtractorLocalization()).responseBody();
         try {
@@ -110,11 +111,15 @@ public class SoundcloudChannelExtractor extends ChannelExtractor {
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws ExtractionException {
         try {
-            final StreamInfoItemsCollector streamInfoItemsCollector =
-                    new StreamInfoItemsCollector(getServiceId());
-
-            final String apiUrl = USERS_ENDPOINT + getId() + "/tracks" + "?client_id="
-                    + SoundcloudParsingHelper.clientId() + "&limit=20" + "&linked_partitioning=1";
+            final var streamInfoItemsCollector = new StreamInfoItemsCollector(getServiceId());
+            final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                    .addPathSegment("users")
+                    .addPathSegment(getId())
+                    .addPathSegment("tracks")
+                    .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                    .addQueryParameter("limit", "20")
+                    .addQueryParameter("linked_partitioning", "1")
+                    .toString();
 
             final String nextPageUrl = SoundcloudParsingHelper.getStreamsFromApiMinItems(15,
                     streamInfoItemsCollector, apiUrl);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
@@ -1,9 +1,13 @@
 package org.schabi.newpipe.extractor.services.soundcloud.extractors;
 
+import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.SOUNDCLOUD_API_V2_URL;
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
+
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
@@ -16,15 +20,13 @@ import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.SOUNDCLOUD_API_V2_URL;
-import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import javax.annotation.Nonnull;
 
 public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     private static final int STREAMS_PER_REQUESTED_PAGE = 15;
@@ -40,10 +42,13 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     @Override
     public void onFetchPage(@Nonnull final Downloader downloader) throws IOException,
             ExtractionException {
-
         playlistId = getLinkHandler().getId();
-        final String apiUrl = SOUNDCLOUD_API_V2_URL + "playlists/" + playlistId + "?client_id="
-                + SoundcloudParsingHelper.clientId() + "&representation=compact";
+        final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("playlists")
+                .addPathSegment(playlistId)
+                .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                .addQueryParameter("representation", "compact")
+                .toString();
 
         final String response = downloader.get(apiUrl, getExtractorLocalization()).responseBody();
         try {
@@ -162,8 +167,11 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
             nextIds = page.getIds().subList(STREAMS_PER_REQUESTED_PAGE, page.getIds().size());
         }
 
-        final String currentPageUrl = SOUNDCLOUD_API_V2_URL + "tracks?client_id="
-                + SoundcloudParsingHelper.clientId() + "&ids=" + String.join(",", currentIds);
+        final var currentPageUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("tracks")
+                .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                .addQueryParameter("ids", String.join(",", currentIds))
+                .toString();
 
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
         final String response = NewPipe.getDownloader().get(currentPageUrl,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -213,8 +213,13 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
     @Nullable
     private String getDownloadUrl(@Nonnull final String trackId)
             throws IOException, ExtractionException {
-        final String response = NewPipe.getDownloader().get(SOUNDCLOUD_API_V2_URL + "tracks/"
-                + trackId + "/download" + "?client_id=" + clientId()).responseBody();
+        final var url = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("tracks")
+                .addPathSegment(trackId)
+                .addPathSegment("download")
+                .addQueryParameter("client_id", clientId())
+                .toString();
+        final String response = NewPipe.getDownloader().get(url).responseBody();
 
         final JsonObject downloadJsonObject;
         try {
@@ -343,10 +348,13 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
     @Nullable
     @Override
     public StreamInfoItemsCollector getRelatedItems() throws IOException, ExtractionException {
-        final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-
-        final String apiUrl = SOUNDCLOUD_API_V2_URL + "tracks/" + urlEncode(getId())
-                + "/related?client_id=" + urlEncode(clientId());
+        final var collector = new StreamInfoItemsCollector(getServiceId());
+        final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("tracks")
+                .addPathSegment(getId())
+                .addPathSegment("related")
+                .addQueryParameter("client_id", clientId())
+                .toString();
 
         SoundcloudParsingHelper.getStreamsFromApi(collector, apiUrl);
         return collector;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSubscriptionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSubscriptionExtractor.java
@@ -1,5 +1,9 @@
 package org.schabi.newpipe.extractor.services.soundcloud.extractors;
 
+import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.SOUNDCLOUD_API_V2_URL;
+import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
+import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
+
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItemsCollector;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -12,10 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.SOUNDCLOUD_API_V2_URL;
-import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
-import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
 
 /**
  * Extract the "followings" from a user in SoundCloud.
@@ -45,10 +45,14 @@ public class SoundcloudSubscriptionExtractor extends SubscriptionExtractor {
             throw new InvalidSourceException(e);
         }
 
-        final String apiUrl = SOUNDCLOUD_API_V2_URL + "users/" + id + "/followings" + "?client_id="
-                + SoundcloudParsingHelper.clientId() + "&limit=200";
-        final ChannelInfoItemsCollector collector = new ChannelInfoItemsCollector(service
-                .getServiceId());
+        final var apiUrl = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegment("users")
+                .addPathSegment(id)
+                .addPathSegment("followings")
+                .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                .addQueryParameter("limit", "200")
+                .toString();
+        final var collector = new ChannelInfoItemsCollector(service.getServiceId());
         // ± 2000 is the limit of followings on SoundCloud, so this minimum should be enough
         SoundcloudParsingHelper.getUsersFromApiMinItems(2500, collector, apiUrl);
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSuggestionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudSuggestionExtractor.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.services.soundcloud.extractors;
 
 import static org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper.SOUNDCLOUD_API_V2_URL;
 
-import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
@@ -14,11 +13,10 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
-import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SoundcloudSuggestionExtractor extends SuggestionExtractor {
 
@@ -29,22 +27,20 @@ public class SoundcloudSuggestionExtractor extends SuggestionExtractor {
     @Override
     public List<String> suggestionList(final String query) throws IOException,
             ExtractionException {
-        final List<String> suggestions = new ArrayList<>();
         final Downloader dl = NewPipe.getDownloader();
-        final String url = SOUNDCLOUD_API_V2_URL + "search/queries?q="
-                + Utils.encodeUrlUtf8(query) + "&client_id=" + SoundcloudParsingHelper.clientId()
-                + "&limit=10";
+        final var url = SOUNDCLOUD_API_V2_URL.newBuilder()
+                .addPathSegments("search/queries")
+                .addQueryParameter("q", query)
+                .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                .addQueryParameter("limit", "10")
+                .toString();
         final String response = dl.get(url, getExtractorLocalization()).responseBody();
 
         try {
-            final JsonArray collection = JsonParser.object().from(response).getArray("collection");
-            for (final Object suggestion : collection) {
-                if (suggestion instanceof JsonObject) {
-                    suggestions.add(((JsonObject) suggestion).getString("query"));
-                }
-            }
-
-            return suggestions;
+            return JsonParser.object().from(response).getArray("collection").stream()
+                    .filter(JsonObject.class::isInstance)
+                    .map(suggestion -> ((JsonObject) suggestion).getString("query"))
+                    .collect(Collectors.toList());
         } catch (final JsonParserException e) {
             throw new ParsingException("Could not parse json response", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudSearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/linkHandler/SoundcloudSearchQueryHandlerFactory.java
@@ -12,45 +12,33 @@ import org.schabi.newpipe.extractor.utils.Utils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.Set;
 
 public class SoundcloudSearchQueryHandlerFactory extends SearchQueryHandlerFactory {
-
     public static final String TRACKS = "tracks";
     public static final String USERS = "users";
     public static final String PLAYLISTS = "playlists";
     public static final String ALL = "all";
+    private static final Set<String> QUERY_TYPES = Set.of(TRACKS, USERS, PLAYLISTS);
 
     public static final int ITEMS_PER_PAGE = 10;
 
     @Override
-    public String getUrl(final String id,
-                         final List<String> contentFilter,
-                         final String sortFilter)
+    public String getUrl(final String id, final List<String> contentFilter, final String sortFilter)
             throws ParsingException {
         try {
-            String url = SOUNDCLOUD_API_V2_URL + "search";
+            final var urlBuilder = SOUNDCLOUD_API_V2_URL.newBuilder()
+                    .addPathSegment("search");
 
-            if (!contentFilter.isEmpty()) {
-                switch (contentFilter.get(0)) {
-                    case TRACKS:
-                        url += "/tracks";
-                        break;
-                    case USERS:
-                        url += "/users";
-                        break;
-                    case PLAYLISTS:
-                        url += "/playlists";
-                        break;
-                    case ALL:
-                    default:
-                        break;
-                }
+            if (!contentFilter.isEmpty() && QUERY_TYPES.contains(contentFilter.get(0))) {
+                urlBuilder.addPathSegment(contentFilter.get(0));
             }
 
-            return url + "?q=" + Utils.encodeUrlUtf8(id)
-                    + "&client_id=" + SoundcloudParsingHelper.clientId()
-                    + "&limit=" + ITEMS_PER_PAGE + "&offset=0";
-
+            return urlBuilder.addEncodedQueryParameter("q", Utils.encodeUrlUtf8(id))
+                    .addQueryParameter("client_id", SoundcloudParsingHelper.clientId())
+                    .addQueryParameter("limit", String.valueOf(ITEMS_PER_PAGE))
+                    .addQueryParameter("offset", "0")
+                    .toString();
         } catch (final UnsupportedEncodingException e) {
             throw new ParsingException("Could not encode query", e);
         } catch (final ReCaptchaException e) {
@@ -62,10 +50,6 @@ public class SoundcloudSearchQueryHandlerFactory extends SearchQueryHandlerFacto
 
     @Override
     public String[] getAvailableContentFilter() {
-        return new String[]{
-                ALL,
-                TRACKS,
-                USERS,
-                PLAYLISTS};
+        return new String[]{ALL, TRACKS, USERS, PLAYLISTS};
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampSearchQueryHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampSearchQueryHandlerFactoryTest.java
@@ -2,15 +2,15 @@
 
 package org.schabi.newpipe.extractor.services.bandcamp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.schabi.newpipe.extractor.ServiceList.Bandcamp;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.schabi.newpipe.downloader.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.bandcamp.linkHandler.BandcampSearchQueryHandlerFactory;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.schabi.newpipe.extractor.ServiceList.Bandcamp;
 
 public class BandcampSearchQueryHandlerFactoryTest {
 
@@ -27,8 +27,9 @@ public class BandcampSearchQueryHandlerFactoryTest {
     @Test
     public void testEncoding() throws ParsingException {
         // Note: this isn't exactly as bandcamp does it (it wouldn't encode '!'), but both works
-        assertEquals("https://bandcamp.com/search?q=hello%21%22%C2%A7%24%25%26%2F%28%29%3D&page=1", searchQuery.getUrl("hello!\"§$%&/()="));
-        // Note: bandcamp uses %20 instead of '+', but both works
-        assertEquals("https://bandcamp.com/search?q=search+query+with+spaces&page=1", searchQuery.getUrl("search query with spaces"));
+        assertEquals("https://bandcamp.com/search?q=hello%21%22%C2%A7%24%25%26%2F%28%29%3D&page=1",
+                searchQuery.getUrl("hello!\"§$%&/()="));
+        assertEquals("https://bandcamp.com/search?q=search%20query%20with%20spaces&page=1",
+                searchQuery.getUrl("search query with spaces"));
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
----
OkHttp's [`HttpUrl`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-http-url/) class offers greater functionality compared to the standard [`URL`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html) class, such as a builder class for creating request URLs.

I created a relatively small changeset in this PR to get feedback on if the idea was sound, with more uses of `HttpUrl` to be added in future PRs.