### PR TITLE
[PeerTube] Fix comments info test

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeCommentsExtractorTest.java
@@ -48,7 +48,7 @@ public class PeertubeCommentsExtractorTest {
 
         @Test
         void testGetCommentsFromCommentsInfo() throws IOException, ExtractionException {
-            final String comment = "great video";
+            final String comment = "Thanks for creating such an informative video";
 
             final CommentsInfo commentsInfo =
                     CommentsInfo.getInfo("https://framatube.org/w/kkGMgK9ZtnKfYAgnEtQxbv");
@@ -69,33 +69,33 @@ public class PeertubeCommentsExtractorTest {
 
         @Test
         void testGetCommentsAllData() throws IOException, ExtractionException {
-            InfoItemsPage<CommentsInfoItem> comments = extractor.getInitialPage();
-            for (CommentsInfoItem c : comments.getItems()) {
-                assertFalse(Utils.isBlank(c.getUploaderUrl()));
-                assertFalse(Utils.isBlank(c.getUploaderName()));
-                assertFalse(Utils.isBlank(c.getUploaderAvatarUrl()));
-                assertFalse(Utils.isBlank(c.getCommentId()));
-                assertFalse(Utils.isBlank(c.getCommentText().getContent()));
-                assertFalse(Utils.isBlank(c.getName()));
-                assertFalse(Utils.isBlank(c.getTextualUploadDate()));
-                assertFalse(Utils.isBlank(c.getThumbnailUrl()));
-                assertFalse(Utils.isBlank(c.getUrl()));
-                assertEquals(-1, c.getLikeCount());
-                assertTrue(Utils.isBlank(c.getTextualLikeCount()));
-            }
+            extractor.getInitialPage()
+                    .getItems()
+                    .forEach(commentsInfoItem -> {
+                        assertFalse(Utils.isBlank(commentsInfoItem.getUploaderUrl()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getUploaderName()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getUploaderAvatarUrl()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getCommentId()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getCommentText().getContent()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getName()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getTextualUploadDate()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getThumbnailUrl()));
+                        assertFalse(Utils.isBlank(commentsInfoItem.getUrl()));
+                        assertEquals(-1, commentsInfoItem.getLikeCount());
+                        assertTrue(Utils.isBlank(commentsInfoItem.getTextualLikeCount()));
+                    });
         }
 
-        private boolean findInComments(InfoItemsPage<CommentsInfoItem> comments, String comment) {
+        private boolean findInComments(final InfoItemsPage<CommentsInfoItem> comments,
+                                       final String comment) {
             return findInComments(comments.getItems(), comment);
         }
 
-        private boolean findInComments(List<CommentsInfoItem> comments, String comment) {
-            for (CommentsInfoItem c : comments) {
-                if (c.getCommentText().getContent().contains(comment)) {
-                    return true;
-                }
-            }
-            return false;
+        private boolean findInComments(final List<CommentsInfoItem> comments,
+                                       final String comment) {
+            return comments.stream()
+                    .anyMatch(commentsInfoItem ->
+                            commentsInfoItem.getCommentText().getContent().contains(comment));
         }
     }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

A comment from which a part of its text was used in `testGetCommentsFromCommentsInfo` method of `PeertubeCommentsExtractorTest.Default` test class has been removed, so it couldn't be found in the comments list.

This comment has been replaced by a new one from the current comments of the video.

Also, in the parent class `PeertubeCommentsExtractorTest`, `final` has been also used as much as possible and for-each loops of lists have been replaced by their `forEach` method or the Stream API, in order to simplify code.