### PR TITLE
Create FUNDING.yml to display Liberapay as sponsoring option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+liberapay: TeamNewPipe
+custom: 'https://newpipe.net/donate/'


### PR DESCRIPTION
This creates FUNDING.yml  to display Liberapay as sponsoring option as it is done in NewPipe:
<img width="417" height="199" alt="grafik" src="https://github.com/user-attachments/assets/37ccaea8-c7d3-4ef9-b4ba-2dfdc209c1c9" />

It might be necessary to enable this feature in the project settings [as described in the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository).

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.