### PR TITLE
[YouTube] Implement emergency meta info

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeMetaInfoHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeMetaInfoHelper.java
@@ -1,0 +1,200 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.extractCachedUrlIfNeeded;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObjectOrThrow;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isGoogleURL;
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.replaceHttpWithHttps;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.MetaInfo;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.stream.Description;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+public final class YoutubeMetaInfoHelper {
+
+    private YoutubeMetaInfoHelper() {
+    }
+
+
+    @Nonnull
+    public static List<MetaInfo> getMetaInfo(@Nonnull final JsonArray contents)
+            throws ParsingException {
+        final List<MetaInfo> metaInfo = new ArrayList<>();
+        for (final Object content : contents) {
+            final JsonObject resultObject = (JsonObject) content;
+            if (resultObject.has("itemSectionRenderer")) {
+                for (final Object sectionContentObject
+                        : resultObject.getObject("itemSectionRenderer").getArray("contents")) {
+
+                    final JsonObject sectionContent = (JsonObject) sectionContentObject;
+                    if (sectionContent.has("infoPanelContentRenderer")) {
+                        metaInfo.add(getInfoPanelContent(sectionContent
+                                .getObject("infoPanelContentRenderer")));
+                    }
+                    if (sectionContent.has("clarificationRenderer")) {
+                        metaInfo.add(getClarificationRenderer(sectionContent
+                                .getObject("clarificationRenderer")
+                        ));
+                    }
+                    if (sectionContent.has("emergencyOneboxRenderer")) {
+                        getEmergencyOneboxRenderer(
+                                sectionContent.getObject("emergencyOneboxRenderer"),
+                                metaInfo::add
+                        );
+                    }
+                }
+            }
+        }
+        return metaInfo;
+    }
+
+    @Nonnull
+    private static MetaInfo getInfoPanelContent(@Nonnull final JsonObject infoPanelContentRenderer)
+            throws ParsingException {
+        final MetaInfo metaInfo = new MetaInfo();
+        final StringBuilder sb = new StringBuilder();
+        for (final Object paragraph : infoPanelContentRenderer.getArray("paragraphs")) {
+            if (sb.length() != 0) {
+                sb.append("<br>");
+            }
+            sb.append(getTextFromObject((JsonObject) paragraph));
+        }
+        metaInfo.setContent(new Description(sb.toString(), Description.HTML));
+        if (infoPanelContentRenderer.has("sourceEndpoint")) {
+            final String metaInfoLinkUrl = getUrlFromNavigationEndpoint(
+                    infoPanelContentRenderer.getObject("sourceEndpoint"));
+            try {
+                metaInfo.addUrl(new URL(Objects.requireNonNull(extractCachedUrlIfNeeded(
+                        metaInfoLinkUrl))));
+            } catch (final NullPointerException | MalformedURLException e) {
+                throw new ParsingException("Could not get metadata info URL", e);
+            }
+
+            final String metaInfoLinkText = getTextFromObject(
+                    infoPanelContentRenderer.getObject("inlineSource"));
+            if (isNullOrEmpty(metaInfoLinkText)) {
+                throw new ParsingException("Could not get metadata info link text.");
+            }
+            metaInfo.addUrlText(metaInfoLinkText);
+        }
+
+        return metaInfo;
+    }
+
+    @Nonnull
+    private static MetaInfo getClarificationRenderer(
+            @Nonnull final JsonObject clarificationRenderer) throws ParsingException {
+        final MetaInfo metaInfo = new MetaInfo();
+
+        final String title = getTextFromObject(clarificationRenderer
+                .getObject("contentTitle"));
+        final String text = getTextFromObject(clarificationRenderer
+                .getObject("text"));
+        if (title == null || text == null) {
+            throw new ParsingException("Could not extract clarification renderer content");
+        }
+        metaInfo.setTitle(title);
+        metaInfo.setContent(new Description(text, Description.PLAIN_TEXT));
+
+        if (clarificationRenderer.has("actionButton")) {
+            final JsonObject actionButton = clarificationRenderer.getObject("actionButton")
+                    .getObject("buttonRenderer");
+            try {
+                final String url = getUrlFromNavigationEndpoint(actionButton
+                        .getObject("command"));
+                metaInfo.addUrl(new URL(Objects.requireNonNull(extractCachedUrlIfNeeded(url))));
+            } catch (final NullPointerException | MalformedURLException e) {
+                throw new ParsingException("Could not get metadata info URL", e);
+            }
+
+            final String metaInfoLinkText = getTextFromObject(
+                    actionButton.getObject("text"));
+            if (isNullOrEmpty(metaInfoLinkText)) {
+                throw new ParsingException("Could not get metadata info link text.");
+            }
+            metaInfo.addUrlText(metaInfoLinkText);
+        }
+
+        if (clarificationRenderer.has("secondaryEndpoint") && clarificationRenderer
+                .has("secondarySource")) {
+            final String url = getUrlFromNavigationEndpoint(clarificationRenderer
+                    .getObject("secondaryEndpoint"));
+            // Ignore Google URLs, because those point to a Google search about "Covid-19"
+            if (url != null && !isGoogleURL(url)) {
+                try {
+                    metaInfo.addUrl(new URL(url));
+                    final String description = getTextFromObject(clarificationRenderer
+                            .getObject("secondarySource"));
+                    metaInfo.addUrlText(description == null ? url : description);
+                } catch (final MalformedURLException e) {
+                    throw new ParsingException("Could not get metadata info secondary URL", e);
+                }
+            }
+        }
+
+        return metaInfo;
+    }
+
+    private static void getEmergencyOneboxRenderer(
+            @Nonnull final JsonObject emergencyOneboxRenderer,
+            final Consumer<MetaInfo> addMetaInfo
+    ) throws ParsingException {
+        final List<JsonObject> supportRenderers = emergencyOneboxRenderer.values()
+                .stream()
+                .filter(o -> o instanceof JsonObject
+                        && ((JsonObject) o).has("singleActionEmergencySupportRenderer"))
+                .map(o -> ((JsonObject) o).getObject("singleActionEmergencySupportRenderer"))
+                .collect(Collectors.toList());
+
+        if (supportRenderers.isEmpty()) {
+            throw new ParsingException("Could not extract any meta info from emergency renderer");
+        }
+
+        for (final JsonObject r : supportRenderers) {
+            final MetaInfo metaInfo = new MetaInfo();
+
+            // usually an encouragement like "We are with you"
+            final String title = getTextFromObjectOrThrow(r.getObject("title"), "title");
+            // usually a phone number
+            final String action = getTextFromObjectOrThrow(r.getObject("actionText"), "action");
+            // usually details about the phone number
+            final String details = getTextFromObjectOrThrow(r.getObject("detailsText"), "details");
+            // usually the name of an association
+            final String urlText = getTextFromObjectOrThrow(r.getObject("navigationText"),
+                    "urlText");
+
+            metaInfo.setTitle(title);
+            metaInfo.setContent(new Description(details + "\n" + action, Description.PLAIN_TEXT));
+            metaInfo.addUrlText(urlText);
+
+            // usually the webpage of the association
+            final String url = getUrlFromNavigationEndpoint(r.getObject("navigationEndpoint"));
+            if (url == null) {
+                throw new ParsingException("Could not extract emergency renderer url");
+            }
+
+            try {
+                metaInfo.addUrl(new URL(replaceHttpWithHttps(url)));
+            } catch (final MalformedURLException e) {
+                throw new ParsingException("Could not parse emergency renderer url", e);
+            }
+
+            addMetaInfo.accept(metaInfo);
+        }
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -30,7 +30,7 @@ import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
-import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
+import org.schabi.newpipe.extractor.services.youtube.YoutubeMetaInfoHelper;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import java.io.IOException;
@@ -151,7 +151,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
     @Nonnull
     @Override
     public List<MetaInfo> getMetaInfo() throws ParsingException {
-        return YoutubeParsingHelper.getMetaInfo(
+        return YoutubeMetaInfoHelper.getMetaInfo(
                 initialData.getObject("contents")
                         .getObject("twoColumnSearchResultsRenderer")
                         .getObject("primaryContents")

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -67,6 +67,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.localization.TimeAgoPatternsManager;
 import org.schabi.newpipe.extractor.services.youtube.ItagItem;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager;
+import org.schabi.newpipe.extractor.services.youtube.YoutubeMetaInfoHelper;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.stream.AudioStream;
@@ -1592,7 +1593,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Nonnull
     @Override
     public List<MetaInfo> getMetaInfo() throws ParsingException {
-        return YoutubeParsingHelper.getMetaInfo(nextResponse
+        return YoutubeMetaInfoHelper.getMetaInfo(nextResponse
                 .getObject("contents")
                 .getObject("twoColumnWatchNextResults")
                 .getObject("results")

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -446,5 +446,15 @@ public class YoutubeSearchExtractorTest {
         @Override public String expectedOriginalUrlContains() throws Exception { return "youtube.com/results?search_query=" + Utils.encodeUrlUtf8(QUERY); }
         @Override public String expectedSearchString() { return QUERY; }
         @Nullable @Override public String expectedSearchSuggestion() { return null; }
+
+        @Test
+        @Override
+        public void testMetaInfo() throws Exception {
+            final List<MetaInfo> metaInfoList = extractor().getMetaInfo();
+
+            // the meta info will have different text and language depending on where in the world
+            // the connection is established from, so we can't check the actual content
+            assertEquals(1, metaInfoList.size());
+        }
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

As seen in #1127, YouTube provides that meta info panel when users search for really sensitive content like suicide (e.g. "blue whale").

<img width="912" alt="image" src="https://github.com/TeamNewPipe/NewPipeExtractor/assets/36421898/1d4f2897-c067-4ab9-b39c-223fb8f32932">


It contains:
- an encouragement as title (e.g. "Siamo con te" / "We are with you")
- a phone number as action (e.g.  "Chiama ..." / "Call ...")
- details about how to call the phone number (e.g. in which time ranges the phone number can be called)
- an url pointing to the website of an association (e.g. "Samaritans Onlus")

Since NewPipe's meta infos contain only one details field, I concatenated the phone number on a new line after the phone number details.

<img width="552" alt="image" src="https://github.com/TeamNewPipe/NewPipeExtractor/assets/36421898/1cb2ada8-7b1a-487c-9219-e893fd5bdb90">

This is how it looks in NewPipe:

<img width="247" alt="image" src="https://github.com/TeamNewPipe/NewPipeExtractor/assets/36421898/e08e6210-4e8b-4cf3-912b-fd02b92be9a5">

Also add a test that just checks if a meta info is properly extracted. Since this test depends on #1127, this PR includes those commits, too. I will cherry-pick once #1127 is merged.

Also move meta info extraction to separate file, since YoutubeParsingHelper was longer than 2000 lines which caused checkstyle issues.