### PR TITLE
Block wrong nullable/nonnull imports in checkstyle

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -96,7 +96,15 @@
         <!-- Checks for imports                              -->
         <!-- See https://checkstyle.org/config_import.html -->
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="IllegalImport"> <!-- defaults to sun.* packages -->
+            <property name="illegalClasses" value="
+                org.jetbrains.annotations.Nullable,
+                org.jetbrains.annotations.NotNull,
+                androidx.annotation.Nullable,
+                androidx.annotation.NonNull,
+                io.reactivex.rxjava3.annotations.NonNull,
+                io.reactivex.rxjava3.annotations.Nullable" />
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Same as https://github.com/TeamNewPipe/NewPipe/pull/9474, but here the Android annotation is forbidden and instead the `javax` is allowed. @TobiGr 