### PR TITLE
Fix aggregatedJavadocs task and update API link to JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,10 @@ subprojects {
 
 // https://discuss.gradle.org/t/best-approach-gradle-multi-module-project-generate-just-one-global-javadoc/18657/21
 tasks.register('aggregatedJavadocs', Javadoc) {
-    destinationDir = file("${layout.buildDirectory}/docs/javadoc")
+    destinationDir = layout.buildDirectory.file("docs/javadoc").get().asFile
     title = "$project.name $version"
     // options.memberLevel = JavadocMemberLevel.PRIVATE
-    options.links 'https://docs.oracle.com/javase/8/docs/api/'
+    options.links 'https://docs.oracle.com/javase/11/docs/api/'
     options.encoding 'UTF-8'
     // Fixes unknown tag @implNote; the other two were added precautionary
     options.tags = [


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Previous deployment resulted in deletion of all files (https://github.com/TeamNewPipe/NewPipeExtractor/commit/86530389f3e0faefc22fd0a3f9598d41b7e583da). Fixed deployment, see deployment in my repo: https://github.com/TobiGr/NewPipeExtractor/commit/0c96e1da7af59af9c43eeee924037b71bbce8d78 

This needs to be pushed to master to fix the JDoc deployment.