### PR TITLE
[YouTube] New regex for player throttling function

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -127,11 +127,12 @@ final class YoutubeThrottlingParameterUtils {
                     + "known patterns in the base JavaScript player code", e);
         }
 
+        if (matcher.groupCount() == 1) {
+            return matcher.group(1);
+        }
+
         final int funcNameIndex = matcher.groupCount() - 1;
         final String functionName = matcher.group(funcNameIndex);
-        if (matcher.groupCount() == 1) {
-            return functionName;
-        }
 
         final int arrayNumIndex = matcher.groupCount();
         final int arrayNum = Integer.parseInt(matcher.group(arrayNumIndex));

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -127,13 +127,13 @@ final class YoutubeThrottlingParameterUtils {
                     + "known patterns in the base JavaScript player code", e);
         }
 
-        int funcNameIndex = matcher.groupCount() - 1;
+        final int funcNameIndex = matcher.groupCount() - 1;
         final String functionName = matcher.group(funcNameIndex);
         if (matcher.groupCount() == 1) {
             return functionName;
         }
 
-        int arrayNumIndex = matcher.groupCount();
+        final int arrayNumIndex = matcher.groupCount();
         final int arrayNum = Integer.parseInt(matcher.group(arrayNumIndex));
         final Pattern arrayPattern = Pattern.compile(
                 DEOBFUSCATION_FUNCTION_ARRAY_OBJECT_TYPE_DECLARATION_REGEX

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -73,7 +73,22 @@ final class YoutubeThrottlingParameterUtils {
              */
             Pattern.compile("\\.get\\(\"n\"\\)\\)&&\\(" + SINGLE_CHAR_VARIABLE_REGEX
                     + "=(" + FUNCTION_NAME_REGEX + ")(?:" + ARRAY_ACCESS_REGEX + ")?\\("
-                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)")
+                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)"),
+
+            /*
+             * The fifth regex matches the following text, where we want oDa and the array index
+             * accessed:
+             *
+             * ;a.D&&(PL(a),b=a.j.n||null)&&(b=oDa[0](b)
+             */
+            Pattern.compile("(?x)" +
+                "(?:\\.get\\(\"n\"\\)\\)&&\\(b=|" +
+                "(?:b=String\\.fromCharCode\\(110\\)|" +
+                "(" + SINGLE_CHAR_VARIABLE_REGEX + "+)&&\\(b=\"nn\"\\[\\+\\1\\]" +
+                "),c=a\\.get\\(b\\)\\)&&\\(c=|" +
+                "\\b(" + SINGLE_CHAR_VARIABLE_REGEX + "+)=" +
+                ")(" + SINGLE_CHAR_VARIABLE_REGEX + "+)(?:\\[(\\d+)\\])?\\" +
+                "(" + SINGLE_CHAR_VARIABLE_REGEX + "\\).*?(?=,a\\.set\\(\"n\",\\2\\))")
     };
     // CHECKSTYLE:ON
 
@@ -112,12 +127,14 @@ final class YoutubeThrottlingParameterUtils {
                     + "known patterns in the base JavaScript player code", e);
         }
 
-        final String functionName = matcher.group(1);
+        int funcNameIndex = matcher.groupCount() - 1;
+        final String functionName = matcher.group(funcNameIndex);
         if (matcher.groupCount() == 1) {
             return functionName;
         }
 
-        final int arrayNum = Integer.parseInt(matcher.group(2));
+        int arrayNumIndex = matcher.groupCount();
+        final int arrayNum = Integer.parseInt(matcher.group(arrayNumIndex));
         final Pattern arrayPattern = Pattern.compile(
                 DEOBFUSCATION_FUNCTION_ARRAY_OBJECT_TYPE_DECLARATION_REGEX
                         + Pattern.quote(functionName)


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

yt-dlp reference: https://github.com/yt-dlp/yt-dlp/pull/10611

As of today seeing new JS players referenced `20dfca59` and `d2e656ee` on age-restricted videos which fail.

Fix is working for me on the 2 new and past `b22ef6e7` hash. Could not get the new regex to work in the same way as the others in the `DEOBFUSCATION_FUNCTION_NAME_REGEXES` array with `matcher.group(1)`/`matcher.group(2)` for func name/array index. **Therefore the fix I have is likely problematic and may not be compatible with untested player hashes**. Hopefully someone can improve on this. Seems to me a couple of better options would be:
- make new regex work with current `matcher.group(1)`/`matcher.group(2)` format, if possible
- use named groups rather than hardcoded group indexes 

or alternatively just split this new regex up from the others in some other way.