### PR TITLE
[YouTube] Fix search subscriber count extraction with channel handles

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -111,7 +111,8 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     public long getStreamCount() throws ParsingException {
         try {
             if (withHandle || !channelInfoItem.has("videoCountText")) {
-                // Video count is not available, channel probably has no public uploads.
+                // Video count is not available, either the channel has no public uploads
+                // or YouTube displays the channel handle instead.
                 return ListExtractor.ITEM_COUNT_UNKNOWN;
             }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelInfoItemExtractor.java
@@ -34,9 +34,26 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 
 public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor {
     private final JsonObject channelInfoItem;
+    /**
+     * New layout:
+     * "subscriberCountText": Channel handle
+     * "videoCountText": Subscriber count
+     */
+    private final boolean withHandle;
 
     public YoutubeChannelInfoItemExtractor(final JsonObject channelInfoItem) {
         this.channelInfoItem = channelInfoItem;
+
+        boolean wHandle = false;
+        try {
+            final String subscriberCountText = getTextFromObject(
+                    channelInfoItem.getObject("subscriberCountText"));
+            if (subscriberCountText != null) {
+                wHandle = subscriberCountText.startsWith("@");
+            }
+        } catch (final ParsingException ignored) {
+        }
+        this.withHandle = wHandle;
     }
 
     @Override
@@ -78,6 +95,11 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
                 return -1;
             }
 
+            if (withHandle) {
+                return Utils.mixedNumberWordToLong(getTextFromObject(
+                        channelInfoItem.getObject("videoCountText")));
+            }
+
             return Utils.mixedNumberWordToLong(getTextFromObject(
                     channelInfoItem.getObject("subscriberCountText")));
         } catch (final Exception e) {
@@ -88,7 +110,7 @@ public class YoutubeChannelInfoItemExtractor implements ChannelInfoItemExtractor
     @Override
     public long getStreamCount() throws ParsingException {
         try {
-            if (!channelInfoItem.has("videoCountText")) {
+            if (withHandle || !channelInfoItem.has("videoCountText")) {
                 // Video count is not available, channel probably has no public uploads.
                 return ListExtractor.ITEM_COUNT_UNKNOWN;
             }


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- no API changes

I fixed the extraction of channels' subscriber count and the error when trying to extract channel public videos count in search results with the new channel handles.

Fixes #976, fixes TeamNewPipe/NewPipe#9442.