### PR TITLE
Use Locale.forLanguageTag() in tests

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/LocaleCompat.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/LocaleCompat.java
@@ -6,7 +6,7 @@ import java.util.Locale;
  * This class contains a simple implementation of {@link Locale#forLanguageTag(String)} for Android
  * API levels below 21 (Lollipop). This is needed as core library desugaring does not backport that
  * method as of this writing.
- *
+ * <br>
  * Relevant issue: https://issuetracker.google.com/issues/171182330
  */
 public final class LocaleCompat {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/media_ccc/MediaCCCStreamExtractorTest.java
@@ -1,5 +1,10 @@
 package org.schabi.newpipe.extractor.services.media_ccc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.schabi.newpipe.extractor.ExtractorAsserts.assertContainsImageUrlInImageCollection;
+import static org.schabi.newpipe.extractor.ServiceList.MediaCCC;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.schabi.newpipe.downloader.DownloaderTestImpl;
@@ -10,19 +15,13 @@ import org.schabi.newpipe.extractor.services.media_ccc.extractors.MediaCCCStream
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
-import org.schabi.newpipe.extractor.utils.LocaleCompat;
-
-import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.schabi.newpipe.extractor.ExtractorAsserts.assertContainsImageUrlInImageCollection;
-import static org.schabi.newpipe.extractor.ServiceList.MediaCCC;
+import javax.annotation.Nullable;
 
 /**
  * Test {@link MediaCCCStreamExtractor}
@@ -96,7 +95,7 @@ public class MediaCCCStreamExtractorTest {
             super.testAudioStreams();
             final List<AudioStream> audioStreams = extractor.getAudioStreams();
             assertEquals(2, audioStreams.size());
-            final Locale expectedLocale = LocaleCompat.forLanguageTag("deu");
+            final Locale expectedLocale = Locale.forLanguageTag("deu");
             assertTrue(audioStreams.stream().allMatch(audioStream ->
                     Objects.equals(audioStream.getAudioLocale(), expectedLocale)));
         }
@@ -174,7 +173,7 @@ public class MediaCCCStreamExtractorTest {
             super.testAudioStreams();
             final List<AudioStream> audioStreams = extractor.getAudioStreams();
             assertEquals(2, audioStreams.size());
-            final Locale expectedLocale = LocaleCompat.forLanguageTag("eng");
+            final Locale expectedLocale = Locale.forLanguageTag("eng");
             assertTrue(audioStreams.stream().allMatch(audioStream ->
                     Objects.equals(audioStream.getAudioLocale(), expectedLocale)));
         }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/stream/YoutubeStreamExtractorDefaultTest.java
@@ -50,7 +50,6 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.stream.StreamSegment;
 import org.schabi.newpipe.extractor.stream.StreamType;
-import org.schabi.newpipe.extractor.utils.LocaleCompat;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -560,7 +559,7 @@ public class YoutubeStreamExtractorDefaultTest {
                     .anyMatch(audioStream ->
                             "English original".equals(audioStream.getAudioTrackName())));
 
-            final Locale hindiLocale = LocaleCompat.forLanguageTag("hi");
+            final Locale hindiLocale = Locale.forLanguageTag("hi");
             assertTrue(audioStreams.stream()
                     .anyMatch(audioStream ->
                             Objects.equals(audioStream.getAudioLocale(), hindiLocale)));


### PR DESCRIPTION
Use `Locale.forLanguageTag()` directly in the tests.

----

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
