### PR TITLE
feat: support ContentAvailability for video lockup metadata

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -411,14 +411,19 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         throw new ParsingException("Failed to determine channel image view model");
     }
 
-    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex)
-        throws ParsingException {
+    private JsonArray getMetadataRows() throws ParsingException {
         if (cachedMetadataRows == null) {
             cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
                 "metadata.lockupMetadataViewModel.metadata"
                     + ".contentMetadataViewModel.metadataRows");
         }
-        return cachedMetadataRows
+
+        return cachedMetadataRows;
+    }
+
+    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex)
+        throws ParsingException {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -472,12 +477,7 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
      */
     private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate)
             throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+        return getMetadataRows()
             .streamAsJsonObjects()
             .flatMap(jsonObject -> jsonObject.getArray("metadataParts")
                 .streamAsJsonObjects())
@@ -516,13 +516,7 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
     }
 
     private boolean isMembersOnly() throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                    "metadata.lockupMetadataViewModel.metadata"
-                            + ".contentMetadataViewModel.metadataRows");
-        }
-
-        return cachedMetadataRows
+        return getMetadataRows()
                 .streamAsJsonObjects()
                 .flatMap(jsonObject -> jsonObject.getArray("badges")
                         .streamAsJsonObjects())

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory;
+import org.schabi.newpipe.extractor.stream.ContentAvailability;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
@@ -512,6 +513,36 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         return getDateText().map(dateText -> dateText.contains(PREMIERES_TEXT))
                 // If we can't get date text, assume it is not a premiere, it should be a livestream
                 .orElse(false);
+    }
+
+    private boolean isMembersOnly() throws ParsingException {
+        if (cachedMetadataRows == null) {
+            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                    "metadata.lockupMetadataViewModel.metadata"
+                            + ".contentMetadataViewModel.metadataRows");
+        }
+
+        return cachedMetadataRows
+                .streamAsJsonObjects()
+                .flatMap(jsonObject -> jsonObject.getArray("badges")
+                        .streamAsJsonObjects())
+                .map(badge -> badge.getObject("badgeViewModel").getString("badgeStyle"))
+                .anyMatch("BADGE_MEMBERS_ONLY"::equals);
+    }
+
+
+    @Nonnull
+    @Override
+    public ContentAvailability getContentAvailability() throws ParsingException {
+        if (isPremiere()) {
+            return ContentAvailability.UPCOMING;
+        }
+
+        if (isMembersOnly()) {
+            return ContentAvailability.MEMBERSHIP;
+        }
+
+        return ContentAvailability.AVAILABLE;
     }
 
     abstract static class ChannelImageViewModel {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -7,6 +7,7 @@ import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.localization.TimeAgoPatternsManager;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamInfoItemLockupExtractor;
+import org.schabi.newpipe.extractor.stream.ContentAvailability;
 import org.schabi.newpipe.extractor.stream.StreamType;
 
 import java.io.FileInputStream;
@@ -82,6 +83,7 @@ class YoutubeStreamInfoItemTest {
         () -> assertEquals(-1, extractor.getViewCount()),
         () -> assertFalse(extractor.getThumbnails().isEmpty()),
         () -> assertNull(extractor.getShortDescription()),
+        () -> assertEquals(ContentAvailability.UPCOMING, extractor.getContentAvailability()),
         () -> assertFalse(extractor.isShortFormContent())
         );
     }
@@ -301,6 +303,26 @@ class YoutubeStreamInfoItemTest {
                 () -> assertFalse(extractor.getThumbnails().isEmpty()),
                 () -> assertNull(extractor.getShortDescription()),
                 () -> assertFalse(extractor.isShortFormContent())
+        );
+    }
+
+    @Test
+    void membersOnly()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupviewmodelmembersonly")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            // Channel tabs use 1-row format at index 0
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+                () -> assertEquals(ContentAvailability.MEMBERSHIP, extractor.getContentAvailability())
         );
     }
 }

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelmembersonly.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelmembersonly.json
@@ -1,0 +1,552 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/x3pS1_qqtIs/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLAAJidge0mz8pSh67xP6_QhvLtOcw",
+            "width": 168,
+            "height": 94
+          },
+          {
+            "url": "https://i.ytimg.com/vi/x3pS1_qqtIs/hqdefault.jpg?sqp=-oaymwEbCMQBEG5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLCkvpYtw8LvhsH3AtpxfQdhEmddDw",
+            "width": 196,
+            "height": 110
+          },
+          {
+            "url": "https://i.ytimg.com/vi/x3pS1_qqtIs/hqdefault.jpg?sqp=-oaymwEcCPYBEIoBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLBXyv-SKSeEwDMTfLZVNW9MwiM4Cg",
+            "width": 246,
+            "height": 138
+          },
+          {
+            "url": "https://i.ytimg.com/vi/x3pS1_qqtIs/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLAaT2WxRLXOkrYGLypPqXSoag0ZkQ",
+            "width": 336,
+            "height": 188
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "text": "12:05",
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT",
+                  "animationActivationTargetId": "x3pS1_qqtIs",
+                  "animationActivationEntityKey": "Eh8veW91dHViZS9hcHAvd2F0Y2gvcGxheWVyX3N0YXRlIMMCKAE%3D",
+                  "lottieData": {
+                    "url": "https://www.gstatic.com/youtube/img/lottie/audio_indicator/audio_indicator_v2.json",
+                    "settings": {
+                      "loop": true,
+                      "autoplay": true
+                    }
+                  },
+                  "animatedText": "Now playing",
+                  "animationActivationEntitySelectorType": "THUMBNAIL_BADGE_ANIMATION_ENTITY_SELECTOR_TYPE_PLAYER_STATE",
+                  "rendererContext": {
+                    "accessibilityContext": {
+                      "label": "12 minutes, 5 seconds"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "thumbnailHoverOverlayToggleActionsViewModel": {
+            "buttons": [
+              {
+                "toggleButtonViewModel": {
+                  "defaultButtonViewModel": {
+                    "buttonViewModel": {
+                      "iconName": "WATCH_LATER",
+                      "onTap": {
+                        "innertubeCommand": {
+                          "clickTrackingParams": "CPcCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                          "commandMetadata": {
+                            "webCommandMetadata": {
+                              "sendPost": true,
+                              "apiUrl": "/youtubei/v1/browse/edit_playlist"
+                            }
+                          },
+                          "playlistEditEndpoint": {
+                            "playlistId": "WL",
+                            "actions": [
+                              {
+                                "addedVideoId": "x3pS1_qqtIs",
+                                "action": "ACTION_ADD_VIDEO"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "accessibilityText": "Watch later",
+                      "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY_DARK",
+                      "trackingParams": "CPcCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                      "type": "BUTTON_VIEW_MODEL_TYPE_TONAL",
+                      "buttonSize": "BUTTON_VIEW_MODEL_SIZE_COMPACT",
+                      "state": "BUTTON_VIEW_MODEL_STATE_ACTIVE"
+                    }
+                  },
+                  "toggledButtonViewModel": {
+                    "buttonViewModel": {
+                      "iconName": "CHECK",
+                      "onTap": {
+                        "innertubeCommand": {
+                          "clickTrackingParams": "CPYCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                          "commandMetadata": {
+                            "webCommandMetadata": {
+                              "sendPost": true,
+                              "apiUrl": "/youtubei/v1/browse/edit_playlist"
+                            }
+                          },
+                          "playlistEditEndpoint": {
+                            "playlistId": "WL",
+                            "actions": [
+                              {
+                                "action": "ACTION_REMOVE_VIDEO_BY_VIDEO_ID",
+                                "removedVideoId": "x3pS1_qqtIs"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "accessibilityText": "Added",
+                      "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY_DARK",
+                      "trackingParams": "CPYCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                      "type": "BUTTON_VIEW_MODEL_TYPE_TONAL",
+                      "buttonSize": "BUTTON_VIEW_MODEL_SIZE_COMPACT",
+                      "state": "BUTTON_VIEW_MODEL_STATE_ACTIVE"
+                    }
+                  },
+                  "isToggled": false,
+                  "trackingParams": "CO4CEICeECITCLjJ-byz35QDFZlEegUdGfk37Q=="
+                }
+              },
+              {
+                "toggleButtonViewModel": {
+                  "defaultButtonViewModel": {
+                    "buttonViewModel": {
+                      "iconName": "ADD_TO_QUEUE_TAIL",
+                      "onTap": {
+                        "innertubeCommand": {
+                          "clickTrackingParams": "CPUCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                          "commandMetadata": {
+                            "webCommandMetadata": {
+                              "sendPost": true
+                            }
+                          },
+                          "signalServiceEndpoint": {
+                            "signal": "CLIENT_SIGNAL",
+                            "actions": [
+                              {
+                                "clickTrackingParams": "CPUCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                "addToPlaylistCommand": {
+                                  "openMiniplayer": true,
+                                  "videoId": "x3pS1_qqtIs",
+                                  "listType": "PLAYLIST_EDIT_LIST_TYPE_QUEUE",
+                                  "onCreateListCommand": {
+                                    "clickTrackingParams": "CPUCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                    "commandMetadata": {
+                                      "webCommandMetadata": {
+                                        "sendPost": true,
+                                        "apiUrl": "/youtubei/v1/playlist/create"
+                                      }
+                                    },
+                                    "createPlaylistServiceEndpoint": {
+                                      "videoIds": [
+                                        "x3pS1_qqtIs"
+                                      ],
+                                      "params": "CAQ%3D"
+                                    }
+                                  },
+                                  "videoIds": [
+                                    "x3pS1_qqtIs"
+                                  ],
+                                  "videoCommand": {
+                                    "clickTrackingParams": "CPUCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                    "commandMetadata": {
+                                      "webCommandMetadata": {
+                                        "url": "/watch?v=x3pS1_qqtIs&pp=0gcJCZ0AKgI3ePta",
+                                        "webPageType": "WEB_PAGE_TYPE_WATCH",
+                                        "rootVe": 3832
+                                      }
+                                    },
+                                    "watchEndpoint": {
+                                      "videoId": "x3pS1_qqtIs",
+                                      "playerParams": "0gcJCZ0AKgI3ePta",
+                                      "watchEndpointSupportedOnesieConfig": {
+                                        "html5PlaybackOnesieConfig": {
+                                          "commonConfig": {
+                                            "url": "https://rr6---sn-uxax4vopj5qx-q0n6.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&id=c77a52d7faaab48b&ip=2a02%3A3100%3A427b%3A3600%3Ad5b3%3Ac510%3A96f7%3A42b8&initcwndbps=1521250&mt=1780088482&oweuc="
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "accessibilityText": "Add to queue",
+                      "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY_DARK",
+                      "trackingParams": "CPUCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                      "type": "BUTTON_VIEW_MODEL_TYPE_TONAL",
+                      "buttonSize": "BUTTON_VIEW_MODEL_SIZE_COMPACT",
+                      "state": "BUTTON_VIEW_MODEL_STATE_ACTIVE"
+                    }
+                  },
+                  "toggledButtonViewModel": {
+                    "buttonViewModel": {
+                      "iconName": "CHECK",
+                      "accessibilityText": "Added",
+                      "style": "BUTTON_VIEW_MODEL_STYLE_OVERLAY_DARK",
+                      "trackingParams": "CPQCEPBbIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                      "type": "BUTTON_VIEW_MODEL_TYPE_TONAL",
+                      "buttonSize": "BUTTON_VIEW_MODEL_SIZE_COMPACT",
+                      "state": "BUTTON_VIEW_MODEL_STATE_ACTIVE"
+                    }
+                  },
+                  "isToggled": false,
+                  "trackingParams": "CO4CEICeECITCLjJ-byz35QDFZlEegUdGfk37Q=="
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Daily Linux News - S03E105 - EU will fund European datacenters, Steam Deck's massive price increase"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "12 hours ago"
+                  },
+                  "accessibilityLabel": "12 hours ago"
+                }
+              ]
+            },
+            {
+              "badges": [
+                {
+                  "badgeViewModel": {
+                    "badgeText": "Members only",
+                    "badgeStyle": "BADGE_MEMBERS_ONLY",
+                    "trackingParams": "CO4CEICeECITCLjJ-byz35QDFZlEegUdGfk37Q==",
+                    "iconName": "SPONSORSHIP_STAR"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {
+        "buttonViewModel": {
+          "iconName": "MORE_VERT",
+          "onTap": {
+            "innertubeCommand": {
+              "clickTrackingParams": "CO8CEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+              "showSheetCommand": {
+                "panelLoadingStrategy": {
+                  "inlineContent": {
+                    "sheetViewModel": {
+                      "content": {
+                        "listViewModel": {
+                          "listItems": [
+                            {
+                              "listItemViewModel": {
+                                "title": {
+                                  "content": "Add to queue"
+                                },
+                                "leadingImage": {
+                                  "sources": [
+                                    {
+                                      "clientResource": {
+                                        "imageName": "ADD_TO_QUEUE_TAIL"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "rendererContext": {
+                                  "loggingContext": {
+                                    "loggingDirectives": {
+                                      "trackingParams": "CPMCEP6YBBgAIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                                      "visibility": {
+                                        "types": "12"
+                                      }
+                                    }
+                                  },
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "clickTrackingParams": "CPMCEP6YBBgAIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                        "commandMetadata": {
+                                          "webCommandMetadata": {
+                                            "sendPost": true
+                                          }
+                                        },
+                                        "signalServiceEndpoint": {
+                                          "signal": "CLIENT_SIGNAL",
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CPMCEP6YBBgAIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                              "addToPlaylistCommand": {
+                                                "openMiniplayer": true,
+                                                "videoId": "x3pS1_qqtIs",
+                                                "listType": "PLAYLIST_EDIT_LIST_TYPE_QUEUE",
+                                                "onCreateListCommand": {
+                                                  "clickTrackingParams": "CPMCEP6YBBgAIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                                  "commandMetadata": {
+                                                    "webCommandMetadata": {
+                                                      "sendPost": true,
+                                                      "apiUrl": "/youtubei/v1/playlist/create"
+                                                    }
+                                                  },
+                                                  "createPlaylistServiceEndpoint": {
+                                                    "videoIds": [
+                                                      "x3pS1_qqtIs"
+                                                    ],
+                                                    "params": "CAQ%3D"
+                                                  }
+                                                },
+                                                "videoIds": [
+                                                  "x3pS1_qqtIs"
+                                                ],
+                                                "videoCommand": {
+                                                  "clickTrackingParams": "CPMCEP6YBBgAIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                                  "commandMetadata": {
+                                                    "webCommandMetadata": {
+                                                      "url": "/watch?v=x3pS1_qqtIs",
+                                                      "webPageType": "WEB_PAGE_TYPE_WATCH",
+                                                      "rootVe": 3832
+                                                    }
+                                                  },
+                                                  "watchEndpoint": {
+                                                    "videoId": "x3pS1_qqtIs",
+                                                    "watchEndpointSupportedOnesieConfig": {
+                                                      "html5PlaybackOnesieConfig": {
+                                                        "commonConfig": {
+                                                          "url": "https://rr6---sn-uxax4vopj5qx-q0n6.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&id=c77a52d7faaab48b&ip=2a02%3A3100%3A427b%3A3600%3Ad5b3%3Ac510%3A96f7%3A42b8&initcwndbps=1521250&mt=1780088482&oweuc="
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "listItemViewModel": {
+                                "title": {
+                                  "content": "Save to playlist"
+                                },
+                                "leadingImage": {
+                                  "sources": [
+                                    {
+                                      "clientResource": {
+                                        "imageName": "BOOKMARK_BORDER"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "rendererContext": {
+                                  "loggingContext": {
+                                    "loggingDirectives": {
+                                      "trackingParams": "CPICEJSsCRgBIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                                      "visibility": {
+                                        "types": "12"
+                                      }
+                                    }
+                                  },
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "clickTrackingParams": "CPICEJSsCRgBIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                        "commandMetadata": {
+                                          "webCommandMetadata": {
+                                            "url": "https://accounts.google.com/ServiceLogin?service=youtube&uilel=3&passive=true&continue=https%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26app%3Ddesktop%26hl%3Den&hl=en",
+                                            "webPageType": "WEB_PAGE_TYPE_UNKNOWN",
+                                            "rootVe": 83769
+                                          }
+                                        },
+                                        "signInEndpoint": {
+                                          "nextEndpoint": {
+                                            "clickTrackingParams": "CPICEJSsCRgBIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                            "showSheetCommand": {
+                                              "panelLoadingStrategy": {
+                                                "requestTemplate": {
+                                                  "panelId": "PAadd_to_playlist",
+                                                  "params": "-gYNCgt4M3BTMV9xcXRJcw%3D%3D"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "downloadListItemViewModel": {
+                                "rendererContext": {
+                                  "loggingContext": {
+                                    "loggingDirectives": {
+                                      "trackingParams": "CPECENGqBRgCIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                                      "visibility": {
+                                        "types": "12"
+                                      }
+                                    }
+                                  },
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "clickTrackingParams": "CPECENGqBRgCIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                        "offlineVideoEndpoint": {
+                                          "videoId": "x3pS1_qqtIs",
+                                          "onAddCommand": {
+                                            "clickTrackingParams": "CPECENGqBRgCIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                            "getDownloadActionCommand": {
+                                              "videoId": "x3pS1_qqtIs",
+                                              "params": "CAIQAA%3D%3D",
+                                              "isCrossDeviceDownload": false
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "listItemViewModel": {
+                                "title": {
+                                  "content": "Share"
+                                },
+                                "leadingImage": {
+                                  "sources": [
+                                    {
+                                      "clientResource": {
+                                        "imageName": "SHARE"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "rendererContext": {
+                                  "commandContext": {
+                                    "onTap": {
+                                      "innertubeCommand": {
+                                        "clickTrackingParams": "CO8CEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                        "commandMetadata": {
+                                          "webCommandMetadata": {
+                                            "sendPost": true,
+                                            "apiUrl": "/youtubei/v1/share/get_share_panel"
+                                          }
+                                        },
+                                        "shareEntityServiceEndpoint": {
+                                          "serializedShareEntity": "Cgt4M3BTMV9xcXRJcw%3D%3D",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CO8CEPBbIhMIuMn5vLPflAMVmUR6BR0Z-TftygEEig-68Q==",
+                                              "openPopupAction": {
+                                                "popup": {
+                                                  "unifiedSharePanelRenderer": {
+                                                    "trackingParams": "CPACEI5iIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+                                                    "showLoadingSpinner": true
+                                                  }
+                                                },
+                                                "popupType": "DIALOG",
+                                                "beReused": true
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "accessibilityText": "More actions",
+          "style": "BUTTON_VIEW_MODEL_STYLE_MONO",
+          "trackingParams": "CO8CEPBbIhMIuMn5vLPflAMVmUR6BR0Z-Tft",
+          "type": "BUTTON_VIEW_MODEL_TYPE_TEXT",
+          "buttonSize": "BUTTON_VIEW_MODEL_SIZE_DEFAULT",
+          "state": "BUTTON_VIEW_MODEL_STATE_ACTIVE"
+        }
+      }
+    }
+  },
+  "contentId": "x3pS1_qqtIs",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+  "rendererContext": {
+    "loggingContext": {
+      "loggingDirectives": {
+        "trackingParams": "CO4CEICeECITCLjJ-byz35QDFZlEegUdGfk37Q==",
+        "visibility": {
+          "types": "12"
+        }
+      }
+    },
+    "accessibilityContext": {
+      "label": "Daily Linux News - S03E105 - EU will fund European datacenters, Steam Deck's massive price increase 12 minutes, 5 seconds"
+    },
+    "commandContext": {
+      "onTap": {
+        "innertubeCommand": {
+          "clickTrackingParams": "CO4CEICeECITCLjJ-byz35QDFZlEegUdGfk37VoYVUM1VUF3QlV1bTdDUE41YnVjLV9OMUZ3mgEDEPI4ygEEig-68Q==",
+          "commandMetadata": {
+            "webCommandMetadata": {
+              "url": "/watch?v=x3pS1_qqtIs",
+              "webPageType": "WEB_PAGE_TYPE_WATCH",
+              "rootVe": 3832
+            }
+          },
+          "watchEndpoint": {
+            "videoId": "x3pS1_qqtIs",
+            "watchEndpointSupportedOnesieConfig": {
+              "html5PlaybackOnesieConfig": {
+                "commonConfig": {
+                  "url": "https://rr6---sn-uxax4vopj5qx-q0n6.googlevideo.com/initplayback?source=youtube&oeis=1&c=WEB&oad=3200&ovd=3200&oaad=11000&oavd=11000&ocs=700&oewis=1&oputc=1&ofpcc=1&msp=1&odepv=1&id=c77a52d7faaab48b&ip=2a02%3A3100%3A427b%3A3600%3Ad5b3%3Ac510%3A96f7%3A42b8&initcwndbps=1521250&mt=1780088482&oweuc="
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Supports retrieving the content availability status (e.g. if the video is a premiere, only for members, etc) from the recently added video lockup metadata.

Ref: https://github.com/TeamNewPipe/NewPipeExtractor/pull/1280


- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
