### PR TITLE
Use Files methods in tests

### DIFF
--- a/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
@@ -6,12 +6,9 @@ import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,19 +27,14 @@ class MockDownloader extends Downloader {
     public MockDownloader(@Nonnull final String path) {
         this.path = path;
         this.mocks = new HashMap<>();
-        final File[] files = new File(path).listFiles();
-        if (files != null) {
-            for (final File file : files) {
-                if (file.getName().startsWith(RecordingDownloader.FILE_NAME_PREFIX)) {
-                    final TestRequestResponse response;
-                    try(final InputStreamReader reader = new InputStreamReader(
-                            new FileInputStream(file), StandardCharsets.UTF_8)) {
-                        response = new GsonBuilder()
-                                .create()
-                                .fromJson(reader, TestRequestResponse.class);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
+        try (final var directoryStream = Files.newDirectoryStream(Paths.get(path),
+                entry -> entry.getFileName().toString()
+                        .startsWith(RecordingDownloader.FILE_NAME_PREFIX))) {
+            for (final var entry : directoryStream) {
+                try (final var reader = Files.newBufferedReader(entry)) {
+                    final var response = new GsonBuilder()
+                            .create()
+                            .fromJson(reader, TestRequestResponse.class);
                     mocks.put(response.getRequest(), response.getResponse());
                 }
             }

--- a/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/MockDownloader.java
@@ -7,7 +7,9 @@ import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,10 +29,11 @@ class MockDownloader extends Downloader {
     public MockDownloader(@Nonnull final String path) {
         this.path = path;
         this.mocks = new HashMap<>();
+
         try (final var directoryStream = Files.newDirectoryStream(Paths.get(path),
                 entry -> entry.getFileName().toString()
                         .startsWith(RecordingDownloader.FILE_NAME_PREFIX))) {
-            for (final var entry : directoryStream) {
+            for (final Path entry : directoryStream) {
                 try (final var reader = Files.newBufferedReader(entry)) {
                     final var response = new GsonBuilder()
                             .create()
@@ -38,6 +41,8 @@ class MockDownloader extends Downloader {
                     mocks.put(response.getRequest(), response.getResponse());
                 }
             }
+        } catch (final IOException ioe) {
+            throw new UncheckedIOException(ioe);
         }
     }
 

--- a/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
@@ -7,14 +7,9 @@ import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import javax.annotation.Nonnull;
@@ -54,12 +49,13 @@ class RecordingDownloader extends Downloader {
      */
     public RecordingDownloader(final String stringPath) {
         this.path = stringPath;
-        final Path path = Paths.get(stringPath);
-        final File folder = path.toFile();
-        if (folder.exists()) {
-            for (final File file : folder.listFiles()) {
-                if (file.getName().startsWith(RecordingDownloader.FILE_NAME_PREFIX)) {
-                    file.delete();
+        final var path = Paths.get(stringPath);
+        if (Files.exists(path)) {
+            try (final var directoryStream = Files.newDirectoryStream(path,
+                    entry -> entry.getFileName().toString()
+                            .startsWith(RecordingDownloader.FILE_NAME_PREFIX))) {
+                for (final var entry : directoryStream) {
+                    Files.delete(entry);
                 }
             }
         } else {
@@ -84,20 +80,13 @@ class RecordingDownloader extends Downloader {
             response.latestUrl()
         );
 
-        final File outputFile = new File(
-            path + File.separator + FILE_NAME_PREFIX + index + ".json");
+        final var outputPath = Paths.get(path).resolve(FILE_NAME_PREFIX + index + ".json");
         index++;
-        outputFile.createNewFile();
-
-        try (final OutputStreamWriter writer = new OutputStreamWriter(
-            new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
-
+        try (final var writer = Files.newBufferedWriter(outputPath)) {
             new GsonBuilder()
-                .setPrettyPrinting()
-                .create()
-                .toJson(new TestRequestResponse(request, response), writer);
-
-            writer.flush();
+                    .setPrettyPrinting()
+                    .create()
+                    .toJson(new TestRequestResponse(request, response), writer);
         }
 
         return response;

--- a/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
+++ b/extractor/src/test/java/org/schabi/newpipe/downloader/RecordingDownloader.java
@@ -10,6 +10,7 @@ import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import javax.annotation.Nonnull;
@@ -40,7 +41,7 @@ class RecordingDownloader extends Downloader {
             "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)";
 
     private int index = 0;
-    private final String path;
+    private final Path path;
 
     /**
      * Creates the folder described by {@code stringPath} if it does not exist.
@@ -48,20 +49,22 @@ class RecordingDownloader extends Downloader {
      * @param stringPath Path to the folder where the json files will be saved to.
      */
     public RecordingDownloader(final String stringPath) {
-        this.path = stringPath;
-        final var path = Paths.get(stringPath);
+        this.path = Paths.get(stringPath);
+        
         if (Files.exists(path)) {
             try (final var directoryStream = Files.newDirectoryStream(path,
                     entry -> entry.getFileName().toString()
                             .startsWith(RecordingDownloader.FILE_NAME_PREFIX))) {
-                for (final var entry : directoryStream) {
+                for (final Path entry : directoryStream) {
                     Files.delete(entry);
                 }
+            } catch (final IOException ioe) {
+                throw new UncheckedIOException(ioe);
             }
         } else {
             try {
                 Files.createDirectories(path);
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
@@ -80,7 +83,7 @@ class RecordingDownloader extends Downloader {
             response.latestUrl()
         );
 
-        final var outputPath = Paths.get(path).resolve(FILE_NAME_PREFIX + index + ".json");
+        final Path outputPath = path.resolve(FILE_NAME_PREFIX + index + ".json");
         index++;
         try (final var writer = Files.newBufferedWriter(outputPath)) {
             new GsonBuilder()


### PR DESCRIPTION
Use additional [`Files`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html) methods in the unit tests, as they provide better exceptions.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
