### PR TITLE
Add media.ccc specific parsing of recordings

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/data/MediaCCCRecording.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/data/MediaCCCRecording.java
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.extractor.services.media_ccc.extractors.data;
+
+import com.grack.nanojson.JsonObject;
+
+import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+
+/** A recording stream of a talk/event. Switch on the implementation to get the actual data. */
+public interface MediaCCCRecording {
+
+    /** A recording stream of a talk/event.
+     * These files usually have one or more audio streams in different languages. */
+    class Video implements MediaCCCRecording {
+        public String filename;
+        public VideoType recordingType;
+        public String mimeType;
+        /** Each language is one separate audio track on the video. */
+        public List<Locale> languages;
+        public String url;
+        public int lengthSeconds;
+        public int width;
+        public int height;
+    }
+
+    /** Some talks have multiple kinds of video. */
+    enum VideoType {
+        /** The main recording of a talk/event. */
+        MAIN,
+        /** A side-recording of a talk/event that has the slides full-screen.
+         * Usually if there is a slide-recording there is a MAIN recording as well */
+        SLIDES
+    }
+
+    /** An audio recording of a talk/event.
+     * These audio streams are usually also available in their respective video streams.
+     */
+    class Audio implements MediaCCCRecording {
+        public String filename;
+        public String mimeType;
+        public @Nullable Locale language;
+        public String url;
+        public int lengthSeconds;
+    }
+
+    /** A subtitle file of a talk/event. */
+    class Subtitle implements MediaCCCRecording {
+        public String filename;
+        public String mimeType;
+        public @Nullable Locale language;
+        public String url;
+    }
+
+    /** The Slides of the talk, usually as PDF file. */
+    class Slides implements MediaCCCRecording {
+        public String filename;
+        public String mimeType;
+        public String url;
+        public @Nullable Locale language;
+    }
+
+    /** Anything we can’t put in any of the other categories. */
+    class Unknown implements MediaCCCRecording {
+        public String filename;
+        public String mimeType;
+        public String url;
+        /** The raw object for easier debugging. */
+        public JsonObject rawObject;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -257,6 +257,11 @@ public final class Utils {
         return url;
     }
 
+    /**
+     * Check if the string is `null`, or the empty string.
+     * @param str string
+     * @return true if null or empty, false otherwise
+     */
     public static boolean isNullOrEmpty(final String str) {
         return str == null || str.isEmpty();
     }


### PR DESCRIPTION
Instead of pushing the `media.ccc` recordings straight into the StreamExtractor straightjacket (which does not really provide the correct API for handling the semantics of the media.ccc data), we parse into an intermediate structure first that contains all relevant information about the different streams.

This is required for correct handling of the different languages.

It should not change the API, since its specfic to the media.ccc Extractor. I just type-cast in frankenplayer at the moment.
I skipped adding getters/setters in the MediaCCCRecording structs, once this repository is migrated to Kotlin (?), it would just be a data class.

- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
