### PR TITLE
 [YouTube] Add custom error for "Sign in to confirm ..."

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/SignInConfirmNotBotException.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/exceptions/SignInConfirmNotBotException.java
@@ -1,0 +1,11 @@
+package org.schabi.newpipe.extractor.exceptions;
+
+/**
+ * Content can't be extracted because the service requires logging in to confirm the user is not a
+ * bot. Can usually only be solvable by changing IP (e.g. in the case of YouTube).
+ */
+public class SignInConfirmNotBotException extends ParsingException {
+    public SignInConfirmNotBotException(final String message) {
+        super(message);
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -53,6 +53,7 @@ import org.schabi.newpipe.extractor.exceptions.PaidContentException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
 import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException;
+import org.schabi.newpipe.extractor.exceptions.SignInConfirmNotBotException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
@@ -901,7 +902,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             }
         }
 
-        throw new ContentNotAvailableException("Got error: \"" + reason + "\"");
+        // "Sign in to confirm that you're not a bot"
+        if (reason != null && reason.contains("a bot")) {
+            throw new SignInConfirmNotBotException(
+                    "YouTube probably temporarily blocked this IP, got error "
+                            + status + ": \"" + reason + "\"");
+        }
+
+        throw new ContentNotAvailableException("Got error " + status + ": \"" + reason + "\"");
     }
 
     private void fetchHtml5Client(@Nonnull final Localization localization,


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

This PR adds a custom exception when "Sign in to confirm that you're not a bot" is detected from YouTube, so we can show a custom message in NewPipe. I could not test whether the detection works because I am not experiencing temporary bans from YouTube at the moment, but I based my checks on https://github.com/TeamNewPipe/NewPipe/issues/11139 .