### PR TITLE
[YouTube] Fix ParsingException when comments are unavailable in a video

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -68,7 +68,14 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
     @Nullable
     private String findInitialCommentsToken(final JsonObject nextResponse)
             throws ExtractionException {
-        final String token = getJsonContents(nextResponse)
+        final JsonArray contents = getJsonContents(nextResponse);
+
+        // For videos where comments are unavailable, this would be null
+        if (contents == null) {
+            return null;
+        }
+
+        final String token = contents
                 .stream()
                 // Only use JsonObjects
                 .filter(JsonObject.class::isInstance)
@@ -104,13 +111,13 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         return token;
     }
 
-    @Nonnull
+    @Nullable
     private JsonArray getJsonContents(final JsonObject nextResponse) {
         try {
             return JsonUtils.getArray(nextResponse,
                     "contents.twoColumnWatchNextResults.results.results.contents");
         } catch (final ParsingException e) {
-            return new JsonArray(Collections.emptyList());
+            return null;
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -66,8 +66,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
      * @return the continuation token or null if none was found
      */
     @Nullable
-    private String findInitialCommentsToken(final JsonObject nextResponse)
-            throws ExtractionException {
+    private String findInitialCommentsToken(final JsonObject nextResponse) {
         final JsonArray contents = getJsonContents(nextResponse);
 
         // For videos where comments are unavailable, this would be null

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -68,8 +68,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
     @Nullable
     private String findInitialCommentsToken(final JsonObject nextResponse)
             throws ExtractionException {
-        final String token = JsonUtils.getArray(nextResponse,
-                        "contents.twoColumnWatchNextResults.results.results.contents")
+        final String token = getJsonContents(nextResponse)
                 .stream()
                 // Only use JsonObjects
                 .filter(JsonObject.class::isInstance)
@@ -103,6 +102,16 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         commentsDisabled = token == null;
 
         return token;
+    }
+
+    @Nonnull
+    private JsonArray getJsonContents(final JsonObject nextResponse) {
+        try {
+            return JsonUtils.getArray(nextResponse,
+                    "contents.twoColumnWatchNextResults.results.results.contents");
+        } catch (final ParsingException pe) {
+            return new JsonArray(Collections.emptyList());
+        }
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -109,7 +109,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         try {
             return JsonUtils.getArray(nextResponse,
                     "contents.twoColumnWatchNextResults.results.results.contents");
-        } catch (final ParsingException pe) {
+        } catch (final ParsingException e) {
             return new JsonArray(Collections.emptyList());
         }
     }


### PR DESCRIPTION
Issue #969. Parsing exception is handled when the JSON path does not exist in the case of disabled comments.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Fixes #969

The output is now
`{"comments":[],"nextpage":null,"disabled":true}`