### PR TITLE
[PeerTube] Don't return "No description" when there is no description for a channel or an account

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeAccountExtractor.java
@@ -21,6 +21,7 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper.COUNT_KEY;
@@ -90,13 +91,10 @@ public class PeertubeAccountExtractor extends ChannelExtractor {
         return subscribersCount;
     }
 
+    @Nullable
     @Override
     public String getDescription() {
-        try {
-            return JsonUtils.getString(json, "description");
-        } catch (final ParsingException e) {
-            return "No description";
-        }
+        return json.getString("description");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeChannelExtractor.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper.COUNT_KEY;
@@ -63,13 +64,10 @@ public class PeertubeChannelExtractor extends ChannelExtractor {
         return json.getLong("followersCount");
     }
 
+    @Nullable
     @Override
     public String getDescription() {
-        try {
-            return JsonUtils.getString(json, "description");
-        } catch (final ParsingException e) {
-            return "No description";
-        }
+        return json.getString("description");
     }
 
     @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeAccountExtractorTest.java
@@ -10,10 +10,15 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.BaseChannelExtractorTest;
 import org.schabi.newpipe.extractor.services.peertube.extractors.PeertubeAccountExtractor;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.PeerTube;
-import static org.schabi.newpipe.extractor.services.DefaultTests.*;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestGetPageInNewExtractor;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestMoreItems;
+import static org.schabi.newpipe.extractor.services.DefaultTests.defaultTestRelatedItems;
 
 /**
  * Test for {@link PeertubeAccountExtractor}
@@ -82,7 +87,7 @@ public class PeertubeAccountExtractorTest {
 
         @Test
         public void testDescription() throws ParsingException {
-            assertNotNull(extractor.getDescription());
+            assertNull(extractor.getDescription());
         }
 
         @Test


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

When a description is missing, no description should be returned, even the ones indicating there is no description. This behavior is represented by a null return instead.

Also update `PeertubeAccountExtractorTest` to reflect these changes.