### PR TITLE
Make sure CI is not vulnerable to bash word splitting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         # See gradle file for difference between downloaders
       - name: Build and run Tests
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'schedule' ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == 'schedule' ]]; then
             echo running with real downloader
             ./gradlew check --stacktrace -Ddownloader=REAL
           else


### PR DESCRIPTION
This shouldn't actually be an issue, since `GITHUB_EVENT_NAME` only contains [known names](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) without spaces, but just to be sure here is a small fix. See the bottom section of https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
