### PR TITLE
Revert "Bump rhino from 1.8.1 to 1.9.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jsoup = "1.21.2"
 okhttp = "5.3.2"
 protobuf-lib = "4.33.2"
 protobuf-plugin = "0.9.6"
-rhino = "1.8.1"
+rhino = "1.8.1" # rhino 1.9.0 requires Android minSDK >= 26, see #1423
 teamnewpipe-nanojson = "e9d656ddb49a412a5a0a5d5ef20ca7ef09549996"
 
 [libraries]


### PR DESCRIPTION
Reverts TeamNewPipe/NewPipeExtractor#1420

Rhino 1.9.0 throws an error while trying to build and minify with minSDK < 26:

<details><summary>Stacktrace</summary>

```
Execution failed for task ':app:mergeExtDexDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform rhino-1.9.0.jar (org.mozilla:rhino:1.9.0) to match attributes {artifactType=android-dex, dexing-component-attributes=ComponentSpecificParameters(minSdkVersion=24, debuggable=true, enableCoreLibraryDesugaring=true, enableGlobalSynthetics=true, enableApiModeling=false, dependenciesClassesAreInstrumented=false, asmTransformComponent=null, useJacocoTransformInstrumentation=false, enableDesugaring=true, needsClasspath=false, useFullClasspath=false, componentIfUsingFullClasspath=null), org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=11, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /home/tobias/.gradle/caches/modules-2/files-2.1/org.mozilla/rhino/1.9.0/fa35ed9a35d456bda30c817d7337a6e88ccc1e1e/rhino-1.9.0.jar.
         > Error while dexing.
           Increase the minSdkVersion to 26 or above.

```
</details> 