### PR TITLE
[YouTube] Support LOCKUP_CONTENT_TYPE_PODCAST

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -247,10 +247,14 @@ public class YoutubeSearchExtractor extends SearchExtractor {
                             item.getObject("showRenderer")));
                 } else if (item.has("lockupViewModel")) {
                     final JsonObject lockupViewModel = item.getObject("lockupViewModel");
-                    if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(
-                            lockupViewModel.getString("contentType"))) {
+                    final String contentType = lockupViewModel.getString("contentType");
+                    if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(contentType)
+                            || "LOCKUP_CONTENT_TYPE_PODCAST".equals(contentType)) {
                         collector.commit(
                                 new YoutubeMixOrPlaylistLockupInfoItemExtractor(lockupViewModel));
+                    } else if ("LOCKUP_CONTENT_TYPE_VIDEO".equals(contentType)) {
+                        collector.commit(new YoutubeStreamInfoItemLockupExtractor(
+                                lockupViewModel, timeAgoParser));
                     }
                 }
             }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -760,7 +760,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         } else if (result.has("lockupViewModel")) {
                             final JsonObject lockupViewModel = result.getObject("lockupViewModel");
                             final String contentType = lockupViewModel.getString("contentType");
-                            if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(contentType)) {
+                            if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(contentType)
+                                    || "LOCKUP_CONTENT_TYPE_PODCAST".equals(contentType)) {
                                 return new YoutubeMixOrPlaylistLockupInfoItemExtractor(
                                         lockupViewModel);
                             } else if ("LOCKUP_CONTENT_TYPE_VIDEO".equals(contentType)) {


### PR DESCRIPTION
This PR adds support for the `LOCKUP_CONTENT_TYPE_PODCAST` lockup view model by reusing the lockup playlist item extractor. The JSON is basically the same as `LOCKUP_CONTENT_TYPE_PLAYLIST`, I even tried doing a diff and their structure is identical.

<details><summary>JSON</summary>


```json
{
  "1": {
    "lockupViewModel": {
      "contentImage": {
        "collectionThumbnailViewModel": {
          "primaryThumbnail": {
            "thumbnailViewModel": {
              "image": {
                "sources": [
                  {
                    "url": "https://i.ytimg.com/pl_c/PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL/studio_square_thumbnail.jpg?sqp=CMCU3sMG-oaymwEICPABEPABSFqi85f_AwYI6oG9vQY=&rs=AOn4CLApEpZwgLEPcWmMr6_cs6IR5PkXTg",
                    "width": 240,
                    "height": 240
                  },
                  {
                    "url": "https://i.ytimg.com/pl_c/PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL/studio_square_thumbnail.jpg?sqp=CNKI3sMG-oaymwEICOADEOADSFqi85f_AwYI6oG9vQY=&rs=AOn4CLDpdAz93ci5onCCltBh4kNZqk0w6g",
                    "width": 480,
                    "height": 480
                  },
                  {
                    "url": "https://i.ytimg.com/pl_c/PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL/studio_square_thumbnail.jpg?sqp=CJis3sMG-oaymwEICNAFENAFSFqi85f_AwYI6oG9vQY=&rs=AOn4CLD9RhKytxnOMuRCIlimhkAT-cvo6A",
                    "width": 720,
                    "height": 720
                  }
                ]
              },
              "overlays": [
                {
                  "thumbnailOverlayBadgeViewModel": {
                    "thumbnailBadges": [
                      {
                        "thumbnailBadgeViewModel": {
                          "icon": {
                            "sources": [
                              {
                                "clientResource": {
                                  "imageName": "BROADCAST"
                                }
                              }
                            ]
                          },
                          "text": "23 episodes",
                          "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT",
                          "backgroundColor": {
                            "lightTheme": 2763059,
                            "darkTheme": 2763059
                          }
                        }
                      }
                    ],
                    "position": "THUMBNAIL_OVERLAY_BADGE_POSITION_BOTTOM_END"
                  }
                },
                {
                  "thumbnailHoverOverlayViewModel": {
                    "icon": {
                      "sources": [
                        {
                          "clientResource": {
                            "imageName": "PLAY_ALL"
                          }
                        }
                      ]
                    },
                    "text": {
                      "content": "Play all",
                      "styleRuns": [
                        {
                          "startIndex": 0,
                          "length": 8
                        }
                      ]
                    },
                    "style": "THUMBNAIL_HOVER_OVERLAY_STYLE_COVER"
                  }
                }
              ],
              "backgroundColor": {
                "lightTheme": 2763058,
                "darkTheme": 2763058
              }
            }
          },
          "stackColor": {
            "lightTheme": 8354713,
            "darkTheme": 8486299
          }
        }
      },
      "metadata": {
        "lockupMetadataViewModel": {
          "title": {
            "content": "Кампанія 2 \"Ехо Аркани\" [Записи ігор]"
          },
          "metadata": {
            "contentMetadataViewModel": {
              "metadataRows": [
                {
                  "metadataParts": [
                    {
                      "text": {
                        "content": "View full podcast",
                        "commandRuns": [
                          {
                            "startIndex": 0,
                            "length": 17,
                            "onTap": {
                              "innertubeCommand": {
                                "clickTrackingParams": "REDACTED",
                                "commandMetadata": {
                                  "webCommandMetadata": {
                                    "url": "/playlist?list=PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL",
                                    "webPageType": "WEB_PAGE_TYPE_PLAYLIST",
                                    "rootVe": 5754,
                                    "apiUrl": "/youtubei/v1/browse"
                                  }
                                },
                                "browseEndpoint": {
                                  "browseId": "VLPLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL"
                                }
                              }
                            }
                          }
                        ],
                        "styleRuns": [
                          {
                            "startIndex": 0,
                            "length": 17,
                            "weightLabel": "FONT_WEIGHT_MEDIUM"
                          }
                        ]
                      }
                    }
                  ]
                }
              ],
              "delimiter": " • "
            }
          }
        }
      },
      "contentId": "PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL",
      "contentType": "LOCKUP_CONTENT_TYPE_PODCAST",
      "rendererContext": {
        "loggingContext": {
          "loggingDirectives": {
            "trackingParams": "REDACTED",
            "visibility": {
              "types": "12"
            }
          }
        },
        "commandContext": {
          "onTap": {
            "innertubeCommand": {
              "clickTrackingParams": "REDACTED",
              "commandMetadata": {
                "webCommandMetadata": {
                  "url": "/watch?v=CKX4TlQS-Ug&list=PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL&pp=0gcJCV8EOCosWNin",
                  "webPageType": "WEB_PAGE_TYPE_WATCH",
                  "rootVe": 3832
                }
              },
              "watchEndpoint": {
                "videoId": "CKX4TlQS-Ug",
                "playlistId": "PLO1kG5YTufOZJSMc9QddoVZhjN1l8egdL",
                "params": "OAI%3D",
                "playerParams": "REDACTED",
                "loggingContext": {
                  "vssLoggingContext": {
                    "serializedContextData": "REDACTED"
                  }
                },
                "watchEndpointSupportedOnesieConfig": {
                  "html5PlaybackOnesieConfig": {
                    "commonConfig": {
                      "url": "REDACTED"
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```
</details>

While I was at it, I also made `LOCKUP_CONTENT_TYPE_VIDEO` (#1320) work in other places in the app (not just recommended videos), just in case they'll start using it more in the future.

Here is a testing APK: [app-debug.zip](https://github.com/user-attachments/files/21258058/app-debug.zip)

<table>
  <tr>
    <th>Before (NewPipe)</th>
    <th>After (NewPipe)</th>
    <th>On YouTube</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/07a79592-68b8-49f6-ad44-599e46db6f8f" width="200px" alt="NewPipe"/></td>
    <td><img src="https://github.com/user-attachments/assets/3bf5e7e4-47f7-40dd-90ca-0ea6197935f2" width="200px" alt="NewPipe"/></td>
    <td><img src="https://github.com/user-attachments/assets/f58a089a-a980-4bf6-88e2-52b5f7f350ae" width="300px" alt="YouTube"/></td>
  </tr>
</table>


- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).

