### PR TITLE
[Bandcamp] Show comments as disabled on radio streams

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsExtractor.java
@@ -53,4 +53,9 @@ public class BandcampCommentsExtractor extends CommentsExtractor {
             throws IOException, ExtractionException {
         return null;
     }
+
+    @Override
+    public boolean isCommentsDisabled() throws ExtractionException {
+        return BandcampExtractorHelper.isRadioUrl(getUrl());
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/linkHandler/BandcampCommentsLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/linkHandler/BandcampCommentsLinkHandlerFactory.java
@@ -19,6 +19,10 @@ public class BandcampCommentsLinkHandlerFactory extends ListLinkHandlerFactory {
 
     @Override
     public boolean onAcceptUrl(final String url) throws ParsingException {
+        if (BandcampExtractorHelper.isRadioUrl(url)) {
+            return true;
+        }
+
         // Don't accept URLs that don't point to a track
         if (!url.toLowerCase().matches("https?://.+\\..+/(track|album)/.+")) {
             return false;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampCommentsLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampCommentsLinkHandlerFactoryTest.java
@@ -32,8 +32,8 @@ public class BandcampCommentsLinkHandlerFactoryTest {
         assertFalse(linkHandler.acceptUrl("https://bandcamp.com"));
         assertFalse(linkHandler.acceptUrl("https://zachbenson.bandcamp.com/"));
         assertFalse(linkHandler.acceptUrl("https://example.com/track/sampletrack"));
-        assertFalse(linkHandler.acceptUrl("http://bandcamP.com/?show=38"));
 
+        assertTrue(linkHandler.acceptUrl("http://bandcamP.com/?show=38"));
         assertTrue(linkHandler.acceptUrl("https://powertothequeerkids.bandcamp.com/album/power-to-the-queer-kids"));
         assertTrue(linkHandler.acceptUrl("https://zachbenson.bandcamp.com/track/kitchen"));
         assertTrue(linkHandler.acceptUrl("http://ZachBenson.Bandcamp.COM/Track/U-I-Tonite/"));


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
No NewPipe changes required.

Comments are now shown as disabled on Bandcamp radio streams, which do not have comments.

Fixes TeamNewPipe/NewPipe#9732

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/88139840/221004066-e35138dc-5a62-4472-b8a6-951933dc4b4f.png)|![image](https://user-images.githubusercontent.com/88139840/221004152-029120c0-35d9-4356-9032-a6c0ad25207a.png)|
