### PR TITLE
[media.ccc.de] Only extract kiosk live stream rooms if they are streaming

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCService.java
@@ -101,7 +101,7 @@ public class MediaCCCService extends StreamingService {
                             kioskId
                     ),
                     new MediaCCCConferencesListLinkHandlerFactory(),
-                    "conferences"
+                    MediaCCCConferenceKiosk.KIOSK_ID
             );
 
             list.addKioskEntry(
@@ -111,7 +111,7 @@ public class MediaCCCService extends StreamingService {
                             kioskId
                     ),
                     new MediaCCCRecentListLinkHandlerFactory(),
-                    "recent"
+                    MediaCCCRecentKiosk.KIOSK_ID
             );
 
             list.addKioskEntry(
@@ -121,10 +121,10 @@ public class MediaCCCService extends StreamingService {
                             kioskId
                     ),
                     new MediaCCCLiveListLinkHandlerFactory(),
-                    "live"
+                    MediaCCCLiveStreamKiosk.KIOSK_ID
             );
 
-            list.setDefaultKiosk("recent");
+            list.setDefaultKiosk(MediaCCCRecentKiosk.KIOSK_ID);
         } catch (final Exception e) {
             throw new ExtractionException(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceExtractor.java
@@ -96,7 +96,7 @@ public class MediaCCCConferenceExtractor extends ChannelExtractor {
         try {
             conferenceData = JsonParser.object().from(downloader.get(conferenceUrl).responseBody());
         } catch (final JsonParserException jpe) {
-            throw new ExtractionException("Could not parse json returnd by url: " + conferenceUrl);
+            throw new ExtractionException("Could not parse json returned by URL: " + conferenceUrl);
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceKiosk.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCConferenceKiosk.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 
 public class MediaCCCConferenceKiosk extends KioskExtractor<ChannelInfoItem> {
+
+    public static final String KIOSK_ID = "conferences";
     private JsonObject doc;
 
     public MediaCCCConferenceKiosk(final StreamingService streamingService,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamKiosk.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamKiosk.java
@@ -36,13 +36,16 @@ public class MediaCCCLiveStreamKiosk extends KioskExtractor<StreamInfoItem> {
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
         for (int c = 0; c < doc.size(); c++) {
             final JsonObject conference = doc.getObject(c);
-            final JsonArray groups = conference.getArray("groups");
-            for (int g = 0; g < groups.size(); g++) {
-                final String group = groups.getObject(g).getString("group");
-                final JsonArray rooms = groups.getObject(g).getArray("rooms");
-                for (int r = 0; r < rooms.size(); r++) {
-                    final JsonObject room = rooms.getObject(r);
-                    collector.commit(new MediaCCCLiveStreamKioskExtractor(conference, group, room));
+            if (conference.getBoolean("isCurrentlyStreaming")) {
+                final JsonArray groups = conference.getArray("groups");
+                for (int g = 0; g < groups.size(); g++) {
+                    final String group = groups.getObject(g).getString("group");
+                    final JsonArray rooms = groups.getObject(g).getArray("rooms");
+                    for (int r = 0; r < rooms.size(); r++) {
+                        final JsonObject room = rooms.getObject(r);
+                        collector.commit(new MediaCCCLiveStreamKioskExtractor(
+                                conference, group, room));
+                    }
                 }
             }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamKiosk.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamKiosk.java
@@ -16,6 +16,8 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 public class MediaCCCLiveStreamKiosk extends KioskExtractor<StreamInfoItem> {
+
+    public static final String KIOSK_ID = "live";
     private JsonArray doc;
 
     public MediaCCCLiveStreamKiosk(final StreamingService streamingService,
@@ -62,6 +64,6 @@ public class MediaCCCLiveStreamKiosk extends KioskExtractor<StreamInfoItem> {
     @Nonnull
     @Override
     public String getName() throws ParsingException {
-        return "live";
+        return KIOSK_ID;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCRecentKiosk.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCRecentKiosk.java
@@ -23,6 +23,8 @@ import javax.annotation.Nonnull;
 
 public class MediaCCCRecentKiosk extends KioskExtractor<StreamInfoItem> {
 
+    public static final String KIOSK_ID = "recent";
+
     private JsonObject doc;
 
     public MediaCCCRecentKiosk(final StreamingService streamingService,
@@ -77,6 +79,6 @@ public class MediaCCCRecentKiosk extends KioskExtractor<StreamInfoItem> {
     @Nonnull
     @Override
     public String getName() throws ParsingException {
-        return "recent";
+        return KIOSK_ID;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeService.java
@@ -146,9 +146,9 @@ public class YoutubeService extends StreamingService {
                             id
                     ),
                     new YoutubeTrendingLinkHandlerFactory(),
-                    "Trending"
+                    YoutubeTrendingExtractor.KIOSK_ID
             );
-            list.setDefaultKiosk("Trending");
+            list.setDefaultKiosk(YoutubeTrendingExtractor.KIOSK_ID);
         } catch (final Exception e) {
             throw new ExtractionException(e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -46,6 +46,9 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
+
+    public static final String KIOSK_ID = "Trending";
+
     private JsonObject initialData;
 
     private static final String VIDEOS_TAB_PARAMS = "4gIOGgxtb3N0X3BvcHVsYXI%3D";


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

The c3voc opens the rooms for testing although there is no livestream playing or intended to be watched by the public sometimes. This leads to errors, because no stream can be extracted.

I also made the kiosk ids accessible from outside for better code quality and changes in NewPipe.