### PR TITLE
[YouTube] Add support for ultralow audio formats

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
@@ -51,14 +51,14 @@ public class ItagItem implements Serializable {
             //////////////////////////////////////////////////////////////////
             new ItagItem(171, AUDIO, WEBMA, 128),
             new ItagItem(172, AUDIO, WEBMA, 256),
+            new ItagItem(599, AUDIO, M4A, 32),
             new ItagItem(139, AUDIO, M4A, 48),
             new ItagItem(140, AUDIO, M4A, 128),
             new ItagItem(141, AUDIO, M4A, 256),
+            new ItagItem(600, AUDIO, WEBMA_OPUS, 35),
             new ItagItem(249, AUDIO, WEBMA_OPUS, 50),
             new ItagItem(250, AUDIO, WEBMA_OPUS, 70),
             new ItagItem(251, AUDIO, WEBMA_OPUS, 160),
-            new ItagItem(599, AUDIO, M4A, 32),
-            new ItagItem(600, AUDIO, WEBMA_OPUS, 48),
 
             /// VIDEO ONLY ////////////////////////////////////////////
             //           ID      Type     Format  Resolution  FPS  ////

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
@@ -57,6 +57,8 @@ public class ItagItem implements Serializable {
             new ItagItem(249, AUDIO, WEBMA_OPUS, 50),
             new ItagItem(250, AUDIO, WEBMA_OPUS, 70),
             new ItagItem(251, AUDIO, WEBMA_OPUS, 160),
+            new ItagItem(599, AUDIO, M4A, 32),
+            new ItagItem(600, AUDIO, WEBMA_OPUS, 48),
 
             /// VIDEO ONLY ////////////////////////////////////////////
             //           ID      Type     Format  Resolution  FPS  ////


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [X] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [X] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

---

While using yt-dlp I noticed that there are two new audio formats for ultra-low connections (599 m4a and 600 webm) which NewPipe doesn't support yet, so I added them.

```
[info] Available formats for NyLdD8wk2XI:
ID  EXT   RESOLUTION FPS CH │   FILESIZE  TBR PROTO │ VCODEC       VBR ACODEC      ABR ASR MORE INFO
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
599 m4a   audio only      2 │    6.61MiB  31k dash  │ audio only       mp4a.40.5   31k 22k ultralow, m4a_dash
600 webm  audio only      2 │    7.46MiB  35k dash  │ audio only       opus        35k 48k ultralow, webm_dash
139 m4a   audio only      2 │   10.48MiB  49k dash  │ audio only       mp4a.40.5   49k 22k low, m4a_dash
249 webm  audio only      2 │   10.89MiB  51k dash  │ audio only       opus        51k 48k low, webm_dash
250 webm  audio only      2 │   13.89MiB  65k dash  │ audio only       opus        65k 48k low, webm_dash
140 m4a   audio only      2 │   27.80MiB 129k dash  │ audio only       mp4a.40.2  129k 44k medium, m4a_dash
251 webm  audio only      2 │   27.06MiB 126k dash  │ audio only       opus       126k 48k medium, webm_dash
```

Here's a screenshot from the build app after these changes, works as expected.

<details>
<summary>Screenshot</summary>

![Screenshot_1684584369](https://github.com/TeamNewPipe/NewPipeExtractor/assets/17043808/c3688d48-e5cd-4f16-b2e9-cbdbc734cef2)

</details>
