### PR TITLE
[YouTube] Fix getting the comment text if the comment contains a hashtag

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -845,6 +845,14 @@ public final class YoutubeParsingHelper {
     @Nullable
     public static String getUrlFromNavigationEndpoint(@Nonnull final JsonObject navigationEndpoint)
             throws ParsingException {
+        if (navigationEndpoint.has("webCommandMetadata")) {
+            // this case needs to be handled before the browseEndpoint,
+            // e.g. for hashtags in comments
+            final JsonObject metadata = navigationEndpoint.getObject("webCommandMetadata");
+            if (metadata.has("url")) {
+                return "https://www.youtube.com" + metadata.getString("url");
+            }
+        }
         if (navigationEndpoint.has("urlEndpoint")) {
             String internUrl = navigationEndpoint.getObject("urlEndpoint").getString("url");
             if (internUrl.startsWith("https://www.youtube.com/redirect?")) {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This fix needs further investigation.
The current approach is very strict and throws a ParsingException if the `webCommandMetadata` is present, but no URL field is given. I was not able to find any other occurrences of that field, but that does not mean there aren't any (I don't know much about the `navigationEndpoint`, maybe somebody can help us out here). A possibly better solution is to put the condition before the `if () else if ...` block as shown below to prevent any unintentional exceptions.
``` Java
@Nullable
public static String getUrlFromNavigationEndpoint(@Nonnull final JsonObject navigationEndpoint)
        throws ParsingException {
   if (navigationEndpoint.has("webCommandMetadata")) {
        // this case needs to be handled before the browseEndpoint,
        // e.g. for hashtags in comments
        final JsonObject metadata = navigationEndpoint.getObject("webCommandMetadata");
        if (metadata.has("url")) {
            return "https://www.youtube.com" + metadata.getString("url");
        }
    }
    if (navigationEndpoint.has("urlEndpoint")) {
        // ...
    } else if (navigationEndpoint.has("browseEndpoint")) {
    // ...
```
Fixes #1019 
