### PR TITLE
[YouTube] Fix serialization of Videos channel tab when it is already fetched

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -42,10 +42,11 @@ import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
  */
 public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
 
+    @Nullable
+    protected YoutubeChannelHelper.ChannelHeader channelHeader;
+
     private JsonObject jsonResponse;
     private String channelId;
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    protected Optional<YoutubeChannelHelper.ChannelHeader> channelHeader;
 
     public YoutubeChannelTabExtractor(final StreamingService service,
                                       final ListLinkHandler linkHandler) {
@@ -104,9 +105,9 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
     }
 
     protected String getChannelName() throws ParsingException {
-        return YoutubeChannelHelper.getChannelName(
-                channelHeader, jsonResponse,
-                YoutubeChannelHelper.getChannelAgeGateRenderer(jsonResponse));
+        return YoutubeChannelHelper.getChannelName(channelHeader,
+                YoutubeChannelHelper.getChannelAgeGateRenderer(jsonResponse),
+                jsonResponse);
     }
 
     @Nonnull
@@ -140,11 +141,14 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
             }
         }
 
-        final VerifiedStatus verifiedStatus = channelHeader.flatMap(header ->
-                        YoutubeChannelHelper.isChannelVerified(header)
-                                ? Optional.of(VerifiedStatus.VERIFIED)
-                                : Optional.of(VerifiedStatus.UNVERIFIED))
-                .orElse(VerifiedStatus.UNKNOWN);
+        final VerifiedStatus verifiedStatus;
+        if (channelHeader == null) {
+            verifiedStatus = VerifiedStatus.UNKNOWN;
+        } else {
+            verifiedStatus = YoutubeChannelHelper.isChannelVerified(channelHeader)
+                    ? VerifiedStatus.VERIFIED
+                    : VerifiedStatus.UNVERIFIED;
+        }
 
         // If a channel tab is fetched, the next page requires channel ID and name, as channel
         // streams don't have their channel specified.
@@ -462,8 +466,7 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         VideosTabExtractor(final StreamingService service,
                            final ListLinkHandler linkHandler,
                            final JsonObject tabRenderer,
-                           @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-                           final Optional<YoutubeChannelHelper.ChannelHeader> channelHeader,
+                           @Nullable final YoutubeChannelHelper.ChannelHeader channelHeader,
                            final String channelName,
                            final String channelId,
                            final String channelUrl) {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API. Not needed, the API changes are on code that is not a part of the API that users should use (that's the case of NewPipe).

This PR fixes the ability to serialize `ReadyChannelTabListLinkHandler`s for YouTube channels. It was due to the usage of the `channelHeader` field of `YoutubeChannelExtractor`, as explained in https://github.com/TeamNewPipe/NewPipe/issues/11356#issuecomment-2266657671. Even if this usage has been removed by copying the instance members into a new object, the `ChannelHeader` class of `YoutubeChannelHelper` was not serializable, so crashes would still happen if I didn't make this class serializable.

`Optional` as fields and parameters of methods have been removed in the related extractor code as it is not a good practice. This simplifies in some places channel info extraction code.

This PR and the issue it fixes also raise the question of the limits of the serialization system we use, both in the app and in the extractor.

Debug NewPipe APK based on app commit `035c394cf6704c0af9077c01ebfa55b810d02140` with changes from commit 422df7002e6aa2d2096b4ef0c1546002823445b6: [app-debug.zip](https://github.com/user-attachments/files/17006047/app-debug.zip)

Fixes TeamNewPipe/NewPipe#11356.