### PR TITLE
[YouTube] Extract shorts thumbnails from `thumbnailViewModel`

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsLockupInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsLockupInfoItemExtractor.java
@@ -78,7 +78,15 @@ class YoutubeShortsLockupInfoItemExtractor implements StreamInfoItemExtractor {
     @Nonnull
     @Override
     public List<Image> getThumbnails() throws ParsingException {
-        return getImagesFromThumbnailsArray(shortsLockupViewModel.getObject("thumbnail")
+        if (shortsLockupViewModel.has("thumbnail")) {
+            return getImagesFromThumbnailsArray(shortsLockupViewModel.getObject("thumbnail")
+                .getArray("sources"));
+        }
+
+        return getImagesFromThumbnailsArray(shortsLockupViewModel
+                .getObject("thumbnailViewModel")
+                .getObject("thumbnailViewModel")
+                .getObject("image")
                 .getArray("sources"));
     }
 


### PR DESCRIPTION
Fixes an issue, where shorts thumbnails where not extracted, as they're now contained within a `thumbnailViewModel`, instead of a simple `thumbnail` object.

Closes: https://github.com/TeamNewPipe/NewPipe/issues/12907

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
