### PR TITLE
[YouTube] Fix getting next comments pages

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -179,7 +179,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
                 .getBytes(StandardCharsets.UTF_8);
         // @formatter:on
 
-        final var jsonObject = getJsonPostResponse("next", body, localization);
+        final JsonObject jsonObject = getJsonPostResponse("next", body, localization);
 
         return extractComments(jsonObject);
     }
@@ -188,15 +188,16 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
             throws ExtractionException {
         final CommentsInfoItemsCollector collector = new CommentsInfoItemsCollector(
                 getServiceId());
-        collectCommentsFrom(collector);
+        collectCommentsFrom(collector, jsonObject);
         return new InfoItemsPage<>(collector, getNextPage(jsonObject));
     }
 
-    private void collectCommentsFrom(final CommentsInfoItemsCollector collector)
+    private void collectCommentsFrom(final CommentsInfoItemsCollector collector,
+                                     final JsonObject jsonObject)
             throws ParsingException {
 
         final JsonArray onResponseReceivedEndpoints =
-                ajaxJson.getArray("onResponseReceivedEndpoints");
+                jsonObject.getArray("onResponseReceivedEndpoints");
         // Prevent ArrayIndexOutOfBoundsException
         if (onResponseReceivedEndpoints.isEmpty()) {
             return;


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Fix crash when trying to get second comments pages for YouTube. A regression introduced in #794.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'com.grack.nanojson.JsonArray com.grack.nanojson.JsonObject.getArray(java.lang.String)' on a null object reference
	at org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor.collectCommentsFrom(YoutubeCommentsExtractor.java:199)
	at org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor.extractComments(YoutubeCommentsExtractor.java:191)
	at org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeCommentsExtractor.getPage(YoutubeCommentsExtractor.java:184)
	at org.schabi.newpipe.extractor.comments.CommentsInfo.getMoreItems(CommentsInfo.java:79)
	at org.schabi.newpipe.extractor.comments.CommentsInfo.getMoreItems(CommentsInfo.java:72)
	at org.schabi.newpipe.util.ExtractorHelper.lambda$getMoreCommentItems$8(ExtractorHelper.java:168)
	at org.schabi.newpipe.util.ExtractorHelper$$ExternalSyntheticLambda3.call(Unknown Source:6)
	at io.reactivex.rxjava3.internal.operators.single.SingleFromCallable.subscribeActual(SingleFromCallable.java:43)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4855)
	at io.reactivex.rxjava3.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89)
	at io.reactivex.rxjava3.core.Scheduler$DisposeTask.run(Scheduler.java:644)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:65)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:56)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)


```