### PR TITLE
[PeerTube] Add support for PeerTube v6 features

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/Frameset.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/Frameset.java
@@ -3,6 +3,9 @@ package org.schabi.newpipe.extractor.stream;
 import java.io.Serializable;
 import java.util.List;
 
+/**
+ * Class to handle framesets / storyboards which summarize the stream content.
+ */
 public final class Frameset implements Serializable {
 
     private final List<String> urls;
@@ -13,6 +16,17 @@ public final class Frameset implements Serializable {
     private final int framesPerPageX;
     private final int framesPerPageY;
 
+    /**
+     * Creates a new Frameset or set of storyboards.
+     * @param urls the URLs to the images with frames / storyboards
+     * @param frameWidth the width of a single frame, in pixels
+     * @param frameHeight the height of a single frame, in pixels
+     * @param totalCount the total count of frames
+     * @param durationPerFrame the duration per frame in milliseconds
+     * @param framesPerPageX the maximum count of frames per page by x / over the width of the image
+     * @param framesPerPageY the maximum count of frames per page by y / over the height
+     *                       of the image
+     */
     public Frameset(
             final List<String> urls,
             final int frameWidth,
@@ -32,7 +46,7 @@ public final class Frameset implements Serializable {
     }
 
     /**
-     * @return list of urls to images with frames
+     * @return list of URLs to images with frames
      */
     public List<String> getUrls() {
         return urls;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/peertube/PeertubeStreamExtractorTest.java
@@ -26,7 +26,6 @@ public abstract class PeertubeStreamExtractorTest extends DefaultStreamExtractor
     private static final String BASE_URL = "/videos/watch/";
 
     @Override public boolean expectedHasAudioStreams() { return false; }
-    @Override public boolean expectedHasFrames() { return false; }
 
     public static class WhatIsPeertube extends PeertubeStreamExtractorTest {
         private static final String ID = "9c9de5e8-0a1e-484a-b099-e80766180a6d";
@@ -138,6 +137,7 @@ public abstract class PeertubeStreamExtractorTest extends DefaultStreamExtractor
         @Override public String expectedLicence() { return "Unknown"; }
         @Override public Locale expectedLanguageInfo() { return null; }
         @Override public List<String> expectedTags() { return Arrays.asList("Marinauts", "adobe flash", "adobe flash player", "flash games", "the marinauts"); }
+        @Override public boolean expectedHasFrames() { return false; } // not yet supported by instance
     }
 
     @Disabled("Test broken, SSL problem")
@@ -185,6 +185,50 @@ public abstract class PeertubeStreamExtractorTest extends DefaultStreamExtractor
         @Override public List<String> expectedTags() { return Arrays.asList("Covid-19", "Gérôme-Mary trebor", "Horreur et beauté", "court-métrage", "nue artistique"); }
     }
 
+    public static class Segments extends PeertubeStreamExtractorTest {
+        private static final String ID = "vqABGP97fEjo7RhPuDnSZk";
+        private static final String INSTANCE = "https://tube.tchncs.de";
+
+        private static final String URL = INSTANCE + BASE_URL + ID;
+        private static StreamExtractor extractor;
+
+        @BeforeAll
+        public static void setUp() throws Exception {
+            NewPipe.init(DownloaderTestImpl.getInstance());
+            // setting instance might break test when running in parallel (!)
+            PeerTube.setInstance(new PeertubeInstance(INSTANCE, "tchncs.de"));
+            extractor = PeerTube.getStreamExtractor(URL);
+            extractor.fetchPage();
+        }
+
+        @Override public StreamExtractor extractor() { return extractor; }
+        @Override public StreamingService expectedService() { return PeerTube; }
+        @Override public String expectedName() { return "Bauinformatik 11 – Objekte und Methoden"; }
+        @Override public String expectedId() { return ID; }
+        @Override public String expectedUrlContains() { return INSTANCE + BASE_URL + ID; }
+        @Override public String expectedOriginalUrlContains() { return URL; }
+
+        @Override public StreamType expectedStreamType() { return StreamType.VIDEO_STREAM; }
+        @Override public String expectedUploaderName() { return "Martin Vogel"; }
+        @Override public String expectedUploaderUrl() { return "https://tube.tchncs.de/accounts/martin_vogel@tube.tchncs.de"; }
+        @Override public String expectedSubChannelName() { return "Bauinformatik mit Python"; }
+        @Override public String expectedSubChannelUrl() { return "https://tube.tchncs.de/video-channels/python"; }
+        @Override public List<String> expectedDescriptionContains() { // CRLF line ending
+            return Arrays.asList("Um", "Programme", "Variablen", "Funktionen", "Objekte", "Skript", "Wiederholung", "Listen");
+        }
+        @Override public long expectedLength() { return 1017; }
+        @Override public long expectedViewCountAtLeast() { return 20; }
+        @Nullable @Override public String expectedUploadDate() { return "2023-12-08 15:57:04.142"; }
+        @Nullable @Override public String expectedTextualUploadDate() { return "2023-12-08T15:57:04.142Z"; }
+        @Override public long expectedLikeCountAtLeast() { return 0; }
+        @Override public long expectedDislikeCountAtLeast() { return 0; }
+        @Override public boolean expectedHasSubtitles() { return false; }
+        @Override public String expectedHost() { return "tube.tchncs.de"; }
+        @Override public String expectedCategory() { return "Unknown"; }
+        @Override public String expectedLicence() { return "Unknown"; }
+        @Override public Locale expectedLanguageInfo() { return null; }
+        @Override public List<String> expectedTags() { return Arrays.asList("Attribute", "Bauinformatik", "Klassen", "Objekte", "Python"); }
+    }
 
     @BeforeAll
     public static void setUp() throws Exception {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

# Description

[PeerTube 6.0.0 ](https://joinpeertube.org/news/release-6.0) added support for multiple new features which are implemented in this PR:

- [x] support for stream segments/chapters extraction: implement `PeerTubeStreamExtractor.getStreamSegments()`
- [x] support for storyboard / video preview: implement `PeerTubeStreamExtractor.getFrames()`

# Videos for testing

- https://tube.tchncs.de/w/6U8A1AZ8nEkzgZXwf2kdW7
- https://framatube.org/w/vqABGP97fEjo7RhPuDnSZk
