### PR TITLE
Fix JavaDocs and add Checkstyle exception for line length in JavaDocs' links

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -38,6 +38,8 @@
     <module name="LineLength">
       <property name="max" value="100"/>
       <property name="fileExtensions" value="java"/>
+        <!-- Also allow links in javadocs to be longer (the default would just cover imports) -->
+        <property name="ignorePattern" value="^((package|import) .*)|( *\* (@see )?&lt;a href ?\= ?&quot;.*&quot;&gt;)$"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/MediaFormat.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/MediaFormat.java
@@ -51,7 +51,7 @@ public enum MediaFormat {
     WEBMA_OPUS(0x200, "WebM Opus", "webm", "audio/webm"),
     AIFF      (0x600, "AIFF",      "aiff", "audio/aiff"),
     /**
-     * Same as {@link MediaFormat.AIFF}, just with the shorter suffix/file extension
+     * Same as {@link MediaFormat#AIFF}, just with the shorter suffix/file extension
      */
     AIF       (0x600, "AIFF",      "aif",  "audio/aiff"),
     WAV       (0x700, "WAV",       "wav",  "audio/wav"),

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ReadyChannelTabListLinkHandler.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ReadyChannelTabListLinkHandler.java
@@ -27,7 +27,6 @@ import java.util.List;
  *     return ((ReadyChannelTabListLinkHandler) linkHandler).getChannelTabExtractor(this);
  * }
  * </pre>
- * </p>
  */
 public class ReadyChannelTabListLinkHandler extends ListLinkHandler {
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampExtractorHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampExtractorHelper.java
@@ -111,8 +111,7 @@ public final class BandcampExtractorHelper {
 
     /**
      * Fetch artist details from mobile endpoint.
-     * <a href="https://notabug.org/fynngodau/bandcampDirect/wiki/
-     * rewindBandcamp+%E2%80%93+Fetching+artist+details">
+     * <a href="https://notabug.org/fynngodau/bandcampDirect/wiki/rewindBandcamp+%E2%80%93+Fetching+artist+details">
      * More technical info.</a>
      */
     public static JsonObject getArtistDetails(final String id) throws ParsingException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
@@ -119,7 +119,7 @@ public final class YoutubeDashManifestCreatorsUtils {
     /**
      * Generate a {@link Document} with common manifest creator elements added to it.
      *
-     * <p>
+     * <br>
      * Those are:
      * <ul>
      *     <li>{@code MPD} (using {@link #generateDocumentAndMpdElement(long)});</li>
@@ -132,7 +132,7 @@ public final class YoutubeDashManifestCreatorsUtils {
      *     <li>and, for audio streams, {@code AudioChannelConfiguration} (using
      *     {@link #generateAudioChannelConfigurationElement(Document, ItagItem)}).</li>
      * </ul>
-     * </p>
+     *
      *
      * @param itagItem the {@link ItagItem} associated to the stream, which must not be null
      * @param streamDuration the duration of the stream, in milliseconds
@@ -494,7 +494,6 @@ public final class YoutubeDashManifestCreatorsUtils {
      * This method is only used when generating DASH manifests from OTF and post-live-DVR streams.
      * </p>
      *
-     * <p>
      * It will produce a {@code <SegmentTemplate>} element with the following attributes:
      * <ul>
      *     <li>{@code startNumber}, which takes the value {@code 0} for post-live-DVR streams and
@@ -505,7 +504,6 @@ public final class YoutubeDashManifestCreatorsUtils {
      *     <li>{@code initialization} (only for OTF streams), which is the base URL of the stream
      *     on which is appended {@link #SQ_0}.</li>
      * </ul>
-     * </p>
      *
      * <p>
      * The {@code <Representation>} element needs to be generated before this element with
@@ -578,8 +576,8 @@ public final class YoutubeDashManifestCreatorsUtils {
 
     /**
      * Get the "initialization" {@link Response response} of a stream.
-     *
-     * <p>This method fetches, for OTF streams and for post-live-DVR streams:
+     * <br>
+     * This method fetches, for OTF streams and for post-live-DVR streams:
      *     <ul>
      *         <li>the base URL of the stream, to which are appended {@link #SQ_0} and
      *         {@link #RN_0} parameters, with a {@code GET} request for streaming URLs from HTML5
@@ -588,7 +586,6 @@ public final class YoutubeDashManifestCreatorsUtils {
      *         <li>for streaming URLs from HTML5 clients, the {@link #ALR_YES} param is also added.
      *         </li>
      *     </ul>
-     * </p>
      *
      * @param baseStreamingUrl the base URL of the stream, which must not be null
      * @param itagItem         the {@link ItagItem} of stream, which must not be null

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeOtfDashManifestCreator.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeOtfDashManifestCreator.java
@@ -53,38 +53,37 @@ public final class YoutubeOtfDashManifestCreator {
      * livestreams which have just been re-encoded as normal videos.
      * </p>
      *
-     * <p>This method needs:
-     *     <ul>
-     *         <li>the base URL of the stream (which, if you try to access to it, returns HTTP
-     *         status code 404 after redirects, and if the URL is valid);</li>
-     *         <li>an {@link ItagItem}, which needs to contain the following information:
-     *              <ul>
-     *                  <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
-     *                  an audio or a video stream;</li>
-     *                  <li>its bitrate;</li>
-     *                  <li>its mime type;</li>
-     *                  <li>its codec(s);</li>
-     *                  <li>for an audio stream: its audio channels;</li>
-     *                  <li>for a video stream: its width and height.</li>
-     *              </ul>
-     *         </li>
-     *         <li>the duration of the video, which will be used if the duration could not be
-     *         parsed from the first sequence of the stream.</li>
-     *     </ul>
-     * </p>
+     * This method needs:
+     * <ul>
+     *     <li>the base URL of the stream (which, if you try to access to it, returns HTTP
+     *     status code 404 after redirects, and if the URL is valid);</li>
+     *     <li>an {@link ItagItem}, which needs to contain the following information:
+     *          <ul>
+     *              <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
+     *              an audio or a video stream;</li>
+     *              <li>its bitrate;</li>
+     *              <li>its mime type;</li>
+     *              <li>its codec(s);</li>
+     *              <li>for an audio stream: its audio channels;</li>
+     *              <li>for a video stream: its width and height.</li>
+     *          </ul>
+     *     </li>
+     *     <li>the duration of the video, which will be used if the duration could not be
+     *     parsed from the first sequence of the stream.</li>
+     * </ul>
      *
-     * <p>In order to generate the DASH manifest, this method will:
-     *      <ul>
-     *          <li>request the first sequence of the stream (the base URL on which the first
-     *          sequence parameter is appended (see {@link YoutubeDashManifestCreatorsUtils#SQ_0}))
-     *          with a {@code POST} or {@code GET} request (depending of the client on which the
-     *          streaming URL comes from is a mobile one ({@code POST}) or not ({@code GET}));</li>
-     *          <li>follow its redirection(s), if any;</li>
-     *          <li>save the last URL, remove the first sequence parameter;</li>
-     *          <li>use the information provided in the {@link ItagItem} to generate all
-     *          elements of the DASH manifest.</li>
-     *      </ul>
-     * </p>
+     * In order to generate the DASH manifest, this method will:
+     * <ul>
+     *     <li>request the first sequence of the stream (the base URL on which the first
+     *     sequence parameter is appended (see {@link YoutubeDashManifestCreatorsUtils#SQ_0}))
+     *     with a {@code POST} or {@code GET} request (depending of the client on which the
+     *     streaming URL comes from is a mobile one ({@code POST}) or not ({@code GET}));</li>
+     *     <li>follow its redirection(s), if any;</li>
+     *     <li>save the last URL, remove the first sequence parameter;</li>
+     *     <li>use the information provided in the {@link ItagItem} to generate all
+     *     elements of the DASH manifest.</li>
+     * </ul>
+     *
      *
      * <p>
      * If the duration cannot be extracted, the {@code durationSecondsFallback} value will be used

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubePostLiveStreamDvrDashManifestCreator.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubePostLiveStreamDvrDashManifestCreator.java
@@ -56,25 +56,25 @@ public final class YoutubePostLiveStreamDvrDashManifestCreator {
      * the time)
      * </p>
      *
-     * <p>This method needs:
-     *     <ul>
-     *         <li>the base URL of the stream (which, if you try to access to it, returns HTTP
-     *         status code 404 after redirects, and if the URL is valid);</li>
-     *         <li>an {@link ItagItem}, which needs to contain the following information:
-     *              <ul>
-     *                  <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
-     *                  an audio or a video stream;</li>
-     *                  <li>its bitrate;</li>
-     *                  <li>its mime type;</li>
-     *                  <li>its codec(s);</li>
-     *                  <li>for an audio stream: its audio channels;</li>
-     *                  <li>for a video stream: its width and height.</li>
-     *              </ul>
-     *         </li>
-     *         <li>the duration of the video, which will be used if the duration could not be
-     *         parsed from the first sequence of the stream.</li>
-     *     </ul>
-     * </p>
+     * This method needs:
+     * <ul>
+     *     <li>the base URL of the stream (which, if you try to access to it, returns HTTP
+     *     status code 404 after redirects, and if the URL is valid);</li>
+     *     <li>an {@link ItagItem}, which needs to contain the following information:
+     *         <ul>
+     *             <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
+     *             an audio or a video stream;</li>
+     *             <li>its bitrate;</li>
+     *             <li>its mime type;</li>
+     *             <li>its codec(s);</li>
+     *             <li>for an audio stream: its audio channels;</li>
+     *             <li>for a video stream: its width and height.</li>
+     *         </ul>
+     *     </li>
+     *     <li>the duration of the video, which will be used if the duration could not be
+     *     parsed from the first sequence of the stream.</li>
+     * </ul>
+     *
      *
      * <p>In order to generate the DASH manifest, this method will:
      *      <ul>

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeProgressiveDashManifestCreator.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeProgressiveDashManifestCreator.java
@@ -47,26 +47,25 @@ public final class YoutubeProgressiveDashManifestCreator {
      * YouTube partner, and on videos with a large number of views.
      * </p>
      *
-     * <p>This method needs:
-     *     <ul>
-     *         <li>the base URL of the stream (which, if you try to access to it, returns the whole
-     *         stream, after redirects, and if the URL is valid);</li>
-     *         <li>an {@link ItagItem}, which needs to contain the following information:
-     *              <ul>
-     *                  <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
-     *                  an audio or a video stream;</li>
-     *                  <li>its bitrate;</li>
-     *                  <li>its mime type;</li>
-     *                  <li>its codec(s);</li>
-     *                  <li>for an audio stream: its audio channels;</li>
-     *                  <li>for a video stream: its width and height.</li>
-     *              </ul>
-     *         </li>
-     *         <li>the duration of the video (parameter {@code durationSecondsFallback}), which
-     *         will be used as the stream duration if the duration could not be parsed from the
-     *         {@link ItagItem}.</li>
-     *     </ul>
-     * </p>
+     * This method needs:
+     * <ul>
+     *     <li>the base URL of the stream (which, if you try to access to it, returns the whole
+     *     stream, after redirects, and if the URL is valid);</li>
+     *     <li>an {@link ItagItem}, which needs to contain the following information:
+     *          <ul>
+     *              <li>its type (see {@link ItagItem.ItagType}), to identify if the content is
+     *              an audio or a video stream;</li>
+     *              <li>its bitrate;</li>
+     *              <li>its mime type;</li>
+     *              <li>its codec(s);</li>
+     *              <li>for an audio stream: its audio channels;</li>
+     *              <li>for a video stream: its width and height.</li>
+     *          </ul>
+     *     </li>
+     *     <li>the duration of the video (parameter {@code durationSecondsFallback}), which
+     *     will be used as the stream duration if the duration could not be parsed from the
+     *     {@link ItagItem}.</li>
+     * </ul>
      *
      * @param progressiveStreamingBaseUrl the base URL of the progressive stream, which must not be
      *                                    null

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/ItagInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/ItagInfo.java
@@ -8,15 +8,13 @@ import java.io.Serializable;
 /**
  * Class to build easier {@link org.schabi.newpipe.extractor.stream.Stream}s for
  * {@link YoutubeStreamExtractor}.
- *
- * <p>
+ * <br>
  * It stores, per stream:
  * <ul>
  *     <li>its content (the URL/the base URL of streams);</li>
  *     <li>whether its content is the URL the content itself or the base URL;</li>
  *     <li>its associated {@link ItagItem}.</li>
  * </ul>
- * </p>
  */
 final class ItagInfo implements Serializable {
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/DeliveryMethod.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/DeliveryMethod.java
@@ -34,8 +34,8 @@ public enum DeliveryMethod {
     /**
      * Used for {@link Stream}s served using the SmoothStreaming adaptive streaming method.
      *
-     * @see <a href="https://en.wikipedia.org/wiki/Adaptive_bitrate_streaming
-     * #Microsoft_Smooth_Streaming_(MSS)">Wikipedia's page about adaptive bitrate streaming,
+     * @see <a href="https://en.wikipedia.org/wiki/Adaptive_bitrate_streaming#Microsoft_Smooth_Streaming_(MSS)">
+     * Wikipedia's page about adaptive bitrate streaming,
      * section <i>Microsoft Smooth Streaming (MSS)</i></a> for more information about the
      * SmoothStreaming delivery method
      */


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Add Checkstyle exception for LineLength in JDoc links.

See https://github.com/TeamNewPipe/NewPipeExtractor/actions/runs/8804403691/job/24164703883
