### PR TITLE
[Bandcamp] Show additional info in radio kiosk

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioExtractor.java
@@ -24,7 +24,7 @@ import static org.schabi.newpipe.extractor.services.bandcamp.extractors.Bandcamp
 public class BandcampRadioExtractor extends KioskExtractor<StreamInfoItem> {
 
     public static final String KIOSK_RADIO = "Radio";
-    public static final String RADIO_API_URL = BASE_API_URL + "/bcweekly/1/list";
+    public static final String RADIO_API_URL = BASE_API_URL + "/bcweekly/3/list";
 
     private JsonObject json = null;
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampRadioInfoItemExtractor.java
@@ -37,6 +37,12 @@ public class BandcampRadioInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Nullable
     @Override
+    public String getShortDescription() {
+        return show.getString("desc");
+    }
+
+    @Nullable
+    @Override
     public String getTextualUploadDate() {
         return show.getString("date");
     }
@@ -75,8 +81,8 @@ public class BandcampRadioInfoItemExtractor implements StreamInfoItemExtractor {
 
     @Override
     public String getUploaderName() {
-        // JSON does not contain uploader name
-        return "";
+        // The "title" field contains the title of the series, e.g. "Bandcamp Weekly".
+        return show.getString("title");
     }
 
     @Override

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampFeaturedLinkHandlerFactoryTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampFeaturedLinkHandlerFactoryTest.java
@@ -28,7 +28,7 @@ public class BandcampFeaturedLinkHandlerFactoryTest {
         assertTrue(linkHandler.acceptUrl("https://bandcamp.com/?show=1"));
         assertTrue(linkHandler.acceptUrl("http://bandcamp.com/?show=2"));
         assertTrue(linkHandler.acceptUrl("https://bandcamp.com/api/mobile/24/bootstrap_data"));
-        assertTrue(linkHandler.acceptUrl("https://bandcamp.com/api/bcweekly/1/list"));
+        assertTrue(linkHandler.acceptUrl("https://bandcamp.com/api/bcweekly/3/list"));
 
         assertFalse(linkHandler.acceptUrl("https://bandcamp.com/?show="));
         assertFalse(linkHandler.acceptUrl("https://bandcamp.com/?show=a"));
@@ -38,7 +38,7 @@ public class BandcampFeaturedLinkHandlerFactoryTest {
     @Test
     public void testGetUrl() throws ParsingException {
         assertEquals("https://bandcamp.com/api/mobile/24/bootstrap_data", linkHandler.getUrl("Featured"));
-        assertEquals("https://bandcamp.com/api/bcweekly/1/list", linkHandler.getUrl("Radio"));
+        assertEquals("https://bandcamp.com/api/bcweekly/3/list", linkHandler.getUrl("Radio"));
     }
 
     @Test
@@ -46,7 +46,7 @@ public class BandcampFeaturedLinkHandlerFactoryTest {
         assertEquals("Featured", linkHandler.getId("http://bandcamp.com/api/mobile/24/bootstrap_data"));
         assertEquals("Featured", linkHandler.getId("https://bandcamp.com/api/mobile/24/bootstrap_data"));
         assertEquals("Radio", linkHandler.getId("http://bandcamp.com/?show=1"));
-        assertEquals("Radio", linkHandler.getId("https://bandcamp.com/api/bcweekly/1/list"));
+        assertEquals("Radio", linkHandler.getId("https://bandcamp.com/api/bcweekly/3/list"));
     }
 
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampRadioExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/bandcamp/BandcampRadioExtractorTest.java
@@ -8,6 +8,7 @@ import org.schabi.newpipe.downloader.DownloaderTestImpl;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.services.BaseListExtractorTest;
+import org.schabi.newpipe.extractor.services.DefaultTests;
 import org.schabi.newpipe.extractor.services.bandcamp.extractors.BandcampRadioExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
@@ -35,15 +36,14 @@ public class BandcampRadioExtractorTest implements BaseListExtractorTest {
     }
 
     @Test
-    public void testRadioCount() throws ExtractionException, IOException {
+    public void testRadioCount() {
         final List<StreamInfoItem> list = extractor.getInitialPage().getItems();
         assertTrue(list.size() > 300);
     }
 
     @Test
     public void testRelatedItems() throws Exception {
-        // DefaultTests.defaultTestRelatedItems(extractor);
-        // Would fail because BandcampRadioInfoItemExtractor.getUploaderName() returns an empty String
+        DefaultTests.defaultTestRelatedItems(extractor);
     }
 
     @Test
@@ -68,11 +68,11 @@ public class BandcampRadioExtractorTest implements BaseListExtractorTest {
 
     @Test
     public void testUrl() throws Exception {
-        assertEquals("https://bandcamp.com/api/bcweekly/1/list", extractor.getUrl());
+        assertEquals("https://bandcamp.com/api/bcweekly/3/list", extractor.getUrl());
     }
 
     @Test
     public void testOriginalUrl() throws Exception {
-        assertEquals("https://bandcamp.com/api/bcweekly/1/list", extractor.getOriginalUrl());
+        assertEquals("https://bandcamp.com/api/bcweekly/3/list", extractor.getOriginalUrl());
     }
 }


### PR DESCRIPTION
A newer version of the radio list API delivers additional fields. Thanks @crisp5.

It looks quite much better in the app:

![Screenshot_20240722-000340](https://github.com/user-attachments/assets/d40c4b4c-7e5c-4537-aae5-db56410c5b04)

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Fixes #1152.