### PR TITLE
extractor: Setup signing and publishing for CI snapshots

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,40 @@
+name: Publish snapshot
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Publish snapshot
+        env:
+          PGP_PRIVATE_SIGNING_KEY: ${{ secrets.PGP_PRIVATE_SIGNING_KEY }}
+          PGP_PRIVATE_SIGNING_KEY_PASSWORD: ${{ secrets.PGP_PRIVATE_SIGNING_KEY_PASSWORD }}
+          SONATYPE_MAVEN_CENTRAL_USERNAME: ${{ secrets.SONATYPE_MAVEN_CENTRAL_USERNAME }}
+          SONATYPE_MAVEN_CENTRAL_PASSWORD: ${{ secrets.SONATYPE_MAVEN_CENTRAL_PASSWORD }}
+        run: ./gradlew publishSnapshotPublicationToSonatypeRepository
+
+      - name: Upload metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: NewPipeExtractor-Snapshot
+          path: extractor/build/publications/snapshot/**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ If you're using Gradle, you could add NewPipe Extractor as a dependency with the
 
 ### Testing changes
 
+#### Maven Central
+
+NewPipe Extractor's snapshots are available on Maven Central's snapshot repository. These versions
+are based on the commit's short hash (for e.g. `git rev-parse --short HEAD`) and are available for
+90 days since the date of publication/commit.
+
+```kotlin
+repositories {
+    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
+}
+
+dependencies {
+    implementation("net.newpipe:extractor:${LAST_COMMIT_SHORT_HASH}-SNAPSHOT")
+}
+```
+
+#### Local
+
 To test changes quickly you can build the library locally. A good approach would be to add something like the following to your `settings.gradle`:
 
 ```groovy

--- a/extractor/build.gradle.kts
+++ b/extractor/build.gradle.kts
@@ -6,10 +6,20 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+val ciSigningKey: String? = System.getenv("PGP_PRIVATE_SIGNING_KEY")
+val ciSigningPassword: String? = System.getenv("PGP_PRIVATE_SIGNING_KEY_PASSWORD")
+val shouldSignCIRelease: Boolean
+    get() = !ciSigningKey.isNullOrEmpty() && !ciSigningPassword.isNullOrEmpty()
+
+val lastCommitHash: String = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.map { it.trim() }.get()
+
 plugins {
     alias(libs.plugins.google.protobuf)
     checkstyle
     `maven-publish`
+    signing
 }
 
 java {
@@ -112,47 +122,79 @@ protobuf {
 // Run "./gradlew publishReleasePublicationToLocalRepository" to generate release JARs locally
 publishing {
     publications {
+        val mavenGroupId = "net.newpipe"
+        val mavenArtifactId = "extractor"
+        fun MavenPublication.setupPOM() = pom {
+            name = "NewPipe Extractor"
+            description = "A library for extracting data from streaming websites, used in NewPipe"
+            url = "https://github.com/TeamNewPipe/NewPipeExtractor"
+
+            licenses {
+                license {
+                    name = "GNU GENERAL PUBLIC LICENSE, Version 3"
+                    url = "https://www.gnu.org/licenses/gpl-3.0.txt"
+                }
+            }
+
+            scm {
+                url = "https://github.com/TeamNewPipe/NewPipeExtractor"
+                connection = "scm:git:git@github.com:TeamNewPipe/NewPipeExtractor.git"
+                developerConnection = "scm:git:git@github.com:TeamNewPipe/NewPipeExtractor.git"
+            }
+
+            developers {
+                developer {
+                    id = "newpipe"
+                    name = "Team NewPipe"
+                    email = "team@newpipe.net"
+                }
+            }
+        }
+
         create<MavenPublication>("release") {
-            groupId = "net.newpipe"
-            artifactId = "extractor"
+            groupId = mavenGroupId
+            artifactId = mavenArtifactId
             version = rootProject.version.toString()
 
             afterEvaluate {
                 from(components["java"])
             }
 
-            pom {
-                name = "NewPipe Extractor"
-                description = "A library for extracting data from streaming websites, used in NewPipe"
-                url = "https://github.com/TeamNewPipe/NewPipeExtractor"
+            setupPOM()
+        }
+        create<MavenPublication>("snapshot") {
+            groupId = mavenGroupId
+            artifactId = mavenArtifactId
+            version = "$lastCommitHash-SNAPSHOT"
 
-                licenses {
-                    license {
-                        name = "GNU GENERAL PUBLIC LICENSE, Version 3"
-                        url = "https://www.gnu.org/licenses/gpl-3.0.txt"
-                    }
-                }
-
-                scm {
-                    url = "https://github.com/TeamNewPipe/NewPipeExtractor"
-                    connection = "scm:git:git@github.com:TeamNewPipe/NewPipeExtractor.git"
-                    developerConnection = "scm:git:git@github.com:TeamNewPipe/NewPipeExtractor.git"
-                }
-
-                developers {
-                    developer {
-                        id = "newpipe"
-                        name = "Team NewPipe"
-                        email = "team@newpipe.net"
-                    }
-                }
+            afterEvaluate {
+                from(components["java"])
             }
+
+            setupPOM()
         }
         repositories {
+            maven {
+                name = "sonatype"
+                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+                credentials {
+                    username = System.getenv("SONATYPE_MAVEN_CENTRAL_USERNAME")
+                    password = System.getenv("SONATYPE_MAVEN_CENTRAL_PASSWORD")
+                }
+            }
             maven {
                 name = "local"
                 url = uri(layout.buildDirectory.dir("maven"))
             }
         }
     }
+}
+
+signing {
+    useInMemoryPgpKeys(ciSigningKey, ciSigningPassword)
+    sign(publishing.publications["snapshot"])
+}
+
+tasks.withType<Sign> {
+    onlyIf("Signing credentials are present (only used for maven central)") { shouldSignCIRelease }
 }


### PR DESCRIPTION
#### Summary

This PR:

- Sets up signing and publishing for CI snapshots on Maven Central

#### Guidelines

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
