### PR TITLE
[YouTube] Add trending position to StreamInfoItem

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -509,6 +509,15 @@ public final class YoutubeParsingHelper {
         }
     }
 
+    public static JsonObject getInitialDataFromURL(final String url) throws ParsingException {
+        try {
+            final String html = getDownloader().get(url, getCookieHeader()).responseBody();
+            return getInitialData(html);
+        } catch (final IOException | ReCaptchaException  e) {
+            throw new ParsingException("Could not get ytInitialData", e);
+        }
+    }
+
     private static JsonObject getInitialData(final String html) throws ParsingException {
         try {
             return JsonParser.object().from(getStringResultFromRegexArray(html,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -33,6 +33,7 @@ import org.schabi.newpipe.extractor.localization.DateWrapper;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
@@ -469,5 +470,26 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         } catch (final Exception e) {
             throw new ParsingException("Could not determine if this is short-form content", e);
         }
+    }
+
+    @Override
+    public int getTrendingPosition() throws ParsingException {
+        final JsonObject initialData = YoutubeParsingHelper.getInitialDataFromURL(getUrl());
+        final JsonObject superTitleLink = initialData.getObject("contents")
+                .getObject("twoColumnWatchNextResults")
+                .getObject("results")
+                .getObject("results")
+                .getArray("contents")
+                .getObject(0)
+                .getObject("videoPrimaryInfoRenderer")
+                .getObject("superTitleLink");
+        String text = YoutubeParsingHelper.getTextFromObject(superTitleLink);
+        // example text: #15 on Trending
+        if (text == null || text.isBlank() || !text.startsWith("#")) {
+            return StreamInfoItem.NOT_TRENDING;
+        }
+
+        text = text.substring(1, text.indexOf(' '));
+        return Integer.parseInt(text);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -581,6 +581,17 @@ public abstract class StreamExtractor extends Extractor {
         return false;
     }
 
+    /**
+     * Get trending position.
+     *
+     * @return The current trending position or {@value StreamInfoItem#NOT_TRENDING}
+     *  if the video is not trending
+     * @throws ParsingException if an error occurs while parsing
+     */
+    public int getTrendingPosition() throws ParsingException {
+        return StreamInfoItem.NOT_TRENDING;
+    }
+
     public enum Privacy {
         PUBLIC,
         UNLISTED,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -330,6 +330,11 @@ public class StreamInfo extends Info {
         } catch (final Exception e) {
             streamInfo.addError(e);
         }
+        try {
+            streamInfo.setTrendingPosition(extractor.getTrendingPosition());
+        } catch (final Exception e) {
+            streamInfo.addError(e);
+        }
 
         streamInfo.setRelatedItems(ExtractorHelper.getRelatedItemsOrLogError(streamInfo,
                 extractor));
@@ -381,6 +386,7 @@ public class StreamInfo extends Info {
     private List<StreamSegment> streamSegments = List.of();
     private List<MetaInfo> metaInfo = List.of();
     private boolean shortFormContent = false;
+    private int trendingPosition = -1;
 
     /**
      * Preview frames, e.g. for the storyboard / seekbar thumbnail preview
@@ -726,5 +732,13 @@ public class StreamInfo extends Info {
 
     public void setShortFormContent(final boolean isShortFormContent) {
         this.shortFormContent = isShortFormContent;
+    }
+
+    public int getTrendingPosition() {
+        return trendingPosition;
+    }
+
+    public void setTrendingPosition(final int trendingPosition) {
+        this.trendingPosition = trendingPosition;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
@@ -47,6 +47,10 @@ public class StreamInfoItem extends InfoItem {
     private List<Image> uploaderAvatars = List.of();
     private boolean uploaderVerified = false;
     private boolean shortFormContent = false;
+    private int trendingPosition = -1;
+
+    public static final int NOT_TRENDING = -1;
+
 
     public StreamInfoItem(final int serviceId,
                           final String url,
@@ -141,6 +145,14 @@ public class StreamInfoItem extends InfoItem {
 
     public void setShortFormContent(final boolean shortFormContent) {
         this.shortFormContent = shortFormContent;
+    }
+
+    public int getTrendingPosition() {
+        return trendingPosition;
+    }
+
+    public void setTrendingPosition(final int trendingPosition) {
+        this.trendingPosition = trendingPosition;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
@@ -146,4 +146,15 @@ public interface StreamInfoItemExtractor extends InfoItemExtractor {
     default boolean isShortFormContent() throws ParsingException {
         return false;
     }
+
+    /**
+     * Get trending position.
+     *
+     * @return The current trending position or {@value StreamInfoItem#NOT_TRENDING}
+     *  if the video is not trending
+     * @throws ParsingException if an error occurs while parsing
+     */
+    default int getTrendingPosition() throws ParsingException {
+        return StreamInfoItem.NOT_TRENDING;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
@@ -103,6 +103,11 @@ public class StreamInfoItemsCollector
         } catch (final Exception e) {
             addError(e);
         }
+        try {
+            resultItem.setTrendingPosition(extractor.getTrendingPosition());
+        } catch (final Exception e) {
+            addError(e);
+        }
 
         return resultItem;
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Adds support for getting the trending position of the video, e.g. `#16 on Trending`.
![Image showing the trending tag of a video](https://github.com/TeamNewPipe/NewPipeExtractor/assets/63370021/852af06d-1d5f-42d9-a951-369a643493aa)
