### PR TITLE
Extract Youtube Subscriptions for Pages

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -264,13 +264,22 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         if (channelHeader.isPresent()) {
             final ChannelHeader header = channelHeader.get();
 
-            if (header.headerType == HeaderType.INTERACTIVE_TABBED
-                    || header.headerType == HeaderType.PAGE) {
-                // No subscriber count is available on interactiveTabbedHeaderRenderer and
-                // pageHeaderRenderer headers
+
+            if (header.headerType == HeaderType.INTERACTIVE_TABBED) {
+                // No subscriber count is available on interactiveTabbedHeaderRenderer header
                 return UNKNOWN_SUBSCRIBER_COUNT;
             }
 
+            if (header.headerType == HeaderType.PAGE) {
+                String text = header.json.getObject("content").getObject("pageHeaderViewModel").getObject("metadata").getObject("contentMetadataViewModel").getArray("metadataRows").getObject(1).getArray("metadataParts").getObject(0).getObject("text").getString("content");
+
+                try {
+                    return Utils.mixedNumberWordToLong(text);
+                } catch (final NumberFormatException e) {
+                    throw new ParsingException("Could not get subscriber count", e);
+                }
+            }
+            
             final JsonObject headerJson = header.json;
             JsonObject textObject = null;
 


### PR DESCRIPTION
In this PR, I added a way to get the subscription count for pages. Right now, "sometimes" when I open a youtube channel, it's type is "Page" and therefore no subscription count is displayed. However, one can extrat the subscription count from the metaData for pages.

With "sometimes", I mean that there seems to be a 25% change that when I open a youtube channel in the app, it's type is page. I haven't found any understandable ways on when this happens, it seems random to me. It can even happen that a channel that is not a page becomes a page when I restart the app. 

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

