### PR TITLE
[YouTube] Support multiple declarations for throttling parameter function name array

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -48,6 +48,9 @@ public final class YoutubeThrottlingDecrypter {
     private static final String DECRYPT_FUNCTION_BODY_REGEX =
             "=\\s*function([\\S\\s]*?\\}\\s*return [\\w$]+?\\.join\\(\"\"\\)\\s*\\};)";
 
+    private static final String DECRYPT_FUNCTION_ARRAY_OBJECT_TYPE_DECLARATION_REGEX = "var ";
+    private static final String FUNCTION_NAMES_IN_DECRYPT_ARRAY_REGEX = "\\s*=\\s*\\[(.+?)][;,]";
+
     private static final Map<String, String> N_PARAMS_CACHE = new HashMap<>();
     private static String decryptFunction;
     private static String decryptFunctionName;
@@ -117,7 +120,8 @@ public final class YoutubeThrottlingDecrypter {
 
         final int arrayNum = Integer.parseInt(matcher.group(2));
         final Pattern arrayPattern = Pattern.compile(
-                "var " + Pattern.quote(functionName) + "\\s*=\\s*\\[(.+?)];");
+                DECRYPT_FUNCTION_ARRAY_OBJECT_TYPE_DECLARATION_REGEX + Pattern.quote(functionName)
+                        + FUNCTION_NAMES_IN_DECRYPT_ARRAY_REGEX);
         final String arrayStr = Parser.matchGroup1(arrayPattern, playerJsCode);
         final String[] names = arrayStr.split(",");
         return names[arrayNum];


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

This PR adds support for multiple variable declarations separated by commas for the throttling parameter function name array, when the throttling parameter function name array is the first declaration. It fixes the throttling parameter decryption for the player [`b7910ca8`](https://www.youtube.com/s/player/b7910ca8/player_ias.vflset/en_US/base.js).

I also moved the corresponding regex parts in static class constants for easier future modifications.