### PR TITLE
Update PeertubeTrendingLinkHandlerFactory.java

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
@@ -21,7 +21,7 @@ public final class PeertubeTrendingLinkHandlerFactory extends ListLinkHandlerFac
             KIOSK_TRENDING, "%s/api/v1/videos?sort=-trending",
             KIOSK_MOST_LIKED, "%s/api/v1/videos?sort=-likes",
             KIOSK_RECENT, "%s/api/v1/videos?sort=-publishedAt",
-            KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&filter=local");
+            KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&isLocal=true");
 
     private PeertubeTrendingLinkHandlerFactory() {
     }


### PR DESCRIPTION
correcting Peertube local trending api URL (per TeamNewPipe/NewPipe#10685); see https://docs.joinpeertube.org/api-rest-reference.html#tag/Video/operation/getVideos

- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
