### PR TITLE
[YouTube] Fixes for n param deobfuscation function

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -58,14 +58,16 @@ final class YoutubeThrottlingParameterUtils {
              * The third regex matches the following text, where we want SDa and the array index
              * accessed:
              *
-             * WL(a),c=a.j[b]||null)&&(c=SDa[0](c)
+             * ,Vb(m),W=m.j[c]||null)&&(W=cvb[0](W),m.set(c,W)
              */
-            Pattern.compile(MULTIPLE_CHARS_REGEX + "\\("
+            Pattern.compile("," + MULTIPLE_CHARS_REGEX + "\\("
                     + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
                     + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(" + MULTIPLE_CHARS_REGEX + "=("
-                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX
-                    + "\\(" + MULTIPLE_CHARS_REGEX + "\\)"),
+                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(\\b" + MULTIPLE_CHARS_REGEX + "=("
+                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("
+                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)," + MULTIPLE_CHARS_REGEX
+                    + "\\.set\\((?:\"n+\"|" + MULTIPLE_CHARS_REGEX + ")," + MULTIPLE_CHARS_REGEX
+                    + "\\)"),
 
             /*
              * The fourth regex matches the following text, where we want rma:

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -42,21 +42,6 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("),
 
             /*
-             * This regex matches the following text, where we want Wma:
-             *
-             * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
-             *
-             * UPDATE: This is broken and Wma is not the function needed anymore.
-             * We need the function which is in SDa[0] instead.
-             */
-//            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
-//                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "\\("
-//                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
-//                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-//                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\).+\\|\\|(" + MULTIPLE_CHARS_REGEX
-//                    + ")\\(\"\"\\)"),
-
-            /*
              * The second regex matches the following text, where we want SDa and the array index
              * accessed:
              *
@@ -70,7 +55,22 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX),
 
             /*
-             * The third regex matches the following text, where we want rma:
+             * The third regex matches the following text, where we want Wma:
+             *
+             * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
+             *
+             * UPDATE: This is prone to find the wrong function on recent version of the player.
+             * For this reason a regex which finds the Array + index should be preferred / above.
+             */
+            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
+                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "\\("
+                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
+                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
+                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\).+\\|\\|(" + MULTIPLE_CHARS_REGEX
+                    + ")\\(\"\"\\)"),
+
+            /*
+             * The fourth regex matches the following text, where we want rma:
              *
              * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
              */
@@ -80,7 +80,7 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")\\(\"\"\\)"),
 
             /*
-             * The fourth regex matches the following text, where we want rDa and the array index
+             * The fifth regex matches the following text, where we want rDa and the array index
              * accessed:
              *
              * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
@@ -91,7 +91,7 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + "=(" + MULTIPLE_CHARS_REGEX + ")\\[(\\d+)]"),
 
             /*
-             * The fifth regex matches the following text, where we want BDa and the array index
+             * The sixth regex matches the following text, where we want BDa and the array index
              * accessed:
              *
              * (b=String.fromCharCode(110),c=a.get(b))&&(c=BDa[0](c)
@@ -103,7 +103,7 @@ final class YoutubeThrottlingParameterUtils {
                     + SINGLE_CHAR_VARIABLE_REGEX + "\\)"),
 
             /*
-             * The sixth regex matches the following text, where we want Yva and the array index
+             * The seventh regex matches the following text, where we want Yva and the array index
              * accessed:
              *
              * .get("n"))&&(b=Yva[0](b)

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -207,7 +207,7 @@ final class YoutubeThrottlingParameterUtils {
             // If the throttling parameter could not be parsed from the URL, it means that there is
             // no throttling parameter
             // Return null in this case
-                return null;
+            return null;
         }
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -130,7 +130,8 @@ final class YoutubeThrottlingParameterUtils {
             "=\\s*function\\s*\\(\\s*([^)]*)\\s*\\)";
 
     private static final String EARLY_RETURN_REGEX =
-            ";\\s*if\\s*\\(\\s*typeof\\s+" + MULTIPLE_CHARS_REGEX + "+\\s*===?\\s*([\"'])undefined\\1\\s*\\)\\s*return\\s+";
+            ";\\s*if\\s*\\(\\s*typeof\\s+" + MULTIPLE_CHARS_REGEX
+                    + "+\\s*===?\\s*([\"'])undefined\\1\\s*\\)\\s*return\\s+";
 
     private YoutubeThrottlingParameterUtils() {
     }
@@ -206,7 +207,7 @@ final class YoutubeThrottlingParameterUtils {
             // If the throttling parameter could not be parsed from the URL, it means that there is
             // no throttling parameter
             // Return null in this case
-            return null;
+                return null;
         }
     }
 
@@ -240,7 +241,9 @@ final class YoutubeThrottlingParameterUtils {
     @Nonnull
     private static String fixupFunction(@Nonnull final String function)
             throws Parser.RegexException {
-        final String firstArgName = Parser.matchGroup1(FUNCTION_ARGUMENTS_REGEX, function).split(",")[0].trim();
+        final String firstArgName = Parser
+                .matchGroup1(FUNCTION_ARGUMENTS_REGEX, function)
+                .split(",")[0].trim();
         final Pattern earlyReturnPattern = Pattern.compile(
                 EARLY_RETURN_REGEX + firstArgName + ";",
                 Pattern.DOTALL);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -239,10 +239,20 @@ final class YoutubeThrottlingParameterUtils {
     }
 
     /**
+     * Removes an early return statement from the code of the throttling parameter deobfuscation function.
      *
-     * @param function
-     * @return
-     * @throws Parser.RegexException
+     * <p>In newer version of the player code the function contains a check for something defined outside of the function.
+     * If that was not found it will return early.
+     *
+     * <p>The check can look like this (JS):<br>
+     * if(typeof RUQ==="undefined")return p;
+     *
+     * <p>In this example RUQ will always be undefined when running the function as standalone.
+     * If the check is kept it would just return p which is the input parameter and would be wrong.
+     * For that reason this check and return statement needs to be removed.
+     *
+     * @param function the original throttling parameter deobfuscation function code
+     * @return the throttling parameter deobfuscation function code with the early return statement removed
      */
     @Nonnull
     private static String fixupFunction(@Nonnull final String function)

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -258,10 +258,10 @@ final class YoutubeThrottlingParameterUtils {
     private static String fixupFunction(@Nonnull final String function)
             throws Parser.RegexException {
         final String firstArgName = Parser
-                .matchGroup1(FUNCTION_ARGUMENTS_REGEX + "aba([a-z]\\d)", function)
+                .matchGroup1(FUNCTION_ARGUMENTS_REGEX, function)
                 .split(",")[0].trim();
         final Pattern earlyReturnPattern = Pattern.compile(
-                EARLY_RETURN_REGEX + firstArgName + "aba;",
+                EARLY_RETURN_REGEX + firstArgName + ";",
                 Pattern.DOTALL);
         final Matcher earlyReturnCodeMatcher = earlyReturnPattern.matcher(function);
         return earlyReturnCodeMatcher.replaceFirst(";");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -175,7 +175,7 @@ final class YoutubeThrottlingParameterUtils {
      * Get the throttling parameter deobfuscation code of YouTube's base JavaScript file.
      *
      * @param javaScriptPlayerCode the complete JavaScript base player code
-     * @return the throttling parameter deobfuscation function name
+     * @return the throttling parameter deobfuscation function code
      * @throws ParsingException if the throttling parameter deobfuscation code couldn't be
      * extracted
      */
@@ -238,14 +238,20 @@ final class YoutubeThrottlingParameterUtils {
         return function;
     }
 
+    /**
+     *
+     * @param function
+     * @return
+     * @throws Parser.RegexException
+     */
     @Nonnull
     private static String fixupFunction(@Nonnull final String function)
             throws Parser.RegexException {
         final String firstArgName = Parser
-                .matchGroup1(FUNCTION_ARGUMENTS_REGEX, function)
+                .matchGroup1(FUNCTION_ARGUMENTS_REGEX + "aba([a-z]\\d)", function)
                 .split(",")[0].trim();
         final Pattern earlyReturnPattern = Pattern.compile(
-                EARLY_RETURN_REGEX + firstArgName + ";",
+                EARLY_RETURN_REGEX + firstArgName + "aba;",
                 Pattern.DOTALL);
         final Matcher earlyReturnCodeMatcher = earlyReturnPattern.matcher(function);
         return earlyReturnCodeMatcher.replaceFirst(";");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -33,18 +33,6 @@ final class YoutubeThrottlingParameterUtils {
              * The first regex matches the following text, where we want SDa and the array index
              * accessed:
              *
-             * WL(a),c=a.j[b]||null)&&(c=SDa[0](
-             */
-            Pattern.compile(MULTIPLE_CHARS_REGEX + "\\("
-                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(" + MULTIPLE_CHARS_REGEX + "=("
-                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("),
-
-            /*
-             * The second regex matches the following text, where we want SDa and the array index
-             * accessed:
-             *
              * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
              */
             Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
@@ -55,12 +43,9 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX),
 
             /*
-             * The third regex matches the following text, where we want Wma:
+             * The second regex matches the following text, where we want Wma:
              *
              * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
-             *
-             * UPDATE: This is prone to find the wrong function on recent version of the player.
-             * For this reason a regex which finds the Array + index should be preferred / above.
              */
             Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
                     + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "\\("
@@ -68,6 +53,18 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
                     + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\).+\\|\\|(" + MULTIPLE_CHARS_REGEX
                     + ")\\(\"\"\\)"),
+
+            /*
+             * The third regex matches the following text, where we want SDa and the array index
+             * accessed:
+             *
+             * WL(a),c=a.j[b]||null)&&(c=SDa[0](
+             */
+            Pattern.compile(MULTIPLE_CHARS_REGEX + "\\("
+                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
+                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
+                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(" + MULTIPLE_CHARS_REGEX + "=("
+                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("),
 
             /*
              * The fourth regex matches the following text, where we want rma:

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -58,13 +58,14 @@ final class YoutubeThrottlingParameterUtils {
              * The third regex matches the following text, where we want SDa and the array index
              * accessed:
              *
-             * WL(a),c=a.j[b]||null)&&(c=SDa[0](
+             * WL(a),c=a.j[b]||null)&&(c=SDa[0](c)
              */
             Pattern.compile(MULTIPLE_CHARS_REGEX + "\\("
                     + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
                     + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
                     + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(" + MULTIPLE_CHARS_REGEX + "=("
-                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("),
+                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX
+                    + "\\(" + MULTIPLE_CHARS_REGEX + "\\)"),
 
             /*
              * The fourth regex matches the following text, where we want rma:

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -30,8 +30,7 @@ final class YoutubeThrottlingParameterUtils {
     private static final Pattern[] DEOBFUSCATION_FUNCTION_NAME_REGEXES = {
 
             /*
-             * The first regex matches the following text, where we want SDa and the array index
-             * accessed:
+             * Matches the following text, where we want SDa and the array index accessed:
              *
              * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
              */
@@ -43,7 +42,7 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX),
 
             /*
-             * The second regex matches the following text, where we want Wma:
+             * Matches the following text, where we want Wma:
              *
              * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
              */
@@ -55,8 +54,7 @@ final class YoutubeThrottlingParameterUtils {
                     + ")\\(\"\"\\)"),
 
             /*
-             * The third regex matches the following text, where we want SDa and the array index
-             * accessed:
+             * Matches the following text, where we want cvb and the array index accessed:
              *
              * ,Vb(m),W=m.j[c]||null)&&(W=cvb[0](W),m.set(c,W)
              */
@@ -70,7 +68,7 @@ final class YoutubeThrottlingParameterUtils {
                     + "\\)"),
 
             /*
-             * The fourth regex matches the following text, where we want rma:
+             * Matches the following text, where we want rma:
              *
              * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
              */
@@ -80,8 +78,7 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + ")\\(\"\"\\)"),
 
             /*
-             * The fifth regex matches the following text, where we want rDa and the array index
-             * accessed:
+             * Matches the following text, where we want rDa and the array index accessed:
              *
              * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
              */
@@ -91,8 +88,7 @@ final class YoutubeThrottlingParameterUtils {
                     + MULTIPLE_CHARS_REGEX + "=(" + MULTIPLE_CHARS_REGEX + ")\\[(\\d+)]"),
 
             /*
-             * The sixth regex matches the following text, where we want BDa and the array index
-             * accessed:
+             * Matches the following text, where we want BDa and the array index accessed:
              *
              * (b=String.fromCharCode(110),c=a.get(b))&&(c=BDa[0](c)
              */
@@ -103,8 +99,7 @@ final class YoutubeThrottlingParameterUtils {
                     + SINGLE_CHAR_VARIABLE_REGEX + "\\)"),
 
             /*
-             * The seventh regex matches the following text, where we want Yva and the array index
-             * accessed:
+             * Matches the following text, where we want Yva and the array index accessed:
              *
              * .get("n"))&&(b=Yva[0](b)
              */


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

Fixes #1252

Changes:
- new regex for extracting the name of the n param deobfuscation function
- added fixup for the n param deobfuscation functions code to prevent an early return