### PR TITLE
Bugfix: Extract visitor data from sw.js_data API instead of randomly…

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -218,6 +218,11 @@ public final class YoutubeParsingHelper {
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
     /**
+     * Regex for extracing any JSON array.
+     */
+    private static final String JSON_ARRAY = "\\[.*\\]";
+
+    /**
      * The device machine id for the iPhone 15 Pro Max,
      * used to get 60fps with the {@code iOS} client.
      *

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -338,7 +338,7 @@ public final class YoutubeParsingHelper {
      * The function currently uses very brittle extraction logic.
      * Likely to fail with future changes.
      *
-     * @return extracted encoded visitor data string, or a randomly generated one.
+     * @return extracted encoded visitor data string
      * @throws ParsingException if the format of data is no longer a JSON array
      * @throws IOException when it cannot fetch the API data
      * @throws ReCaptchaException when it cannot fetch the API data


### PR DESCRIPTION
In #1262, visitor data was randomly generated for the iOS client, but this has recently broken. This PR tries to extract this data from `https://www.youtube.com/sw.js_data` as suggested by @gechoto in TeamNewPipe/NewPipe#11980. Works on NewPipe, with the expected behaviour of videos properly loading. Also took it for a spin with a bike ride :)

The solution doesn't feel very robust, but further work on parsing the all the data coming from this endpoint is not something I'm knowledgeable about.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
