### PR TITLE
[YouTube] Add support for automatic dubbed and secondary audio tracks

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -1720,9 +1720,12 @@ public final class YoutubeParsingHelper {
             case "original":
                 return AudioTrackType.ORIGINAL;
             case "dubbed":
+            case "dubbed-auto":
                 return AudioTrackType.DUBBED;
             case "descriptive":
                 return AudioTrackType.DESCRIPTIVE;
+            case "secondary":
+                return AudioTrackType.SECONDARY;
             default:
                 return null;
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
@@ -325,6 +325,8 @@ public final class YoutubeDashManifestCreatorsUtils {
                 case DESCRIPTIVE:
                     return "description";
                 default:
+                    // Secondary track types do not seem to have a dedicated role in the DASH
+                    // specification, so use alternate for them
                     return "alternate";
             }
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/AudioTrackType.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/AudioTrackType.java
@@ -1,12 +1,13 @@
 package org.schabi.newpipe.extractor.stream;
 
 /**
- * An enum representing the track type of an {@link AudioStream} extracted by a {@link
+ * An enum representing the track type of {@link AudioStream}s extracted by a {@link
  * StreamExtractor}.
  */
 public enum AudioTrackType {
+
     /**
-     * An original audio track of the video.
+     * An original audio track of a video.
      */
     ORIGINAL,
 
@@ -20,6 +21,7 @@ public enum AudioTrackType {
 
     /**
      * A descriptive audio track.
+     *
      * <p>
      * A descriptive audio track is an audio track in which descriptions of visual elements of
      * a video are added to the original audio, with the goal to make a video more accessible to
@@ -29,5 +31,15 @@ public enum AudioTrackType {
      * @see <a href="https://en.wikipedia.org/wiki/Audio_description">
      * https://en.wikipedia.org/wiki/Audio_description</a>
      */
-    DESCRIPTIVE
+    DESCRIPTIVE,
+
+    /**
+     * A secondary audio track.
+     *
+     * <p>
+     * A secondary audio track can be an alternate audio track from the original language of a
+     * video or an alternate language.
+     * </p>
+     */
+    SECONDARY
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This PR adds support for (i.e. distinguish) automatic dubbed audio tracks made by YouTube and secondary audio tracks.

Automatic dubbed tracks are generated by YouTube for creators and an example can be found on this video: https://www.youtube.com/watch?v=snZ9w5xc_ic. They are now treated like normal dubbed tracks with this PR.

Secondary audio tracks have now their own track type. In the DASH specification, a specific role value for these tracks doesn't seem to exist, so I used the default value of an audio track type in DASH manifests generated by the extractor, `alternate`. Here is a video with this track type: https://www.youtube.com/watch?v=UPrkC1LdlLY