### PR TITLE
[Bandcamp] Handle paywalled tracks

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
@@ -14,8 +14,8 @@ import org.jsoup.nodes.Document;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
-import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
@@ -64,7 +64,7 @@ public class BandcampPlaylistExtractor extends PlaylistExtractor {
 
         if (trackInfo.isEmpty()) {
             // Albums without trackInfo need to be purchased before they can be played
-            throw new ContentNotAvailableException("Album needs to be purchased");
+            throw new PaidContentException("Album needs to be purchased");
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampStreamExtractor.java
@@ -15,6 +15,7 @@ import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -56,6 +57,10 @@ public class BandcampStreamExtractor extends StreamExtractor {
         if (albumJson.getArray("trackinfo").size() > 1) {
             // In this case, we are actually viewing an album page!
             throw new ExtractionException("Page is actually an album, not a track");
+        }
+
+        if (albumJson.getArray("trackinfo").getObject(0).isNull("file")) {
+            throw new PaidContentException("This track is not available without being purchased");
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampPaidStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampPaidStreamExtractorTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.extractor.services.bandcamp;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.schabi.newpipe.extractor.ServiceList.Bandcamp;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.downloader.DownloaderTestImpl;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
+
+public class BandcampPaidStreamExtractorTest {
+
+    @BeforeAll
+    public static void setUp() {
+        NewPipe.init(DownloaderTestImpl.getInstance());
+    }
+
+    @Test
+    public void testPaidTrack() throws ExtractionException {
+        final var extractor = Bandcamp.getStreamExtractor("https://radicaldreamland.bandcamp.com/track/hackmud-continuous-mix");
+        assertThrows(PaidContentException.class, extractor::fetchPage);
+    }
+}


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
No NewPipe changes required.

Tracks that cannot be accessed without being purchased now show an appropriate error.

Fixes TeamNewPipe/NewPipe#8634

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/88139840/221923296-6138bc73-ec26-47a4-bf42-1a787cec845d.png" width="300">|<img src="https://user-images.githubusercontent.com/88139840/221923395-14016c4d-15a7-48ba-8657-ca977ee766c8.png" width="300">|