### PR TITLE
[YouTube] fix: set musicClientVersion regex capture group

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -835,7 +835,7 @@ public final class YoutubeParsingHelper {
 
             musicKey = getStringResultFromRegexArray(html, INNERTUBE_API_KEY_REGEXES, 1);
             musicClientVersion = getStringResultFromRegexArray(html,
-                    INNERTUBE_CONTEXT_CLIENT_VERSION_REGEXES);
+                    INNERTUBE_CONTEXT_CLIENT_VERSION_REGEXES, 1);
             musicClientName = Parser.matchGroup1(INNERTUBE_CLIENT_NAME_REGEX, html);
         }
 


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] no API changes

I noticed that the code to extract the YouTube Music client version is missing the regex capture group index.

Since the bug is present in the second fallback option, it probably never caused any issues.

I have tested the fix by commenting out the 2 alternative options.