### PR TITLE
[YouTube] fix: nsig deobfuscation function extraction

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingDecrypter.java
@@ -117,7 +117,7 @@ public final class YoutubeThrottlingDecrypter {
 
         final int arrayNum = Integer.parseInt(matcher.group(2));
         final Pattern arrayPattern = Pattern.compile(
-                "var " + Pattern.quote(functionName) + "\\s*=\\s*\\[(.+?)];");
+                "var " + Pattern.quote(functionName) + "\\s*=\\s*\\[(.+?)]");
         final String arrayStr = Parser.matchGroup1(arrayPattern, playerJsCode);
         final String[] names = arrayStr.split(",");
         return names[arrayNum];


### PR DESCRIPTION
Today I noticed that NewPipe is getting throttled. So I looked into the issue and found that the nsig parameter deobfuscation failed because of a small change in the player.js code.

Before, the array definition with the decode function name only defined one variable and ended with a semicolon.

```js
var Zva = [Wka];
```

Now ([Player 71547d26](https://www.youtube.com/s/player/71547d26/player_ias.vflset/en_US/base.js)) they added another variable to the same line. Since the regex was looking for a semicolon, the function name could not be extracted any more:
`"var " + Pattern.quote(functionName) + "\\s*=\\s*\\[(.+?)];"`

```js
var Msa = [ema],
    Jsa = !1;
```

I removed the semicolon from the regex, as it does not seem necessary.