### PR TITLE
Include timeago-parser classes manually

### DIFF
--- a/extractor/build.gradle.kts
+++ b/extractor/build.gradle.kts
@@ -17,6 +17,12 @@ java {
     withJavadocJar()
 }
 
+sourceSets {
+    main {
+        java.srcDir("../timeago-parser/src/main/java")
+    }
+}
+
 // Protobuf files would uselessly end up in the JAR otherwise, see
 // https://github.com/google/protobuf-gradle-plugin/issues/390
 tasks.jar {
@@ -49,7 +55,10 @@ checkstyle {
 
 // Exclude Protobuf generated files from Checkstyle
 tasks.checkstyleMain {
-    exclude("org/schabi/newpipe/extractor/services/youtube/protos")
+    exclude(
+        "org/schabi/newpipe/extractor/services/youtube/protos",
+        "org/schabi/newpipe/extractor/timeago"
+    )
 }
 
 tasks.checkstyleTest {
@@ -57,8 +66,6 @@ tasks.checkstyleTest {
 }
 
 dependencies {
-    implementation(project(":timeago-parser"))
-
     implementation(libs.newpipe.nanojson)
     implementation(libs.jsoup)
     implementation(libs.google.jsr305)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,5 +18,5 @@ dependencyResolutionManagement {
         maven(url = "https://jitpack.io")
     }
 }
-include("extractor", "timeago-parser", "timeago-generator")
+include("extractor", "timeago-generator")
 rootProject.name = "NewPipeExtractor"

--- a/timeago-generator/build.gradle.kts
+++ b/timeago-generator/build.gradle.kts
@@ -6,5 +6,4 @@
 dependencies {
     implementation(libs.newpipe.nanojson)
     implementation(libs.google.jsr305)
-    implementation(project(":timeago-parser"))
 }


### PR DESCRIPTION
Adding a module as implementation adds it as a dependency in the published jar's POM file

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
