### PR TITLE
[YouTube] Fix duration and live stream display in related videos

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -235,6 +235,10 @@ public final class YoutubeParsingHelper {
      */
     public static int parseDurationString(@Nonnull final String input)
             throws ParsingException, NumberFormatException {
+        if (!input.matches(".*\\d.*") && !input.equalsIgnoreCase("SHORTS")) {
+            throw new ParsingException("Error duration string contains no digits: " + input);
+        }
+
         // If time separator : is not detected, try . instead
         final String[] splitInput = input.contains(":")
                 ? input.split(":")

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -49,6 +49,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
 
@@ -155,19 +156,24 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             duration = videoInfo.getString("lengthSeconds");
 
             if (isNullOrEmpty(duration)) {
-                final JsonObject timeOverlay = videoInfo.getArray("thumbnailOverlays")
+                final List<String> timeOverlays = videoInfo.getArray("thumbnailOverlays")
                         .stream()
                         .filter(JsonObject.class::isInstance)
                         .map(JsonObject.class::cast)
                         .filter(thumbnailOverlay ->
                                 thumbnailOverlay.has("thumbnailOverlayTimeStatusRenderer"))
-                        .findFirst()
-                        .orElse(null);
+                        .map(thumbnailOverlay -> getTextFromObject(
+                                thumbnailOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
+                                        .getObject("text")))
+                        .filter(text -> !isNullOrEmpty(text))
+                        .collect(Collectors.toList());
 
-                if (timeOverlay != null) {
-                    duration = getTextFromObject(
-                            timeOverlay.getObject("thumbnailOverlayTimeStatusRenderer")
-                                    .getObject("text"));
+                for (final String timeOverlayText : timeOverlays) {
+                    try {
+                        return YoutubeParsingHelper.parseDurationString(timeOverlayText);
+                    } catch (final ParsingException ex) {
+                        // try next
+                    }
                 }
             }
 
@@ -452,24 +458,21 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
             }
 
             if (!isShort) {
-                final JsonObject thumbnailTimeOverlay = videoInfo.getArray("thumbnailOverlays")
-                        .stream()
-                        .filter(JsonObject.class::isInstance)
-                        .map(JsonObject.class::cast)
-                        .filter(thumbnailOverlay -> thumbnailOverlay.has(
-                                "thumbnailOverlayTimeStatusRenderer"))
-                        .map(thumbnailOverlay -> thumbnailOverlay.getObject(
-                                "thumbnailOverlayTimeStatusRenderer"))
-                        .findFirst()
-                        .orElse(null);
-
-                if (!isNullOrEmpty(thumbnailTimeOverlay)) {
-                    isShort = thumbnailTimeOverlay.getString("style", "")
-                            .equalsIgnoreCase("SHORTS")
-                            || thumbnailTimeOverlay.getObject("icon")
-                            .getString("iconType", "")
-                            .toLowerCase()
-                            .contains("shorts");
+                if (videoInfo.has("thumbnailOverlays")) {
+                    isShort = videoInfo.getArray("thumbnailOverlays")
+                            .stream()
+                            .filter(JsonObject.class::isInstance)
+                            .map(JsonObject.class::cast)
+                            .filter(thumbnailOverlay -> thumbnailOverlay.has(
+                                    "thumbnailOverlayTimeStatusRenderer"))
+                            .map(thumbnailOverlay -> thumbnailOverlay.getObject(
+                                    "thumbnailOverlayTimeStatusRenderer"))
+                            .anyMatch(timeOverlay -> timeOverlay.getString("style", "")
+                                    .equalsIgnoreCase("SHORTS")
+                                    || timeOverlay.getObject("icon")
+                                    .getString("iconType", "")
+                                    .toLowerCase()
+                                    .contains("shorts"));
                 }
             }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 /**
  * Note:
  * This extractor is currently (2025-07) only used to extract related video streams.<br>
- * The following features are currently not implemented because they have never been observed:
+ * The following features are currently not implemented:
  * <ul>
- *     <li>Shorts</li>
+ *     <li>Shorts: appear in related videos without a duration badge; getDuration() returns -1</li>
  *     <li>Paid content (Premium, members first or only)</li>
  * </ul>
  */
@@ -164,16 +164,23 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
             .collect(Collectors.toList());
 
         if (potentialDurations.isEmpty()) {
-            throw new ParsingException("Could not get duration: No parsable durations detected");
+            return -1;
         }
 
         ParsingException parsingException = null;
         for (final String potentialDuration : potentialDurations) {
+            if (potentialDuration == null || !potentialDuration.matches(".*\\d.*")) {
+                continue;
+            }
             try {
                 return YoutubeParsingHelper.parseDurationString(potentialDuration);
             } catch (final ParsingException ex) {
                 parsingException = ex;
             }
+        }
+
+        if (parsingException == null) {
+            return -1; // e.g. only "SHORTS" or "CC" badge was present, no duration available
         }
 
         throw new ParsingException("Could not get duration", parsingException);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -77,22 +77,22 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
     }
 
     private StreamType determineStreamType() throws ParsingException {
-        if (JsonUtils.getArray(lockupViewModel, "contentImage.thumbnailViewModel.overlays")
-            .streamAsJsonObjects()
+        final JsonArray overlays = JsonUtils.getArray(lockupViewModel,
+            "contentImage.thumbnailViewModel.overlays");
+
+        // thumbnailOverlayBadgeViewModel path (legacy/alternate overlay structure)
+        if (overlays.streamAsJsonObjects()
             .flatMap(overlay -> overlay
                 .getObject("thumbnailOverlayBadgeViewModel")
                 .getArray("thumbnailBadges")
                 .streamAsJsonObjects())
             .map(thumbnailBadge -> thumbnailBadge.getObject("thumbnailBadgeViewModel"))
-            .anyMatch(thumbnailBadgeViewModel -> {
-                if ("THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE".equals(
-                    thumbnailBadgeViewModel.getString("badgeStyle"))) {
+            .anyMatch(vm -> {
+                if ("THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE".equals(vm.getString("badgeStyle"))) {
                     return true;
                 }
-
                 // Fallback: Check if there is a live icon
-                return thumbnailBadgeViewModel
-                    .getObject("icon")
+                return vm.getObject("icon")
                     .getArray("sources")
                     .streamAsJsonObjects()
                     .map(source -> source
@@ -100,6 +100,18 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
                         .getString("imageName"))
                     .anyMatch("LIVE"::equals);
             })) {
+            return StreamType.LIVE_STREAM;
+        }
+
+        // thumbnailBottomOverlayViewModel path (used in lockup format for both duration and live)
+        if (overlays.streamAsJsonObjects()
+            .flatMap(overlay -> overlay
+                .getObject("thumbnailBottomOverlayViewModel")
+                .getArray("badges")
+                .streamAsJsonObjects())
+            .map(badge -> badge.getObject("thumbnailBadgeViewModel"))
+            .anyMatch(vm -> "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE".equals(
+                vm.getString("badgeStyle")))) {
             return StreamType.LIVE_STREAM;
         }
 

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -87,6 +87,58 @@ class YoutubeStreamInfoItemTest {
     }
 
     @Test
+    void lockupViewModelVideo()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelVideo") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertFalse(extractor.isAd()),
+        () -> assertEquals("https://www.youtube.com/watch?v=dQw4w9WgXcQ", extractor.getUrl()),
+        () -> assertEquals("VIDEO_TITLE", extractor.getName()),
+        () -> assertEquals(974, extractor.getDuration()),
+        () -> assertFalse(extractor.getThumbnails().isEmpty())
+        );
+    }
+
+    @Test
+    void lockupViewModelLiveStream()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelLiveStream") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.LIVE_STREAM, extractor.getStreamType()),
+        () -> assertFalse(extractor.isAd()),
+        () -> assertEquals("https://www.youtube.com/watch?v=LIVE_VIDEO_ID", extractor.getUrl()),
+        () -> assertEquals("LIVE_VIDEO_TITLE", extractor.getName()),
+        () -> assertEquals(-1, extractor.getDuration()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(0, extractor.getViewCount()),
+        () -> assertFalse(extractor.getThumbnails().isEmpty())
+        );
+    }
+
+    @Test
+    void lockupViewModelNoDuration()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelNoDuration") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertFalse(extractor.isAd()),
+        () -> assertEquals(-1, extractor.getDuration()),
+        () -> assertFalse(extractor.getThumbnails().isEmpty())
+        );
+    }
+
+    @Test
     void emptyTitle() throws FileNotFoundException, JsonParserException {
         final var json = JsonParser.object().from(new FileInputStream(getMockPath(
                 YoutubeStreamInfoItemTest.class, "emptyTitle") + ".json"));

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/search/YoutubeSearchExtractorTest.java
@@ -235,7 +235,8 @@ public class YoutubeSearchExtractorTest {
                     Collections.singletonList("Learn more")
             ));
         }
-        // testMoreRelatedItems is broken because a video has no duration shown
+        // testMoreRelatedItems: a video in this mock has no duration badge; getDuration() now
+        // returns -1 instead of throwing, but the mock may need re-recording before re-enabling.
         @Test @Override public void testMoreRelatedItems() { }
         @Override public StreamingService expectedService() { return YouTube; }
         @Override public String expectedName() { return QUERY; }

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodellivestream.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodellivestream.json
@@ -1,0 +1,103 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/LIVE_VIDEO_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          },
+          {
+            "url": "https://i.ytimg.com/vi/LIVE_VIDEO_ID/hqdefault.jpg",
+            "width": 336,
+            "height": 188
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE",
+                  "text": "LIVE"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "thumbnailHoverOverlayToggleActionsViewModel": {
+            "buttons": []
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "LIVE_VIDEO_TITLE"
+      },
+      "image": {
+        "decoratedAvatarViewModel": {
+          "avatar": {
+            "avatarViewModel": {
+              "image": {
+                "sources": [
+                  {
+                    "url": "https://yt3.ggpht.com/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "width": 68,
+                    "height": 68
+                  }
+                ]
+              },
+              "avatarImageSize": "AVATAR_SIZE_M"
+            }
+          },
+          "a11yLabel": "Go to channel",
+          "rendererContext": {
+            "commandContext": {
+              "onTap": {
+                "innertubeCommand": {
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "url": "/@LIVE_CHANNEL_HANDLE"
+                    }
+                  },
+                  "browseEndpoint": {
+                    "browseId": "UCD_on7-zu7Zuc3zissQvrgw",
+                    "canonicalBaseUrl": "/@LIVE_CHANNEL_HANDLE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "LIVE_CHANNEL_NAME",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "LIVE_VIDEO_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelnoduration.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelnoduration.json
@@ -1,0 +1,105 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          },
+          {
+            "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            "width": 336,
+            "height": 188
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailHoverOverlayToggleActionsViewModel": {
+            "buttons": []
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "VIDEO_TITLE_SHORT"
+      },
+      "image": {
+        "decoratedAvatarViewModel": {
+          "avatar": {
+            "avatarViewModel": {
+              "image": {
+                "sources": [
+                  {
+                    "url": "https://yt3.ggpht.com/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "width": 68,
+                    "height": 68
+                  }
+                ]
+              },
+              "avatarImageSize": "AVATAR_SIZE_M"
+            }
+          },
+          "a11yLabel": "Go to channel",
+          "rendererContext": {
+            "commandContext": {
+              "onTap": {
+                "innertubeCommand": {
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "url": "/@VIDEO_CHANNEL_HANDLE"
+                    }
+                  },
+                  "browseEndpoint": {
+                    "browseId": "UCD_on7-zu7Zuc3zissQvrgw",
+                    "canonicalBaseUrl": "/@VIDEO_CHANNEL_HANDLE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "VIDEO_CHANNEL_NAME",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "500K views"
+                  }
+                },
+                {
+                  "text": {
+                    "content": "1 month ago"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "dQw4w9WgXcQ",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelvideo.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelvideo.json
@@ -1,0 +1,117 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          },
+          {
+            "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            "width": 336,
+            "height": 188
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "text": "16:14",
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "thumbnailHoverOverlayToggleActionsViewModel": {
+            "buttons": []
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "VIDEO_TITLE"
+      },
+      "image": {
+        "decoratedAvatarViewModel": {
+          "avatar": {
+            "avatarViewModel": {
+              "image": {
+                "sources": [
+                  {
+                    "url": "https://yt3.ggpht.com/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "width": 68,
+                    "height": 68
+                  }
+                ]
+              },
+              "avatarImageSize": "AVATAR_SIZE_M"
+            }
+          },
+          "a11yLabel": "Go to channel",
+          "rendererContext": {
+            "commandContext": {
+              "onTap": {
+                "innertubeCommand": {
+                  "commandMetadata": {
+                    "webCommandMetadata": {
+                      "url": "/@VIDEO_CHANNEL_HANDLE"
+                    }
+                  },
+                  "browseEndpoint": {
+                    "browseId": "UCD_on7-zu7Zuc3zissQvrgw",
+                    "canonicalBaseUrl": "/@VIDEO_CHANNEL_HANDLE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "VIDEO_CHANNEL_NAME",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "1.2M views"
+                  }
+                },
+                {
+                  "text": {
+                    "content": "2 years ago"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "dQw4w9WgXcQ",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.


Two bugs in YoutubeStreamInfoItemLockupExtractor caused related/suggested videos to show wrong duration badges:

1. "00:00" on Shorts and videos without a duration badge
getDuration() threw ParsingException when no thumbnailBottomOverlayViewModel overlay was found. StreamInfoItemsCollector catches that exception and leaves duration at the Java default of 0, which the app renders as "00:00". Fixed by returning -1 (the established contract for unknown duration) instad of throwing also added a null guard before .matches() to prevent NPE on badges with no text field.

2. Live streams showing 00:00 on duration
determineStreamType() only checked thumbnailOverlayBadgeViewModel.thumbnailBadges for the live badge style. In the lockup format, YouTube places the live badge inside thumbnailBottomOverlayViewModel.badges — the same overlay used for duration text. So live streams were returned as VIDEO_STREAM, isLive() was false, and the app never reached the isLiveStream() branch that renders "LIVE". Fixed by adding a second check for thumbnailBottomOverlayViewModel.badges[].thumbnailBadgeViewModel.badgeStyle == THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE