### PR TITLE
[Youtube] Mark members-only videos

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -470,4 +470,18 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             throw new ParsingException("Could not determine if this is short-form content", e);
         }
     }
+
+    @Nonnull
+    @Override
+    public boolean requiresMembership() throws ParsingException {
+        final JsonArray badges = videoInfo.getArray("badges");
+        for (final Object badge : badges) {
+            if (((JsonObject) badge).getObject("metadataBadgeRenderer")
+                    .getString("style", "").equals("BADGE_STYLE_TYPE_MEMBERS_ONLY")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamExtractor.java
@@ -581,6 +581,16 @@ public abstract class StreamExtractor extends Extractor {
         return false;
     }
 
+    /**
+     * Whether the stream is only available to channel members.
+     *
+     * @return whether the stream is only available to channel members.
+     * @throws ParsingException if there is an error in the extraction
+     */
+    public boolean requiresMembership() throws ParsingException {
+        return false;
+    }
+
     public enum Privacy {
         PUBLIC,
         UNLISTED,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -330,6 +330,11 @@ public class StreamInfo extends Info {
         } catch (final Exception e) {
             streamInfo.addError(e);
         }
+        try {
+            streamInfo.setRequiresMembership(extractor.requiresMembership());
+        } catch (final Exception e) {
+            streamInfo.addError(e);
+        }
 
         streamInfo.setRelatedItems(ExtractorHelper.getRelatedItemsOrLogError(streamInfo,
                 extractor));
@@ -381,6 +386,7 @@ public class StreamInfo extends Info {
     private List<StreamSegment> streamSegments = List.of();
     private List<MetaInfo> metaInfo = List.of();
     private boolean shortFormContent = false;
+    private boolean membersOnly = false;
 
     /**
      * Preview frames, e.g. for the storyboard / seekbar thumbnail preview
@@ -726,5 +732,13 @@ public class StreamInfo extends Info {
 
     public void setShortFormContent(final boolean isShortFormContent) {
         this.shortFormContent = isShortFormContent;
+    }
+
+    public boolean requiresMembership() {
+        return membersOnly;
+    }
+
+    public void setRequiresMembership(final boolean requiresMembership) {
+        this.membersOnly = requiresMembership;
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItem.java
@@ -47,6 +47,7 @@ public class StreamInfoItem extends InfoItem {
     private List<Image> uploaderAvatars = List.of();
     private boolean uploaderVerified = false;
     private boolean shortFormContent = false;
+    private boolean requiresMembership = false;
 
     public StreamInfoItem(final int serviceId,
                           final String url,
@@ -141,6 +142,14 @@ public class StreamInfoItem extends InfoItem {
 
     public void setShortFormContent(final boolean shortFormContent) {
         this.shortFormContent = shortFormContent;
+    }
+
+    public boolean requiresMembership() {
+        return requiresMembership;
+    }
+
+    public void setRequiresMembership(final boolean requiresMembership) {
+        this.requiresMembership = requiresMembership;
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemExtractor.java
@@ -146,4 +146,14 @@ public interface StreamInfoItemExtractor extends InfoItemExtractor {
     default boolean isShortFormContent() throws ParsingException {
         return false;
     }
+
+    /**
+     * Whether the stream is only available to channel members.
+     *
+     * @return whether the stream is only available to channel members.
+     * @throws ParsingException if there is an error in the extraction
+     */
+    default boolean requiresMembership() throws ParsingException {
+        return false;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfoItemsCollector.java
@@ -103,6 +103,11 @@ public class StreamInfoItemsCollector
         } catch (final Exception e) {
             addError(e);
         }
+        try {
+            resultItem.setRequiresMembership(extractor.requiresMembership());
+        } catch (final Exception e) {
+            addError(e);
+        }
 
         return resultItem;
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

YouTube inserts members-only videos (i.e., videos that require channel membership to watch) into the Videos tab. Because the extractor unable to distinguish between them and "normal" videos, they may appear in subscriptions feeds.
This enables the extractor to check if videos require membership, allowing clients to filter them.

Ref: https://github.com/TeamNewPipe/NewPipe/issues/12040
Ref: https://github.com/TeamNewPipe/NewPipe/issues/12011