### PR TITLE
Make getCommentText @Nonnull

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItem.java
@@ -13,7 +13,8 @@ import java.util.List;
 public class CommentsInfoItem extends InfoItem {
 
     private String commentId;
-    private Description commentText;
+    @Nonnull
+    private Description commentText = Description.EMPTY_DESCRIPTION;
     private String uploaderName;
     @Nonnull
     private List<Image> uploaderAvatars = List.of();
@@ -50,11 +51,12 @@ public class CommentsInfoItem extends InfoItem {
         this.commentId = commentId;
     }
 
+    @Nonnull
     public Description getCommentText() {
         return commentText;
     }
 
-    public void setCommentText(final Description commentText) {
+    public void setCommentText(@Nonnull final Description commentText) {
         this.commentText = commentText;
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfoItemExtractor.java
@@ -45,6 +45,7 @@ public interface CommentsInfoItemExtractor extends InfoItemExtractor {
     /**
      * The text of the comment
      */
+    @Nonnull
     default Description getCommentText() throws ParsingException {
         return Description.EMPTY_DESCRIPTION;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsInfoItemExtractor.java
@@ -38,6 +38,7 @@ public class BandcampCommentsInfoItemExtractor implements CommentsInfoItemExtrac
         return getUploaderAvatars();
     }
 
+    @Nonnull
     @Override
     public Description getCommentText() throws ParsingException {
         return new Description(review.getString("why"), Description.PLAIN_TEXT);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -77,6 +77,7 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
         return new DateWrapper(parseDateFrom(textualUploadDate));
     }
 
+    @Nonnull
     @Override
     public Description getCommentText() throws ParsingException {
         final String htmlText = JsonUtils.getString(item, "text");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/soundcloud/extractors/SoundcloudCommentsInfoItemExtractor.java
@@ -29,6 +29,7 @@ public class SoundcloudCommentsInfoItemExtractor implements CommentsInfoItemExtr
         return Objects.toString(json.getLong("id"), null);
     }
 
+    @Nonnull
     @Override
     public Description getCommentText() {
         return new Description(json.getString("body"), Description.PLAIN_TEXT);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsInfoItemExtractor.java
@@ -184,6 +184,7 @@ public class YoutubeCommentsInfoItemExtractor implements CommentsInfoItemExtract
         }
     }
 
+    @Nonnull
     @Override
     public Description getCommentText() throws ParsingException {
         try {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes https://github.com/TeamNewPipe/NewPipe/issues/10888 by making sure the comment `Description` is always non-null. This PR adds `@Nonnull` to all related methods/fields, but most importantly makes sure the `CommentsInfoItem`'s `commentText` field is initialized to a non-null value. Therefore even if the `CommentsInfoItemsCollector` does not call `setCommentText` because the extractor threw an error while extracting the text, `commentText` will always be non-null.