### PR TITLE
[Bandcamp] Fix extraction of related playlist items URL

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRelatedPlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRelatedPlaylistInfoItemExtractor.java
@@ -25,7 +25,7 @@ public class BandcampRelatedPlaylistInfoItemExtractor implements PlaylistInfoIte
 
     @Override
     public String getUrl() throws ParsingException {
-        return relatedAlbum.getElementsByClass("title-and-artist").attr("abs:href");
+        return relatedAlbum.getElementsByClass("album-link").attr("abs:href");
     }
 
     @Override


### PR DESCRIPTION
Fixes failing Bandcamp tests. There was a small change in the website, so I adjusted the code to pick the class of the actual `a` tag again and not its parent.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
