### PR TITLE
[YouTube] Fix escaping links in YouTubeParsingHelper.getTextFromObject

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -937,6 +937,7 @@ public final class YoutubeParsingHelper {
             String text = run.getString("text");
 
             if (html) {
+                text = Entities.escape(text);
                 if (run.has("navigationEndpoint")) {
                     final String url = getUrlFromNavigationEndpoint(run
                             .getObject("navigationEndpoint"));
@@ -962,7 +963,7 @@ public final class YoutubeParsingHelper {
                     textBuilder.append("<s>");
                 }
 
-                textBuilder.append(Entities.escape(text));
+                textBuilder.append(text);
 
                 if (strikethrough) {
                     textBuilder.append("</s>");


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Before, `<a href="...">...</a>` was also escaped.

Fixes https://github.com/TeamNewPipe/NewPipeExtractor/pull/990#issuecomment-1370959102

Untested