### PR TITLE
Fix JDoc and automated doc build

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 /**
  * Note:
- * This extractor is currently (2025-07) only used to extract related video streams.<br/>
+ * This extractor is currently (2025-07) only used to extract related video streams.<br>
  * The following features are currently not implemented because they have never been observed:
  * <ul>
  *     <li>Shorts</li>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

See https://github.com/TeamNewPipe/NewPipeExtractor/actions/runs/16660575612/job/47156509194#step:5:43
```
NewPipeExtractor/NewPipeExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java:29: error: self-closing element not allowed
 * This extractor is currently (2025-07) only used to extract related video streams.<br/>
```