### PR TITLE
Fix SearchInfo's non-null MetaInfo being null when initialized or when an extraction error occurs

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/search/SearchInfo.java
@@ -19,7 +19,7 @@ public class SearchInfo extends ListInfo<InfoItem> {
     private final String searchString;
     private String searchSuggestion;
     private boolean isCorrectedSearch;
-    private List<MetaInfo> metaInfo;
+    private List<MetaInfo> metaInfo = List.of();
 
     public SearchInfo(final int serviceId,
                       final SearchQueryHandler qIHandler,


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

The meta info might have been null either when SearchInfo is first initialized, or when extractor.getMetaInfo() throws an exception in getInfo(). This caused NewPipe to crash instead of showing a nice error in https://www.reddit.com/r/youtube/comments/184ttmw/what_exactly_about_blue_whales_has_youtube_so/. The meta info extraction for sensitive queries will be fixed in https://github.com/TeamNewPipe/NewPipeExtractor/pull/1135.