### PR TITLE
[YouTube] Fix crash on SABR-only player responses, do not use WEB client for stream URLs anymore

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
@@ -11,12 +11,6 @@ import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.IOS
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.IOS_DEVICE_MODEL;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.IOS_OS_VERSION;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.MOBILE_CLIENT_PLATFORM;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_CLIENT_ID;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_CLIENT_NAME;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_CLIENT_PLATFORM;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_CLIENT_VERSION;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_DEVICE_MAKE;
-import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.TVHTML5_DEVICE_MODEL_AND_OS_NAME;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.WATCH_CLIENT_SCREEN;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.WEB_CLIENT_ID;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.WEB_CLIENT_NAME;
@@ -116,16 +110,6 @@ public final class InnertubeClientRequestInfo {
                         WEB_EMBEDDED_CLIENT_ID, null),
                 new InnertubeClientRequestInfo.DeviceInfo(DESKTOP_CLIENT_PLATFORM, null, null,
                         null, null, -1));
-    }
-
-    @Nonnull
-    public static InnertubeClientRequestInfo ofTvHtml5Client() {
-        return new InnertubeClientRequestInfo(
-                new InnertubeClientRequestInfo.ClientInfo(TVHTML5_CLIENT_NAME,
-                        TVHTML5_CLIENT_VERSION, WATCH_CLIENT_SCREEN, TVHTML5_CLIENT_ID, null),
-                new InnertubeClientRequestInfo.DeviceInfo(TVHTML5_CLIENT_PLATFORM,
-                        TVHTML5_DEVICE_MAKE, TVHTML5_DEVICE_MODEL_AND_OS_NAME,
-                        TVHTML5_DEVICE_MODEL_AND_OS_NAME, "", -1));
     }
 
     @Nonnull


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

This PR fixes `NullPointerException`s when an adapative format has no stream URL available, which is the case for SABR-only YouTube player responses, rolled out for the WEB client (almost?) completely. This caused the extractor to crash, as no null handling for URLs was made.

`TVHTML5` client usage for streaming has been also removed for now, as signatures extraction of HTML5 clients is currently broken (`WEB_EMBEDDED_PLAYER` fallback for age-restricted video is still done but won't work).

Stream mocks need to be updated.

Fixes TeamNewPipe/NewPipe#12126, fixes TeamNewPipe/NewPipe#12134.