### PR TITLE
[YouTube] Remove topStandaloneBadge check for view count of stream items

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -280,7 +280,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Override
     public long getViewCount() throws ParsingException {
-        if (videoInfo.has("topStandaloneBadge") || isPremium() || isPremiere()) {
+        if (isPremium() || isPremiere()) {
             return -1;
         }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Solved TeamNewPipe/NewPipe#9566

<img src="https://user-images.githubusercontent.com/72886809/213560790-6ac77d0a-eec2-4bf3-9e1e-e59bd75f9b07.png" width="200px" alt="yt_stream_items_without_topStandaloneBadge_check">
