### PR TITLE
[Youtube] Add linked album for ytmusic searches

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSongOrVideoInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSongOrVideoInfoItemExtractor.java
@@ -174,4 +174,26 @@ public class YoutubeMusicSongOrVideoInfoItemExtractor implements StreamInfoItemE
             throw new ParsingException("Could not get thumbnails", e);
         }
     }
+
+    @Nonnull
+    public String getPlaylist() {
+        if (searchType.equals(MUSIC_SONGS)) {
+            for (final Object item : descriptionElements) {
+                final JsonObject browseEndpoint = ((JsonObject) item)
+                        .getObject("navigationEndpoint")
+                        .getObject("browseEndpoint");
+
+                final String type = browseEndpoint
+                        .getObject("browseEndpointContextSupportedConfigs")
+                        .getObject("browseEndpointContextMusicConfig")
+                        .getString("pageType");
+
+                if (type != null && type.equals("MUSIC_PAGE_TYPE_ALBUM")) {
+                    return browseEndpoint.getString("browseId");
+                }
+            }
+        }
+        // handles singles, video, and others which may not belong in playlist
+        return "";
+    }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Adds the linked album to the song when doing a ytmusic search. This is a draft and the current change is not visible. Some questions:

1. To expose the linked album for use, is it alright to modify StreamInfoItem to add a new method called getPlaylist?
2. Currently the code just returns the browseId of the album, is there any preferred structure to also return the name of the album as well?

The browseId currently does nothing, hopefully I can try to get the browse endpoint working for ytmusic. I also plan to add a method to get the linked artist as well.