### PR TITLE
 [YouTube] Fix lockup metadata parsing for channels with non-standard metadata rows

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -341,18 +341,14 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
 
         // Fallback: search all rows. Handles livestreams with only 1 metadata row
         // in search/related/kiosk contexts, where that single row contains views.
+        // Also handles channel tabs where the info row may not contain views
+        // (e.g. section headers or 0-viewer livestreams).
         if (optTextContent.isEmpty()) {
             optTextContent = findMetadataPartInAllRows(text -> {
                 final String lower = text.toLowerCase();
                 return lower.matches(".*\\bviews?\\b.*") || lower.contains("watching")
                         || lower.contains("recommended") || lower.contains(NO_VIEWS_LOWERCASE);
             });
-        }
-
-        // Fallback to original position if heuristic didn't match
-        if (optTextContent.isEmpty()) {
-            optTextContent = metadataPart(infoRowIndex, 0)
-                    .map(this::getTextContentFromMetadataPart);
         }
 
         // We could do this inline if the ParsingException would be a RuntimeException -.-
@@ -414,14 +410,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         throw new ParsingException("Failed to determine channel image view model");
     }
 
-    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex)
-        throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -449,15 +439,23 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
      * Searches the metadata parts of a specific row for text matching the given predicate.
      * This handles variable part order (e.g. [views, date] vs [date, views]) within a row.
      */
-    private Optional<String> findMetadataPartInRow(final int rowIndex,
-                                                   @Nonnull final Predicate<String> predicate)
-            throws ParsingException {
+    private JsonArray getMetadataRows() {
         if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
+            try {
+                cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                    "metadata.lockupMetadataViewModel.metadata"
+                        + ".contentMetadataViewModel.metadataRows");
+            } catch (final ParsingException e) {
+                // Some lockups don't have metadata rows at all
+                cachedMetadataRows = new JsonArray();
+            }
         }
-        return cachedMetadataRows
+        return cachedMetadataRows;
+    }
+
+    private Optional<String> findMetadataPartInRow(final int rowIndex,
+                                                   @Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -473,14 +471,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
      * Used as a fallback when the info row doesn't contain the expected data,
      * e.g. for livestreams with only 1 metadata row in search results.
      */
-    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate)
-            throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .flatMap(jsonObject -> jsonObject.getArray("metadataParts")
                 .streamAsJsonObjects())
@@ -507,16 +499,6 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
             if (cachedDateText.isEmpty()) {
                 cachedDateText = findMetadataPartInAllRows(text ->
                         text.endsWith("ago") || text.contains(PREMIERES_TEXT));
-            }
-
-            // Fallback to original positions if heuristic didn't match
-            if (cachedDateText.isEmpty()) {
-                cachedDateText = metadataPart(infoRowIndex, 1)
-                        .map(this::getTextContentFromMetadataPart);
-            }
-            if (cachedDateText.isEmpty()) {
-                cachedDateText = metadataPart(0, 1)
-                        .map(this::getTextContentFromMetadataPart);
             }
         }
         return cachedDateText;

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -219,6 +219,94 @@ class YoutubeStreamInfoItemTest {
         );
     }
 
+    /**
+     * Tests that channel tab items with non-views text in the metadata row
+     * (e.g. section headers) don't crash and return -1 for views.
+     * Regression test for blind metadataPart(infoRowIndex, 0) fallback.
+     */
+    @Test
+    void lockupViewModelChannelTabSectionHeader()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelChannelTabSectionHeader")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            // Channel tabs use 1-row format at index 0
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Section Header Video", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that live streams in channel tabs with only a channel name row
+     * (no viewer count) don't crash and return 0 for views.
+     * Regression test for blind metadataPart(infoRowIndex, 0) fallback.
+     */
+    @Test
+    void lockupViewModelChannelTabLiveNoViewers()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelChannelTabLiveNoViewers")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            // Channel tabs use 1-row format at index 0
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.LIVE_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Live Stream No Viewers", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(0, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that lockups without any metadata rows don't crash.
+     * Regression test for missing metadataRows path.
+     */
+    @Test
+    void lockupViewModelChannelTabNoMetadata()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelChannelTabNoMetadata")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Video With No Metadata Rows", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
     @Test
     void emptyTitle() throws FileNotFoundException, JsonParserException {
         final var json = JsonParser.object().from(new FileInputStream(getMockPath(

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltablivenoviewers.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltablivenoviewers.json
@@ -1,0 +1,57 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/LIVE_NO_VIEWERS_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE",
+                  "text": "LIVE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Live Stream No Viewers"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "Veritasium",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "LIVE_NO_VIEWERS_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabnometadata.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabnometadata.json
@@ -1,0 +1,26 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/NO_METADATA_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Video With No Metadata Rows"
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "NO_METADATA_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabsectionheader.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabsectionheader.json
@@ -1,0 +1,44 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/SECTION_HEADER_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Section Header Video"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "DIRECTOS EN DIRECTO · David Suárez & Jorge Yorya",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "SECTION_HEADER_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}


### PR DESCRIPTION
Fixes `ParsingException` / `RegexException` when loading subscription feeds for channels that return `lockupViewModel` items with non-standard metadata row: missing, section headers, or channel names instead of views/dates

  Reported by @dftf-stu in TeamNewPipe/NewPipe#13540 with examples from affected channels
  - **@jiggylookback** (`UCgYI5VzbdSNz8mZ9t9xaVeA`)
    - `Parser.RegexException`: Failed to parse `"Jiggylookback"` as view count
  - **@talktv** (`UCm0yTweyAa0PwEIp0l3N_gA`)
    - `ParsingException`: Unable to parse date `"Scheduled for 27/05/2026, 18:01"`
  - **@wildlifeaid** (`UC2GYlKSMFgAPqVZoFyw5Itg`)
    - `ParsingException`: `metadataRows` path missing entirely

When `findMetadataPartInRow()` and `findMetadataPartInAllRows()` found nothing, these fallbacks grabbed whatever text was at the fixed position section headers, channel names, scheduled dates, or non-existent paths  and tried to parse them, causing exceptions.


- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
