### PR TITLE
Add Darkibox service

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/ServiceList.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor;
 
 import org.schabi.newpipe.extractor.services.bandcamp.BandcampService;
+import org.schabi.newpipe.extractor.services.darkibox.DarkiboxService;
 import org.schabi.newpipe.extractor.services.media_ccc.MediaCCCService;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeService;
 import org.schabi.newpipe.extractor.services.soundcloud.SoundcloudService;
@@ -40,13 +41,14 @@ public final class ServiceList {
     public static final MediaCCCService MediaCCC = new MediaCCCService(2);
     public static final PeertubeService PeerTube = new PeertubeService(3);
     public static final BandcampService Bandcamp = new BandcampService(4);
+    public static final DarkiboxService Darkibox = new DarkiboxService(5);
 
     /**
      * When creating a new service, put this service in the end of this list,
      * and give it the next free id.
      */
     private static final List<StreamingService> SERVICES = List.of(
-            YouTube, SoundCloud, MediaCCC, PeerTube, Bandcamp);
+            YouTube, SoundCloud, MediaCCC, PeerTube, Bandcamp, Darkibox);
 
     /**
      * Get all the supported services.

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/DarkiboxService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/DarkiboxService.java
@@ -1,0 +1,120 @@
+package org.schabi.newpipe.extractor.services.darkibox;
+
+import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
+
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.channel.ChannelExtractor;
+import org.schabi.newpipe.extractor.channel.tabs.ChannelTabExtractor;
+import org.schabi.newpipe.extractor.comments.CommentsExtractor;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.kiosk.KioskList;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
+import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
+import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.playlist.PlaylistExtractor;
+import org.schabi.newpipe.extractor.search.SearchExtractor;
+import org.schabi.newpipe.extractor.services.darkibox.extractors.DarkiboxStreamExtractor;
+import org.schabi.newpipe.extractor.services.darkibox.linkHandler.DarkiboxSearchQueryHandlerFactory;
+import org.schabi.newpipe.extractor.services.darkibox.linkHandler.DarkiboxStreamLinkHandlerFactory;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
+import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
+
+import java.util.EnumSet;
+
+/**
+ * Service implementation for Darkibox, a video hosting platform.
+ *
+ * <p>Darkibox is a simple file hosting service that only supports playing individual video streams.
+ * Features like search, channels, playlists, and comments are not available.</p>
+ */
+public class DarkiboxService extends StreamingService {
+
+    public DarkiboxService(final int id) {
+        super(id, "Darkibox", EnumSet.of(VIDEO));
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return "https://darkibox.com";
+    }
+
+    @Override
+    public LinkHandlerFactory getStreamLHFactory() {
+        return DarkiboxStreamLinkHandlerFactory.getInstance();
+    }
+
+    @Override
+    public ListLinkHandlerFactory getChannelLHFactory() {
+        return null;
+    }
+
+    @Override
+    public ListLinkHandlerFactory getChannelTabLHFactory() {
+        return null;
+    }
+
+    @Override
+    public ListLinkHandlerFactory getPlaylistLHFactory() {
+        return null;
+    }
+
+    @Override
+    public SearchQueryHandlerFactory getSearchQHFactory() {
+        return DarkiboxSearchQueryHandlerFactory.getInstance();
+    }
+
+    @Override
+    public ListLinkHandlerFactory getCommentsLHFactory() {
+        return null;
+    }
+
+    @Override
+    public SearchExtractor getSearchExtractor(final SearchQueryHandler queryHandler) {
+        // Darkibox does not support search
+        return null;
+    }
+
+    @Override
+    public SuggestionExtractor getSuggestionExtractor() {
+        return null;
+    }
+
+    @Override
+    public SubscriptionExtractor getSubscriptionExtractor() {
+        return null;
+    }
+
+    @Override
+    public KioskList getKioskList() throws ExtractionException {
+        return new KioskList(this);
+    }
+
+    @Override
+    public ChannelExtractor getChannelExtractor(final ListLinkHandler linkHandler) {
+        return null;
+    }
+
+    @Override
+    public ChannelTabExtractor getChannelTabExtractor(final ListLinkHandler linkHandler) {
+        return null;
+    }
+
+    @Override
+    public PlaylistExtractor getPlaylistExtractor(final ListLinkHandler linkHandler) {
+        return null;
+    }
+
+    @Override
+    public StreamExtractor getStreamExtractor(final LinkHandler linkHandler) {
+        return new DarkiboxStreamExtractor(this, linkHandler);
+    }
+
+    @Override
+    public CommentsExtractor getCommentsExtractor(final ListLinkHandler linkHandler) {
+        return null;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/extractors/DarkiboxStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/extractors/DarkiboxStreamExtractor.java
@@ -1,0 +1,266 @@
+package org.schabi.newpipe.extractor.services.darkibox.extractors;
+
+import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.extractor.stream.StreamExtractor;
+import org.schabi.newpipe.extractor.utils.Parser;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.schabi.newpipe.extractor.stream.Stream.ID_UNKNOWN;
+
+/**
+ * Stream extractor for Darkibox video hosting.
+ *
+ * <p>The extraction flow is:</p>
+ * <ol>
+ *     <li>POST to {@code https://darkibox.com/dl} with form data:
+ *         {@code op=embed&file_code=FILECODE&auto=1}</li>
+ *     <li>Response contains packed JavaScript: {@code eval(function(p,a,c,k,e,d){...})}</li>
+ *     <li>After unpacking, the video URL is found in the {@code file:"URL"} parameter
+ *         of a PlayerJS configuration</li>
+ * </ol>
+ */
+public class DarkiboxStreamExtractor extends StreamExtractor {
+
+    private static final String DL_URL = "https://darkibox.com/dl";
+
+    private static final Pattern PACKED_JS_PATTERN = Pattern.compile(
+            "eval\\(function\\(p,a,c,k,e,d\\)\\{.*?\\}\\('(.*?)',(\\d+),(\\d+),"
+                    + "'(.*?)'\\.(split)\\('\\|'\\)",
+            Pattern.DOTALL);
+
+    private static final Pattern FILE_URL_PATTERN = Pattern.compile(
+            "[\"']?file[\"']?\\s*:\\s*\"(https?://[^\"]+)\"");
+
+    private static final Pattern TITLE_PATTERN = Pattern.compile(
+            "<title>([^<]*)</title>", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern THUMBNAIL_PATTERN = Pattern.compile(
+            "[\"']?image[\"']?\\s*:\\s*\"(https?://[^\"]+)\"");
+
+    private String videoUrl;
+    private String videoTitle;
+    private String thumbnailUrl;
+
+    public DarkiboxStreamExtractor(final StreamingService service,
+                                   final LinkHandler linkHandler) {
+        super(service, linkHandler);
+    }
+
+    @Override
+    public void onFetchPage(@Nonnull final Downloader downloader)
+            throws IOException, ExtractionException {
+        final String fileCode = getId();
+
+        // First, fetch the embed page to get the title
+        final String embedUrl = "https://darkibox.com/embed-" + fileCode + ".html";
+        final Response embedResponse = downloader.get(embedUrl);
+        final String embedPage = embedResponse.responseBody();
+
+        // Try to extract title from embed page
+        try {
+            final String rawTitle = Parser.matchGroup1(TITLE_PATTERN, embedPage);
+            // Clean up common suffixes like " - Darkibox" or "Watch "
+            videoTitle = rawTitle
+                    .replaceAll("(?i)\\s*[-|]\\s*darkibox.*$", "")
+                    .replaceAll("(?i)^watch\\s+", "")
+                    .trim();
+        } catch (final Parser.RegexException e) {
+            videoTitle = fileCode;
+        }
+
+        // POST to the dl endpoint with form-encoded data
+        final String formData = "op=embed&file_code=" + fileCode + "&auto=1";
+        final Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type",
+                Collections.singletonList("application/x-www-form-urlencoded"));
+        headers.put("Referer", Collections.singletonList(embedUrl));
+
+        final Response response = downloader.post(
+                DL_URL, headers, formData.getBytes(StandardCharsets.UTF_8));
+        final String responseBody = response.responseBody();
+
+        // Look for packed JS in the response
+        final Matcher packedMatcher = PACKED_JS_PATTERN.matcher(responseBody);
+        final String scriptContent;
+        if (packedMatcher.find()) {
+            scriptContent = unpackJs(
+                    packedMatcher.group(1),
+                    Integer.parseInt(packedMatcher.group(2)),
+                    Integer.parseInt(packedMatcher.group(3)),
+                    packedMatcher.group(4).split("\\|")
+            );
+        } else {
+            // The response might not be packed, try to use it directly
+            scriptContent = responseBody;
+        }
+
+        // Extract the video file URL
+        try {
+            videoUrl = Parser.matchGroup1(FILE_URL_PATTERN, scriptContent);
+        } catch (final Parser.RegexException e) {
+            throw new ExtractionException(
+                    "Could not extract video URL from Darkibox response for file code: "
+                            + fileCode, e);
+        }
+
+        // Try to extract thumbnail
+        try {
+            thumbnailUrl = Parser.matchGroup1(THUMBNAIL_PATTERN, scriptContent);
+        } catch (final Parser.RegexException e) {
+            thumbnailUrl = null;
+        }
+    }
+
+    /**
+     * Unpack JavaScript that has been packed with Dean Edwards' packer.
+     *
+     * <p>The packer encodes JavaScript by replacing words with short symbols and
+     * storing a dictionary. This method reverses that process.</p>
+     *
+     * @param payload   the packed payload string (the p argument)
+     * @param radix     the base/radix used for encoding (the a argument)
+     * @param count     the number of words in the dictionary (the c argument)
+     * @param keywords  the dictionary of replacement words (the k argument split by |)
+     * @return the unpacked JavaScript code
+     */
+    private static String unpackJs(final String payload,
+                                   final int radix,
+                                   final int count,
+                                   final String[] keywords) {
+        // Build the unpacked string by replacing encoded tokens with dictionary words
+        final StringBuilder result = new StringBuilder();
+        final Pattern tokenPattern = Pattern.compile("\\b(\\w+)\\b");
+        final Matcher tokenMatcher = tokenPattern.matcher(payload);
+        int lastEnd = 0;
+
+        while (tokenMatcher.find()) {
+            result.append(payload, lastEnd, tokenMatcher.start());
+            final String token = tokenMatcher.group(1);
+            final int index = parseBaseN(token, radix);
+            if (index >= 0 && index < keywords.length && !keywords[index].isEmpty()) {
+                result.append(keywords[index]);
+            } else {
+                result.append(token);
+            }
+            lastEnd = tokenMatcher.end();
+        }
+        result.append(payload, lastEnd, payload.length());
+
+        return result.toString();
+    }
+
+    /**
+     * Parse a string as a number in the given base/radix.
+     * Supports bases up to 36 (digits 0-9, letters a-z).
+     */
+    private static int parseBaseN(final String str, final int radix) {
+        try {
+            return Integer.parseInt(str, radix);
+        } catch (final NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public String getName() throws ParsingException {
+        assertPageFetched();
+        return videoTitle != null ? videoTitle : getId();
+    }
+
+    @Nonnull
+    @Override
+    public List<Image> getThumbnails() throws ParsingException {
+        assertPageFetched();
+        if (thumbnailUrl != null && !thumbnailUrl.isEmpty()) {
+            return List.of(new Image(
+                    thumbnailUrl,
+                    Image.HEIGHT_UNKNOWN,
+                    Image.WIDTH_UNKNOWN,
+                    Image.ResolutionLevel.UNKNOWN));
+        }
+        return List.of();
+    }
+
+    @Nonnull
+    @Override
+    public String getUploaderUrl() {
+        return "";
+    }
+
+    @Nonnull
+    @Override
+    public String getUploaderName() {
+        return "";
+    }
+
+    @Override
+    public List<AudioStream> getAudioStreams() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<VideoStream> getVideoStreams() throws ExtractionException {
+        assertPageFetched();
+        if (videoUrl == null || videoUrl.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final MediaFormat format;
+        if (videoUrl.contains(".m3u8")) {
+            // HLS streams are handled via getHlsUrl()
+            return Collections.emptyList();
+        } else if (videoUrl.contains(".mp4")) {
+            format = MediaFormat.MPEG_4;
+        } else {
+            format = MediaFormat.MPEG_4; // default assumption for video hosters
+        }
+
+        return List.of(new VideoStream.Builder()
+                .setId(ID_UNKNOWN)
+                .setContent(videoUrl, true)
+                .setIsVideoOnly(false)
+                .setMediaFormat(format)
+                .setResolution("720p")
+                .build());
+    }
+
+    @Override
+    public List<VideoStream> getVideoOnlyStreams() {
+        return Collections.emptyList();
+    }
+
+    @Nonnull
+    @Override
+    public String getHlsUrl() throws ParsingException {
+        assertPageFetched();
+        if (videoUrl != null && videoUrl.contains(".m3u8")) {
+            return videoUrl;
+        }
+        return "";
+    }
+
+    @Override
+    public StreamType getStreamType() {
+        return StreamType.VIDEO_STREAM;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/linkHandler/DarkiboxSearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/linkHandler/DarkiboxSearchQueryHandlerFactory.java
@@ -1,0 +1,41 @@
+package org.schabi.newpipe.extractor.services.darkibox.linkHandler;
+
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
+
+import java.util.List;
+
+/**
+ * Darkibox does not support search. This is a minimal stub required by the service framework.
+ */
+public final class DarkiboxSearchQueryHandlerFactory extends SearchQueryHandlerFactory {
+
+    private static final DarkiboxSearchQueryHandlerFactory INSTANCE
+            = new DarkiboxSearchQueryHandlerFactory();
+
+    private DarkiboxSearchQueryHandlerFactory() {
+    }
+
+    public static DarkiboxSearchQueryHandlerFactory getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String[] getAvailableContentFilter() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getAvailableSortFilter() {
+        return new String[0];
+    }
+
+    @Override
+    public String getUrl(final String query,
+                         final List<String> contentFilter,
+                         final String sortFilter)
+            throws ParsingException, UnsupportedOperationException {
+        // Darkibox does not support search
+        return "https://darkibox.com/";
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/linkHandler/DarkiboxStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/darkibox/linkHandler/DarkiboxStreamLinkHandlerFactory.java
@@ -1,0 +1,65 @@
+package org.schabi.newpipe.extractor.services.darkibox.linkHandler;
+
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
+import org.schabi.newpipe.extractor.utils.Parser;
+
+import java.util.regex.Pattern;
+
+/**
+ * Link handler factory for Darkibox streams.
+ *
+ * <p>Accepted URL patterns:</p>
+ * <ul>
+ *     <li>{@code https://darkibox.com/FILECODE}</li>
+ *     <li>{@code https://darkibox.com/d/FILECODE}</li>
+ *     <li>{@code https://darkibox.com/embed-FILECODE.html}</li>
+ * </ul>
+ */
+public final class DarkiboxStreamLinkHandlerFactory extends LinkHandlerFactory {
+
+    private static final DarkiboxStreamLinkHandlerFactory INSTANCE
+            = new DarkiboxStreamLinkHandlerFactory();
+
+    private static final String ID_PATTERN
+            = "https?://(?:www\\.)?darkibox\\.com/(?:embed-([a-zA-Z0-9]+)\\.html"
+            + "|d/([a-zA-Z0-9]+)"
+            + "|([a-zA-Z0-9]+))";
+
+    private DarkiboxStreamLinkHandlerFactory() {
+    }
+
+    public static DarkiboxStreamLinkHandlerFactory getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getId(final String url) throws ParsingException, UnsupportedOperationException {
+        final var matcher = Parser.matchOrThrow(
+                Pattern.compile(ID_PATTERN), url);
+        // Return the first non-null group (embed, /d/, or direct)
+        for (int i = 1; i <= 3; i++) {
+            final String group = matcher.group(i);
+            if (group != null) {
+                return group;
+            }
+        }
+        throw new ParsingException("Could not extract file code from URL: " + url);
+    }
+
+    @Override
+    public String getUrl(final String id)
+            throws ParsingException, UnsupportedOperationException {
+        return "https://darkibox.com/" + id;
+    }
+
+    @Override
+    public boolean onAcceptUrl(final String url) {
+        try {
+            getId(url);
+            return true;
+        } catch (final ParsingException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add service for [darkibox.com](https://darkibox.com/), a video hosting platform (service ID 5)
- Stream-only service (no search, channels, or playlists)

## How it works
1. Fetches embed page for title extraction
2. POSTs to `/dl` with `op=embed&file_code=ID&auto=1`
3. Unpacks Dean Edwards packed JavaScript (pure Java implementation)
4. Extracts video URL from PlayerJS `file:` parameter
5. Supports both HLS (m3u8) and direct MP4

## Supported URLs
- `https://darkibox.com/FILECODE`
- `https://darkibox.com/d/FILECODE`
- `https://darkibox.com/embed-FILECODE.html`

## Files
- `services/darkibox/DarkiboxService.java` - Service definition
- `services/darkibox/extractors/DarkiboxStreamExtractor.java` - Stream extractor with JS unpacker
- `services/darkibox/linkHandler/DarkiboxStreamLinkHandlerFactory.java` - URL handling
- `services/darkibox/linkHandler/DarkiboxSearchQueryHandlerFactory.java` - Required stub
- `ServiceList.java` - Registration (ID 5)

## Test plan
- [x] Syntax verified (balanced braces/parentheses)
- [x] Follows existing service conventions (PeerTube, Bandcamp patterns)