### PR TITLE
[YouTube] Fix lockup metadata parsing for channels with non-standard metadata rows

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -410,14 +410,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         throw new ParsingException("Failed to determine channel image view model");
     }
 
-    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex)
-        throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -441,19 +435,27 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         return 1;
     }
 
+    private JsonArray getMetadataRows() {
+        if (cachedMetadataRows == null) {
+            try {
+                cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                    "metadata.lockupMetadataViewModel.metadata"
+                        + ".contentMetadataViewModel.metadataRows");
+            } catch (final ParsingException e) {
+                // Some lockups don't have metadata rows at all
+                cachedMetadataRows = new JsonArray();
+            }
+        }
+        return cachedMetadataRows;
+    }
+
     /**
      * Searches the metadata parts of a specific row for text matching the given predicate.
      * This handles variable part order (e.g. [views, date] vs [date, views]) within a row.
      */
     private Optional<String> findMetadataPartInRow(final int rowIndex,
-                                                   @Nonnull final Predicate<String> predicate)
-            throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+                                                   @Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -469,14 +471,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
      * Used as a fallback when the info row doesn't contain the expected data,
      * e.g. for livestreams with only 1 metadata row in search results.
      */
-    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate)
-            throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .flatMap(jsonObject -> jsonObject.getArray("metadataParts")
                 .streamAsJsonObjects())

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -279,6 +279,141 @@ class YoutubeStreamInfoItemTest {
         );
     }
 
+    /**
+     * Tests 2-row format in search/related/kiosk where row 1 exists but contains
+     * non-views text. Verifies that the default getInfoMetadataRowIndex()=1 context
+     * does not crash and returns -1 when row 1 has no matching view text.
+     */
+    @Test
+    void lockupViewModelTwoRowNonViewsRow1()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelTwoRowNonViewsRow1")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        // Uses default getInfoMetadataRowIndex() = 1 (search/related/kiosk context)
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Two Row Non Views Row1", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests channel tabs that unexpectedly have 2 rows [author][views,date].
+     * The override returns 0, but the views/date are actually in row 1.
+     * Verifies findMetadataPartInAllRows() fallback finds them correctly.
+     */
+    @Test
+    void lockupViewModelChannelTabTwoRows()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelChannelTabTwoRows")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            // Channel tabs use 1-row format at index 0, but YouTube sometimes sends 2 rows
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Channel Tab Two Rows", extractor.getName()),
+        () -> assertEquals("1 day ago", extractor.getTextualUploadDate()),
+        () -> assertNotNull(extractor.getUploadDate()),
+        () -> assertEquals(1200, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that scheduled premiere dates like "Scheduled for 27/05/2026, 18:01"
+     * don't match the date predicate and return null gracefully.
+     */
+    @Test
+    void lockupViewModelScheduledDate()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelScheduledDate")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Scheduled Date Video", extractor.getName()),
+        // "Scheduled for..." does not end with "ago" nor contain "Premieres "
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that an empty metadataParts array doesn't crash.
+     */
+    @Test
+    void lockupViewModelEmptyMetadataParts()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelEmptyMetadataParts")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Empty Metadata Parts", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that findMetadataPartInAllRows() correctly finds views in row 0
+     * when the default info row (row 1) does not contain them.
+     */
+    @Test
+    void lockupViewModelViewsInRow0()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelViewsInRow0")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        // Uses default getInfoMetadataRowIndex() = 1, but views are in row 0
+        assertAll(
+        () -> assertEquals(StreamType.LIVE_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Views In Row0", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(500, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
     @Test
     void emptyTitle() throws FileNotFoundException, JsonParserException {
         final var json = JsonParser.object().from(new FileInputStream(getMockPath(

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabtworows.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabtworows.json
@@ -1,0 +1,62 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/CHANNEL_TAB_TWO_ROWS_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Channel Tab Two Rows"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "1.2K views",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                },
+                {
+                  "text": {
+                    "content": "1 day ago",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "CHANNEL_TAB_TWO_ROWS_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelemptymetadataparts.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelemptymetadataparts.json
@@ -1,0 +1,36 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/EMPTY_METADATA_PARTS_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Empty Metadata Parts"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": []
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "EMPTY_METADATA_PARTS_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelscheduleddate.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelscheduleddate.json
@@ -1,0 +1,57 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/SCHEDULED_DATE_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_PREMIERE",
+                  "text": "PREMIERE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Scheduled Date Video"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "Scheduled for 27/05/2026, 18:01",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "SCHEDULED_DATE_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodeltworownonviewsrow1.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodeltworownonviewsrow1.json
@@ -1,0 +1,55 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/TWO_ROW_NON_VIEWS_ROW1_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Two Row Non Views Row1"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "Some random text",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "TWO_ROW_NON_VIEWS_ROW1_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelviewsinrow0.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelviewsinrow0.json
@@ -1,0 +1,68 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/VIEWS_IN_ROW0_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE",
+                  "text": "LIVE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Views In Row0"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "500 watching",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "VIEWS_IN_ROW0_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}


### PR DESCRIPTION
Fixes `ParsingException` / `RegexException` when loading subscription feeds for channels that return `lockupViewModel` items with non-standard metadata row: missing, section headers, or channel names instead of views/dates

  Reported by @dftf-stu in [TeamNewPipe/NewPipe#13540-comment](https://github.com/TeamNewPipe/NewPipe/issues/13540#issuecomment-4536111934) with examples from affected channels
  - **@jiggylookback** (`UCgYI5VzbdSNz8mZ9t9xaVeA`)
    - `Parser.RegexException`: Failed to parse `"Jiggylookback"` as view count
  - **@talktv** (`UCm0yTweyAa0PwEIp0l3N_gA`)
    - `ParsingException`: Unable to parse date `"Scheduled for 27/05/2026, 18:01"`
  - **@wildlifeaid** (`UC2GYlKSMFgAPqVZoFyw5Itg`)
    - `ParsingException`: `metadataRows` path missing entirely

When `findMetadataPartInRow()` and `findMetadataPartInAllRows()` found nothing, these fallbacks grabbed whatever text was at the fixed position section headers, channel names, scheduled dates, or non-existent paths  and tried to parse them, causing exceptions.


- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
