### PR TITLE
[SoundCloud] Fix certain playlists showing as empty

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
@@ -141,6 +141,15 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
                     }
                 });
 
+        // extract using getPage if no tracks were collected and playlist is not empty
+        if (streamInfoItemsCollector.getItems().isEmpty() && !ids.isEmpty()) {
+            try {
+                return getPage(new Page(ids));
+            } catch (final IOException | ExtractionException e) {
+                return new InfoItemsPage<>(streamInfoItemsCollector, null);
+            }
+        }
+
         return new InfoItemsPage<>(streamInfoItemsCollector, new Page(ids));
     }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
No NewPipe changes required.

For certain SoundCloud playlists, the initial playlist data does not include the full track info for any of the tracks. Because of this, no items get collected in `getIntialPage` and NewPipe shows the playlist as empty.

This change makes it so that `getPage` is used in initial extraction in those cases to prevent `getInitialPage` from returning no items.

I have tested that other playlists still work, including actually empty ones.

Fixes TeamNewPipe/NewPipe#10012

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/88139840/231733343-38b43316-9bf9-474c-926c-873fa233837b.png" width="300">|<img src="https://user-images.githubusercontent.com/88139840/231733738-29b99e4e-b0a2-4f0c-840c-9ad0fa18f793.png" width="300">|