### PR TITLE
Use TreeMap in Response

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A Data class used to hold the results from requests made by the Downloader implementation.
@@ -14,17 +15,18 @@ public class Response {
     private final String responseMessage;
     private final Map<String, List<String>> responseHeaders;
     private final String responseBody;
-
     private final String latestUrl;
 
     public Response(final int responseCode,
                     final String responseMessage,
-                    @Nullable final Map<String, List<String>> responseHeaders,
+                    @Nonnull final Map<String, List<String>> responseHeaders,
                     @Nullable final String responseBody,
                     @Nullable final String latestUrl) {
         this.responseCode = responseCode;
         this.responseMessage = responseMessage;
-        this.responseHeaders = responseHeaders == null ? Collections.emptyMap() : responseHeaders;
+
+        this.responseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        this.responseHeaders.putAll(responseHeaders);
 
         this.responseBody = responseBody == null ? "" : responseBody;
         this.latestUrl = latestUrl;
@@ -71,13 +73,8 @@ public class Response {
      */
     @Nullable
     public String getHeader(final String name) {
-        for (final Map.Entry<String, List<String>> headerEntry : responseHeaders.entrySet()) {
-            final String key = headerEntry.getKey();
-            if (key != null && key.equalsIgnoreCase(name) && !headerEntry.getValue().isEmpty()) {
-                return headerEntry.getValue().get(0);
-            }
-        }
-
-        return null;
+        // Header lookup is case-insensitive
+        final var values = responseHeaders.getOrDefault(name, Collections.emptyList());
+        return values.isEmpty() ? null : values.get(0);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
@@ -13,7 +14,7 @@ import java.util.TreeMap;
 public class Response {
     private final int responseCode;
     private final String responseMessage;
-    private final Map<String, List<String>> responseHeaders;
+    private final SortedMap<String, List<String>> responseHeaders;
     private final String responseBody;
     private final String latestUrl;
 
@@ -25,8 +26,12 @@ public class Response {
         this.responseCode = responseCode;
         this.responseMessage = responseMessage;
 
-        this.responseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        this.responseHeaders.putAll(responseHeaders);
+        if (responseHeaders instanceof SortedMap) {
+            this.responseHeaders = (SortedMap<String, List<String>>) responseHeaders;
+        } else {
+            this.responseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            this.responseHeaders.putAll(responseHeaders);
+        }
 
         this.responseBody = responseBody == null ? "" : responseBody;
         this.latestUrl = latestUrl;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.extractor.downloader;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -79,7 +78,7 @@ public class Response {
     @Nullable
     public String getHeader(final String name) {
         // Header lookup is case-insensitive
-        final var values = responseHeaders.getOrDefault(name, Collections.emptyList());
+        final var values = responseHeaders.getOrDefault(name, List.of());
         return values.isEmpty() ? null : values.get(0);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Response.java
@@ -76,7 +76,7 @@ public class Response {
      * @return the first value assigned to this header
      */
     @Nullable
-    public String getHeader(final String name) {
+    public String getHeader(@Nonnull final String name) {
         // Header lookup is case-insensitive
         final var values = responseHeaders.getOrDefault(name, List.of());
         return values.isEmpty() ? null : values.get(0);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractor.java
@@ -67,7 +67,7 @@ public class YoutubeSuggestionExtractor extends SuggestionExtractor {
         final String contentTypeHeader = response.getHeader("Content-Type");
         if (isNullOrEmpty(contentTypeHeader) || !contentTypeHeader.contains("application/json")) {
             throw new ExtractionException("Invalid response type (got \"" + contentTypeHeader
-                    + "\", excepted a JSON response) (response code "
+                    + "\", expected a JSON response) (response code "
                     + response.responseCode() + ")");
         }
 


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
----
Store the response headers in a [`TreeMap`](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html). This allows the header value retrieval to be optimised as `TreeMap` orders its keys using a comparator.
