### PR TITLE
Extract playlists description

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -21,6 +21,8 @@ public abstract class PlaylistExtractor extends ListExtractor<StreamInfoItem> {
 
     public abstract long getStreamCount() throws ParsingException;
 
+    public abstract String getDescription() throws ParsingException;
+
     @Nonnull
     public String getThumbnailUrl() throws ParsingException {
         return "";

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -4,6 +4,7 @@ import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import javax.annotation.Nonnull;
@@ -21,7 +22,7 @@ public abstract class PlaylistExtractor extends ListExtractor<StreamInfoItem> {
 
     public abstract long getStreamCount() throws ParsingException;
 
-    public abstract String getDescription() throws ParsingException;
+    public abstract Description getDescription() throws ParsingException;
 
     @Nonnull
     public String getThumbnailUrl() throws ParsingException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistExtractor.java
@@ -22,6 +22,7 @@ public abstract class PlaylistExtractor extends ListExtractor<StreamInfoItem> {
 
     public abstract long getStreamCount() throws ParsingException;
 
+    @Nonnull
     public abstract Description getDescription() throws ParsingException;
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfo.java
@@ -8,6 +8,7 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.utils.ExtractorHelper;
 
@@ -103,6 +104,11 @@ public final class PlaylistInfo extends ListInfo<StreamInfoItem> {
             info.addError(e);
         }
         try {
+            info.setDescription(extractor.getDescription());
+        } catch (final Exception e) {
+            info.addError(e);
+        }
+        try {
             info.setThumbnailUrl(extractor.getThumbnailUrl());
         } catch (final Exception e) {
             info.addError(e);
@@ -174,6 +180,7 @@ public final class PlaylistInfo extends ListInfo<StreamInfoItem> {
     private String subChannelName;
     private String subChannelAvatarUrl;
     private long streamCount = 0;
+    private Description description;
     private PlaylistType playlistType;
 
     public String getThumbnailUrl() {
@@ -246,6 +253,14 @@ public final class PlaylistInfo extends ListInfo<StreamInfoItem> {
 
     public void setStreamCount(final long streamCount) {
         this.streamCount = streamCount;
+    }
+
+    public Description getDescription() {
+        return description;
+    }
+
+    public void setDescription(final Description description) {
+        this.description = description;
     }
 
     public PlaylistType getPlaylistType() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItem.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor.playlist;
 
 import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.stream.Description;
 
 import javax.annotation.Nullable;
 
@@ -13,6 +14,7 @@ public class PlaylistInfoItem extends InfoItem {
      * How many streams this playlist have
      */
     private long streamCount = 0;
+    private Description description;
     private PlaylistInfo.PlaylistType playlistType;
 
     public PlaylistInfoItem(final int serviceId, final String url, final String name) {
@@ -50,6 +52,14 @@ public class PlaylistInfoItem extends InfoItem {
 
     public void setStreamCount(final long streamCount) {
         this.streamCount = streamCount;
+    }
+
+    public Description getDescription() {
+        return description;
+    }
+
+    public void setDescription(final Description description) {
+        this.description = description;
     }
 
     public PlaylistInfo.PlaylistType getPlaylistType() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemExtractor.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.playlist;
 
 import org.schabi.newpipe.extractor.InfoItemExtractor;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.stream.Description;
 
 import javax.annotation.Nonnull;
 
@@ -30,6 +31,16 @@ public interface PlaylistInfoItemExtractor extends InfoItemExtractor {
      * @return the number of streams
      */
     long getStreamCount() throws ParsingException;
+
+    /**
+     * Get the description of the playlist if there is any.
+     * Otherwise, an {@link Description#EMPTY_DESCRIPTION EMPTY_DESCRIPTION} is returned.
+     * @return the playlist's description
+     */
+    @Nonnull
+    default Description getDescription() throws ParsingException {
+        return Description.EMPTY_DESCRIPTION;
+    }
 
     /**
      * @return the type of this playlist, see {@link PlaylistInfo.PlaylistType} for a description

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/playlist/PlaylistInfoItemsCollector.java
@@ -42,6 +42,11 @@ public class PlaylistInfoItemsCollector
             addError(e);
         }
         try {
+            resultItem.setDescription(extractor.getDescription());
+        } catch (final Exception e) {
+            addError(e);
+        }
+        try {
             resultItem.setPlaylistType(extractor.getPlaylistType());
         } catch (final Exception e) {
             addError(e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
@@ -11,6 +11,8 @@ import com.grack.nanojson.JsonParserException;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -25,6 +27,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
@@ -112,7 +115,27 @@ public class BandcampPlaylistExtractor extends PlaylistExtractor {
     @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
-        return Description.EMPTY_DESCRIPTION;
+        final Element tInfo = document.getElementById("trackInfo");
+        if (tInfo == null) {
+            throw new ParsingException("Could not find trackInfo in document");
+        }
+        final Elements about = tInfo.getElementsByClass("tralbum-about");
+        final Elements credits = tInfo.getElementsByClass("tralbum-credits");
+        final Element license = document.getElementById("license");
+        if (about.isEmpty() && credits.isEmpty() && license == null) {
+            return Description.EMPTY_DESCRIPTION;
+        }
+        final StringBuilder sb = new StringBuilder();
+        if (!about.isEmpty()) {
+            sb.append(Objects.requireNonNull(about.first()).html());
+        }
+        if (!credits.isEmpty()) {
+            sb.append(Objects.requireNonNull(credits.first()).html());
+        }
+        if (license != null) {
+            sb.append(license.html());
+        }
+        return new Description(sb.toString(), Description.HTML);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
@@ -109,6 +109,7 @@ public class BandcampPlaylistExtractor extends PlaylistExtractor {
         return trackInfo.size();
     }
 
+    @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
         return Description.EMPTY_DESCRIPTION;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
@@ -108,6 +108,11 @@ public class BandcampPlaylistExtractor extends PlaylistExtractor {
         return trackInfo.size();
     }
 
+    @Override
+    public String getDescription() throws ParsingException {
+        return "";
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws ExtractionException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampPlaylistExtractor.java
@@ -20,6 +20,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.bandcamp.extractors.streaminfoitem.BandcampPlaylistStreamInfoItemExtractor;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
@@ -109,8 +110,8 @@ public class BandcampPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getDescription() throws ParsingException {
-        return "";
+    public Description getDescription() throws ParsingException {
+        return Description.EMPTY_DESCRIPTION;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
@@ -66,9 +66,14 @@ public class PeertubePlaylistExtractor extends PlaylistExtractor {
         return playlistInfo.getLong("videosLength");
     }
 
+    @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
-        return Description.EMPTY_DESCRIPTION;
+        final String description = playlistInfo.getString("description");
+        if (isNullOrEmpty(description)) {
+            return Description.EMPTY_DESCRIPTION;
+        }
+        return new Description(description, Description.PLAIN_TEXT);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
@@ -65,6 +65,11 @@ public class PeertubePlaylistExtractor extends PlaylistExtractor {
         return playlistInfo.getLong("videosLength");
     }
 
+    @Override
+    public String getDescription() throws ParsingException {
+        return "";
+    }
+
     @Nonnull
     @Override
     public String getSubChannelName() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistExtractor.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -66,8 +67,8 @@ public class PeertubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getDescription() throws ParsingException {
-        return "";
+    public Description getDescription() throws ParsingException {
+        return Description.EMPTY_DESCRIPTION;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubePlaylistInfoItemExtractor.java
@@ -4,8 +4,11 @@ import com.grack.nanojson.JsonObject;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemExtractor;
+import org.schabi.newpipe.extractor.stream.Description;
 
 import javax.annotation.Nonnull;
+
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 public class PeertubePlaylistInfoItemExtractor implements PlaylistInfoItemExtractor  {
 
@@ -53,5 +56,15 @@ public class PeertubePlaylistInfoItemExtractor implements PlaylistInfoItemExtrac
     @Override
     public long getStreamCount() throws ParsingException {
         return item.getInt("videosLength");
+    }
+
+    @Nonnull
+    @Override
+    public Description getDescription() throws ParsingException {
+        final String description = item.getString("description");
+        if (isNullOrEmpty(description)) {
+            return Description.EMPTY_DESCRIPTION;
+        }
+        return new Description(description, Description.PLAIN_TEXT);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
@@ -13,6 +13,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudParsingHelper;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
@@ -119,8 +120,8 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getDescription() throws ParsingException {
-        return "";
+    public Description getDescription() throws ParsingException {
+        return Description.EMPTY_DESCRIPTION;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
@@ -118,6 +118,11 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
         return playlist.getLong("track_count");
     }
 
+    @Override
+    public String getDescription() throws ParsingException {
+        return "";
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudPlaylistExtractor.java
@@ -119,9 +119,14 @@ public class SoundcloudPlaylistExtractor extends PlaylistExtractor {
         return playlist.getLong("track_count");
     }
 
+    @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
-        return Description.EMPTY_DESCRIPTION;
+        final String description = playlist.getString("description");
+        if (isNullOrEmpty(description)) {
+            return Description.EMPTY_DESCRIPTION;
+        }
+        return new Description(description, Description.PLAIN_TEXT);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -169,6 +169,11 @@ public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
         return ListExtractor.ITEM_COUNT_INFINITE;
     }
 
+    @Override
+    public String getDescription() throws ParsingException {
+        return "";
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage()

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -170,6 +170,7 @@ public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
         return ListExtractor.ITEM_COUNT_INFINITE;
     }
 
+    @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
         return Description.EMPTY_DESCRIPTION;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
@@ -170,8 +171,8 @@ public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getDescription() throws ParsingException {
-        return "";
+    public Description getDescription() throws ParsingException {
+        return Description.EMPTY_DESCRIPTION;
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -294,6 +294,11 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         return ITEM_COUNT_UNKNOWN;
     }
 
+    @Override
+    public String getDescription() throws ParsingException {
+        return getTextFromObject(getPlaylistInfo().getObject("description"));
+    }
+
     @Nonnull
     @Override
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws IOException, ExtractionException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -295,6 +295,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         return ITEM_COUNT_UNKNOWN;
     }
 
+    @Nonnull
     @Override
     public Description getDescription() throws ParsingException {
         final String description = getTextFromObject(

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
@@ -295,8 +296,13 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     }
 
     @Override
-    public String getDescription() throws ParsingException {
-        return getTextFromObject(getPlaylistInfo().getObject("description"));
+    public Description getDescription() throws ParsingException {
+        final String description = getTextFromObject(
+                getPlaylistInfo().getObject("description"),
+                true
+        );
+
+        return new Description(description, Description.HTML);
     }
 
     @Nonnull

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampPlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampPlaylistExtractorTest.java
@@ -13,12 +13,14 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
 import org.schabi.newpipe.extractor.services.bandcamp.extractors.BandcampPlaylistExtractor;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertContains;
 import static org.schabi.newpipe.extractor.ServiceList.Bandcamp;
 
 /**
@@ -133,6 +135,16 @@ public class BandcampPlaylistExtractorTest {
         @Test
         public void testStreamCount() throws ParsingException {
             assertEquals(5, extractor.getStreamCount());
+        }
+
+        @Test
+        public void testDescription() throws ParsingException {
+            final Description description = extractor.getDescription();
+            assertNotEquals(Description.EMPTY_DESCRIPTION, description);
+            assertContains("Artwork by Shona Radcliffe", description.getContent()); // about
+            assertContains("All tracks written, produced and recorded by Mac Benson",
+                    description.getContent()); // credits
+            assertContains("all rights reserved", description.getContent()); // license
         }
 
         @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubePlaylistExtractorTest.java
@@ -61,6 +61,11 @@ public class PeertubePlaylistExtractorTest {
         }
 
         @Test
+        void testGetDescription() throws ParsingException {
+            ExtractorAsserts.assertContains("épisodes de Shocking", extractor.getDescription().getContent());
+        }
+
+        @Test
         void testGetSubChannelUrl() {
             assertEquals("https://skeptikon.fr/video-channels/metadechoc_channel", extractor.getSubChannelUrl());
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.extractor.services.BasePlaylistExtractorTest;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubePlaylistExtractor;
+import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.io.IOException;
@@ -167,8 +168,8 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testDescription() throws ParsingException {
-            final String description = extractor.getDescription();
-            assertContains("pop songs list", description);
+            final Description description = extractor.getDescription();
+            assertContains("pop songs list", description.getContent());
         }
     }
 
@@ -296,8 +297,8 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testDescription() throws ParsingException {
-            final String description = extractor.getDescription();
-            assertContains("I Wanna Rock Super Gigantic Playlist", description);
+            final Description description = extractor.getDescription();
+            assertContains("I Wanna Rock Super Gigantic Playlist", description.getContent());
         }
     }
 
@@ -410,8 +411,8 @@ public class YoutubePlaylistExtractorTest {
 
         @Test
         public void testDescription() throws ParsingException {
-            final String description = extractor.getDescription();
-            assertContains("47 episodes", description);
+            final Description description = extractor.getDescription();
+            assertContains("47 episodes", description.getContent());
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlaylistExtractorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertContains;
 import static org.schabi.newpipe.extractor.ExtractorAsserts.assertIsSecureUrl;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.services.DefaultTests.assertNoMoreItems;
@@ -163,6 +164,12 @@ public class YoutubePlaylistExtractorTest {
         void getPlaylistType() throws ParsingException {
             assertEquals(PlaylistInfo.PlaylistType.NORMAL, extractor.getPlaylistType());
         }
+
+        @Test
+        public void testDescription() throws ParsingException {
+            final String description = extractor.getDescription();
+            assertContains("pop songs list", description);
+        }
     }
 
     public static class HugePlaylist implements BasePlaylistExtractorTest {
@@ -286,6 +293,12 @@ public class YoutubePlaylistExtractorTest {
         void getPlaylistType() throws ParsingException {
             assertEquals(PlaylistInfo.PlaylistType.NORMAL, extractor.getPlaylistType());
         }
+
+        @Test
+        public void testDescription() throws ParsingException {
+            final String description = extractor.getDescription();
+            assertContains("I Wanna Rock Super Gigantic Playlist", description);
+        }
     }
 
     public static class LearningPlaylist implements BasePlaylistExtractorTest {
@@ -393,6 +406,12 @@ public class YoutubePlaylistExtractorTest {
         @Test
         void getPlaylistType() throws ParsingException {
             assertEquals(PlaylistInfo.PlaylistType.NORMAL, extractor.getPlaylistType());
+        }
+
+        @Test
+        public void testDescription() throws ParsingException {
+            final String description = extractor.getDescription();
+            assertContains("47 episodes", description);
         }
     }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This PR adds a getDescription method for playlist extraction + tests for the description. I am not planning on creating a PR in NewPipe to support this (I implemented this to hopefully add this to the Piped API)

### API changes
This PR adds
- `PlaylistExtractor.getDescription()` and the corresponding  `PlaylistInfo.getDescription()`
- `PlaylistInfoItemExtractor.getDescription()` and the corresponding  `PlaylistInfoItem.getDescription()`