### PR TITLE
[YouTube] Add documentation for faulty framesets

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1377,11 +1377,20 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return itagInfo;
     }
 
-    // Warning: When using this method be aware that the YouTube API very rarely returns framesets,
-    // that are slightly too small e.g. framesPerPageX = 5, frameWidth = 160, but the url contains
-    // a storyboard that is only 795 pixels wide (5*160 > 795). You will need to handle this
-    // "manually" to avoid errors.
-    // For further reference see: https://github.com/TeamNewPipe/NewPipe/pull/11596
+
+    /**
+     * {@inheritDoc}
+     * Should return a list of Frameset object that contains preview of stream frames
+     *
+     * <p><b>Warning:</b> When using this method be aware
+     * that the YouTube API very rarely returns framesets,
+     * that are slightly too small e.g. framesPerPageX = 5, frameWidth = 160, but the url contains
+     * a storyboard that is only 795 pixels wide (5*160 > 795). You will need to handle this
+     * "manually" to avoid errors.</p>
+     *
+     * @see <a href="https://github.com/TeamNewPipe/NewPipe/pull/11596">
+     *     TeamNewPipe/NewPipe#11596</a>
+     */
     @Nonnull
     @Override
     public List<Frameset> getFrames() throws ExtractionException {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1377,6 +1377,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return itagInfo;
     }
 
+    // Warning: When using this method be aware that the YouTube API very rarely returns framesets,
+    // that are slightly too small e.g. framesPerPageX = 5, frameWidth = 160, but the url contains
+    // a storyboard that is only 795 pixels wide (5*160 > 795). You will need to handle this
+    // "manually" to avoid errors.
+    // For further reference see: https://github.com/TeamNewPipe/NewPipe/pull/11596
     @Nonnull
     @Override
     public List<Frameset> getFrames() throws ExtractionException {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Added documentation for faulty framesets (reference: https://github.com/TeamNewPipe/NewPipe/pull/11596)
