### PR TITLE
fix: use String charset for URLDecoder/URLEncoder for Android < 13 compatibility

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -39,7 +39,7 @@ public final class Utils {
             return URLEncoder.encode(string, UTF_8);
         } catch (final UnsupportedEncodingException e) {
             // UTF-8 is always supported, this should never happen
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
     }
 
@@ -53,7 +53,7 @@ public final class Utils {
             return URLDecoder.decode(url, UTF_8);
         } catch (final UnsupportedEncodingException e) {
             // UTF-8 is always supported, this should never happen
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
     }
 


### PR DESCRIPTION
> * [x]  I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
> * [x]  I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
> * [x]  I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
> 

URLDecoder.decode(String, Charset) and URLEncoder.encode(String, Charset) are only available on Android 13+ (API 33). This change uses the older String-based API that works on all Android versions.

Fixes crash: java.lang.NoSuchMethodError: No static method decode( Ljava/lang/String;Ljava/nio/charset/Charset;)Ljava/lang/String;