### PR TITLE
[YouTube] extract additional stream information

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ItagItem.java
@@ -269,6 +269,7 @@ public class ItagItem implements Serializable {
     private Locale audioLocale;
     private boolean isDrc;
     private long lastModified;
+    private String xtags;
 
     public int getBitrate() {
         return bitrate;
@@ -701,4 +702,26 @@ public class ItagItem implements Serializable {
         this.lastModified = lastModified;
     }
 
+    /**
+     * Extra tags about the stream.
+     *
+     * <p>
+     * Contains a Base64 encoded protobuf key-value list of additional tags for the stream,
+     * such as whether the stream is using {@link #isDrc()}.
+     * </p>
+     *
+     * @return Base64-encoded extra tags.
+     */
+    public String getXtags() {
+        return xtags;
+    }
+
+    /**
+     * Sets extra tags of the stream.
+     *
+     * @param xtags extra tags of the stream
+     */
+    public void setXtags(final String xtags) {
+        this.xtags = xtags;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1423,6 +1423,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         itagItem.setCodec(codec);
         itagItem.setIsDrc(formatData.getBoolean("isDrc", false));
         itagItem.setLastModified(Long.parseLong(formatData.getString("lastModified", "-1")));
+        itagItem.setXtags(formatData.getString("xtags"));
 
         if (streamType == StreamType.LIVE_STREAM || streamType == StreamType.POST_LIVE_STREAM) {
             itagItem.setTargetDurationSec(formatData.getInt("targetDurationSec"));


### PR DESCRIPTION
Implements support for extracting `lastModified`, `xtags` and `isDrc` (whether a format is using dynamic range compression) from formats. They are required for initiating SABR playback, but may also be useful on their own (e.g. to filter audio streams with DRC).

Ref: https://github.com/TeamNewPipe/NewPipe/issues/12248

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
