### PR TITLE
Only include ``jsr305`` and not complete spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 
     ext {
         nanojsonVersion = "1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
-        spotbugsVersion = "4.8.6"
+        jsr305Version = "3.0.2"
         junitVersion = "5.11.4"
         checkstyleVersion = "10.4"
     }

--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation "com.github.TeamNewPipe:nanojson:$nanojsonVersion"
     implementation 'org.jsoup:jsoup:1.17.2'
-    implementation "com.github.spotbugs:spotbugs-annotations:$spotbugsVersion"
+    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 
     // do not upgrade to 1.7.14, since in 1.7.14 Rhino uses the `SourceVersion` class, which is not
     // available on Android (even when using desugaring), and `NoClassDefFoundError` is thrown

--- a/timeago-parser/build.gradle
+++ b/timeago-parser/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     implementation "com.github.TeamNewPipe:nanojson:$nanojsonVersion"
-    implementation "com.github.spotbugs:spotbugs-annotations:$spotbugsVersion"
+    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
 }


### PR DESCRIPTION
Fixes #1278

Only ``javax.annotation.Nonnull`` or ``javax.annotation.Nullable`` are currently in used which means that spotbugs can and should be removed.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
