### PR TITLE
[YouTube] Catch RegexException in subscriber count extractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -43,6 +43,7 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeChannelTabExtractor.VideosTabExtractor;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelTabLinkHandlerFactory;
+import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
@@ -304,6 +305,8 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                         .getString(CONTENT));
             } catch (final NumberFormatException e) {
                 throw new ParsingException("Could not get subscriber count", e);
+            } catch (final Parser.RegexException e) {
+                return UNKNOWN_SUBSCRIBER_COUNT;
             }
         }
 


### PR DESCRIPTION
When the subscriber count extraction fails to find the Regex pattern, a RegexException is thrown. This is not a fatal error in most cases, for example when downloading the channel page in order to update the user's subscriptions, and so the correct behavior is to return UNKNOWN_SUBSCRIBER_COUNT.

Related issue: https://github.com/TeamNewPipe/NewPipe/issues/11353.

This bug comprises two issues: subscribers cannot be extracted for channels with pronoun tags, and when the RegexException is thrown, channel subscriptions will fail to update because the exception is uncaught. This commit fixes the latter aspect of the issue.

Please see my comment on the issue for suggestions on how the former issue with scraping the pronoun tags might be fixed.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Note that the last point above is not applicable to this PR, as the API does not change.