### PR TITLE
[SoundCloud] Fix extraction of tracks like count

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudStreamExtractor.java
@@ -133,7 +133,7 @@ public class SoundcloudStreamExtractor extends StreamExtractor {
 
     @Override
     public long getLikeCount() {
-        return track.getLong("favoritings_count", -1);
+        return track.getLong("likes_count", -1);
     }
 
     @Nonnull

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/soundcloud/SoundcloudStreamExtractorTest.java
@@ -22,7 +22,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
 
 public class SoundcloudStreamExtractorTest {
@@ -64,7 +65,7 @@ public class SoundcloudStreamExtractorTest {
         @Override public long expectedViewCountAtLeast() { return 43000; }
         @Nullable @Override public String expectedUploadDate() { return "2019-05-16 16:28:45.000"; }
         @Nullable @Override public String expectedTextualUploadDate() { return "2019-05-16 16:28:45"; }
-        @Override public long expectedLikeCountAtLeast() { return -1; }
+        @Override public long expectedLikeCountAtLeast() { return 600; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
         @Override public boolean expectedHasAudioStreams() { return false; }
         @Override public boolean expectedHasVideoStreams() { return false; }
@@ -127,7 +128,7 @@ public class SoundcloudStreamExtractorTest {
         @Override public long expectedViewCountAtLeast() { return 386000; }
         @Nullable @Override public String expectedUploadDate() { return "2016-11-11 01:16:37.000"; }
         @Nullable @Override public String expectedTextualUploadDate() { return "2016-11-11 01:16:37"; }
-        @Override public long expectedLikeCountAtLeast() { return -1; }
+        @Override public long expectedLikeCountAtLeast() { return 7350; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
         @Override public boolean expectedHasAudioStreams() { return false; }
         @Override public boolean expectedHasVideoStreams() { return false; }
@@ -170,7 +171,7 @@ public class SoundcloudStreamExtractorTest {
         @Override public long expectedViewCountAtLeast() { return 27000; }
         @Nullable @Override public String expectedUploadDate() { return "2019-03-28 13:36:18.000"; }
         @Nullable @Override public String expectedTextualUploadDate() { return "2019-03-28 13:36:18"; }
-        @Override public long expectedLikeCountAtLeast() { return -1; }
+        @Override public long expectedLikeCountAtLeast() { return 25; }
         @Override public long expectedDislikeCountAtLeast() { return -1; }
         @Override public boolean expectedHasVideoStreams() { return false; }
         @Override public boolean expectedHasSubtitles() { return false; }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe). As SoundCloud tests still pass with my non-breaking API changes, everything should work fine in the app.

This PR fixes the extraction of SoundCloud likes. It uses the current property to get like counts and not the previous one (see #1017).

The corresponding stream like count tests have been updated to assert a value close to the real one.

Fixes #1017.