### PR TITLE
Fix javadoc typo

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/StreamingService.java
@@ -145,7 +145,7 @@ public abstract class StreamingService {
      * Must return a new instance of an implementation of ListLinkHandlerFactory for channel tabs.
      * If support for channel tabs is not given null must be returned.
      *
-     * @return an instance of a ListLinkHandlerFactory for channels or null
+     * @return an instance of a ListLinkHandlerFactory for channel tabs or null
      */
     public abstract ListLinkHandlerFactory getChannelTabLHFactory();
 


### PR DESCRIPTION
Hi!

Just a stupid fix for a documentation typo I saw while reading it :)

Thanks for the library and overall effort!

Regards,
Iscle

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
