### PR TITLE
[Bandcamp] Null-safe url catenation in track playlist

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/streaminfoitem/BandcampPlaylistStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/streaminfoitem/BandcampPlaylistStreamInfoItemExtractor.java
@@ -43,7 +43,12 @@ public class BandcampPlaylistStreamInfoItemExtractor extends BandcampStreamInfoI
 
     @Override
     public String getUrl() {
-        return getUploaderUrl() + track.getString("title_link");
+        final String relativeUrl = track.getString("title_link");
+        if (relativeUrl != null) {
+            return getUploaderUrl() + relativeUrl;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -66,7 +71,7 @@ public class BandcampPlaylistStreamInfoItemExtractor extends BandcampStreamInfoI
     @Nonnull
     @Override
     public List<Image> getThumbnails() throws ParsingException {
-        if (substituteCovers.isEmpty()) {
+        if (substituteCovers.isEmpty() && getUrl() != null) {
             try {
                 final StreamExtractor extractor = service.getStreamExtractor(getUrl());
                 extractor.fetchPage();


### PR DESCRIPTION
Previously, if no URL was provided due to the track being a preorder or unpaid track that doesn't have its own public page, we would catenate the artist URL and null to a nonsensical string.

This invalid URL would also be used to try fetching a thumbnail URL.

The downstream behavior of the NewPipe client is only marginally improved, as it now no longer throws visible exceptions due to the missing thumbnails, but still gives an unfriendly error upon clicking the item that has a `null` URL.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
