### PR TITLE
[YouTube] Fix Shorts' thumbnails extraction in their channel tab

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsLockupInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsLockupInfoItemExtractor.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getThumbnailsFromInfoItem;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getImagesFromThumbnailsArray;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 /**
@@ -78,8 +78,8 @@ public class YoutubeShortsLockupInfoItemExtractor implements StreamInfoItemExtra
     @Nonnull
     @Override
     public List<Image> getThumbnails() throws ParsingException {
-        return getThumbnailsFromInfoItem(shortsLockupViewModel.getObject("thumbnail")
-                .getObject("sources"));
+        return getImagesFromThumbnailsArray(shortsLockupViewModel.getObject("thumbnail")
+                .getArray("sources"));
     }
 
     @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

This PR fixes usage of wrong methods to access and extract the thumbnails' data of YouTube Shorts. This bug has been introduced when I fixed the extraction of this content in their channel tab with #1221.