### PR TITLE
[YouTube] Improve YoutubeStreamInfoItemExtractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -403,12 +403,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                 .map(JsonObject.class::cast)
                 .filter(video -> video.has(PLAYLIST_VIDEO_RENDERER))
                 .map(video -> new YoutubeStreamInfoItemExtractor(
-                        video.getObject(PLAYLIST_VIDEO_RENDERER), timeAgoParser) {
-                    @Override
-                    public long getViewCount() {
-                        return -1;
-                    }
-                })
+                        video.getObject(PLAYLIST_VIDEO_RENDERER), timeAgoParser))
                 .forEachOrdered(collector::commit);
     }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe). Debug APK to test (contains an app change to return the comment text as a string, not as a `Description`, in order to avoid the corresponding build error): [app-debug.zip](https://github.com/TeamNewPipe/NewPipeExtractor/files/10185647/app-debug.zip)

This PR improves some code in `YoutubeStreamInfoItemExtractor` and:
- makes duration of video premieres available
- returns view count and upload date of streams in playlists
- uses another non-localized method to determine whether a stream is a running livestream (as a last resort)
- removes the YT Shorts workaround code, as it was only useful on channels, and Shorts have been moved into a separated channel tab.

As a side effect, if duration of YouTube stream items cannot be extracted, `-1` is always returned.