### PR TITLE
[YouTube] Don't throw an exception when there is no banner available on a channel

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -282,7 +282,10 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 ))
                 .filter(url -> !url.contains("s.ytimg.com") && !url.contains("default_banner"))
                 .map(YoutubeParsingHelper::fixThumbnailUrl)
-                .orElseThrow(() -> new ParsingException("Could not get banner"));
+                // Channels may not have a banner, so no exception should be thrown if no banner is
+                // found
+                // Return null in this case
+                .orElse(null);
     }
 
     @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractorTest.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.services.youtube;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -720,7 +721,8 @@ public class YoutubeChannelExtractorTest {
 
         @Test
         public void testBannerUrl() throws Exception {
-            // CarouselHeaderRender does not contain a banner
+            // CarouselHeaderRenders do not contain a banner
+            assertNull(extractor.getBannerUrl());
         }
 
         @Test


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
      I tested my changes by using a temporary unit test with the channel from which the issue has been found and another one with which the issue was reproducible (see below).

On YouTube, channels may not have a banner, so no exception should be thrown if no banner is found. This PR makes `YoutubeChannelExtractor.getBannerUrl` returning `null` when there is no banner instead of throwing a `ParsingException`, like it was the case before (the current behavior has been introduced in #1050).

As `carouselHeaderRender`s do not contain a banner, I tested this behavior in the corresponding test method and test class (`testBannerUrl` in `YoutubeChannelExtractorTest.CarouselHeader`).

This bug has been originally reported in [this comment in the issue of NewPipe v0.25.2's release](https://github.com/TeamNewPipe/NewPipe/issues/10284#issuecomment-1659726774).