### PR TITLE
[YouTube] Fix channel ID extraction of YouTube channels RSS feeds

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeFeedExtractor.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 
 public class YoutubeFeedExtractor extends FeedExtractor {
+    private static final String WEBSITE_CHANNEL_BASE_URL = "https://www.youtube.com/channel/";
+
     public YoutubeFeedExtractor(final StreamingService service, final ListLinkHandler linkHandler) {
         super(service, linkHandler);
     }
@@ -57,19 +59,40 @@ public class YoutubeFeedExtractor extends FeedExtractor {
     @Nonnull
     @Override
     public String getId() {
-        return document.getElementsByTag("yt:channelId").first().text();
+        return getUrl().replace(WEBSITE_CHANNEL_BASE_URL, "");
     }
 
     @Nonnull
     @Override
     public String getUrl() {
-        return document.select("feed > author > uri").first().text();
+        final Element authorUriElement = document.select("feed > author > uri")
+                .first();
+        if (authorUriElement != null) {
+            final String authorUriElementText = authorUriElement.text();
+            if (!authorUriElementText.equals("")) {
+                return authorUriElementText;
+            }
+        }
+
+        final Element linkElement = document.select("feed > link[rel*=alternate]")
+                .first();
+        if (linkElement != null) {
+            return linkElement.attr("href");
+        }
+
+        return "";
     }
 
     @Nonnull
     @Override
     public String getName() {
-        return document.select("feed > author > name").first().text();
+        final Element nameElement = document.select("feed > author > name")
+                .first();
+        if (nameElement == null) {
+            return "";
+        }
+
+        return nameElement.text();
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

In RSS channels feeds, the `yt:channelId` element doesn't provide the channel ID anymore (it has no value), like the `id` element (only the `yt:channel:` prefix is provided). This currently makes `getId()` method of `YoutubeFeedExtractor` returning `null`, and so fails the method `testId` of `YoutubeFeedExtractorTest.Kurzgesagt` test class.

We need now to extract it from the channel URL provided in two elements: `author` -> `uri` and `feed` -> `link`.

This PR also avoids `NullPointerException`s which could happen in `getUrl` and `getName` methods of `YoutubeFeedExtractor`.