### PR TITLE
[YouTube] Fix descriptive audio role property value in generated DASH manifests

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
@@ -278,7 +278,7 @@ public final class YoutubeDashManifestCreatorsUtils {
      *
      * <p>
      * {@code <Role schemeIdUri="urn:mpeg:DASH:role:2011" value="VALUE"/>}, where {@code VALUE} is
-     * {@code main} for videos and audios and {@code alternate} for descriptive audio
+     * {@code main} for videos and audios and {@code description} for descriptive audio
      * </p>
      *
      * <p>
@@ -299,7 +299,7 @@ public final class YoutubeDashManifestCreatorsUtils {
 
             setAttribute(roleElement, doc, "schemeIdUri", "urn:mpeg:DASH:role:2011");
             setAttribute(roleElement, doc, "value", itagItem.isDescriptiveAudio()
-                    ? "alternate" : "main");
+                    ? "description" : "main");
 
             adaptationSetElement.appendChild(roleElement);
         } catch (final DOMException e) {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeDashManifestCreatorsTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeDashManifestCreatorsTest.java
@@ -233,7 +233,7 @@ class YoutubeDashManifestCreatorsTest {
     private void assertRoleElement(@Nonnull final Document document,
                                    @Nonnull final ItagItem itagItem) {
         final Element element = assertGetElement(document, ROLE, ADAPTATION_SET);
-        assertAttrEquals(itagItem.isDescriptiveAudio() ? "alternate" : "main", element, "value");
+        assertAttrEquals(itagItem.isDescriptiveAudio() ? "description" : "main", element, "value");
     }
 
     private void assertRepresentationElement(@Nonnull final Document document,


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

The note 2 of the section 5.8.5.5 of [ISO/IEC 23009-1](https://standards.iso.org/ittf/PubliclyAvailableStandards/c083314_ISO_IEC%2023009-1_2022(en).zip) specifies that when using the alternate role value, a description of what the alternate track is should be added.

As `alternate` is a generic role and a `description` role exists, it should be used instead of the `alternate` one.

The property value has been of course updated in the corresponding test.

Thanks to @absidue for flagging this on the Invidious Matrix channel.