### PR TITLE
Fix YouTube videos stuck at 360p by adding ANDROID_VR client fallback

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
@@ -109,4 +109,14 @@ final class ClientsConstants {
      * </p>
      */
     static final String ANDROID_CLIENT_VERSION = "21.03.36";
+
+    // ANDROID_VR (Meta Quest YouTube app) client fields
+
+    static final String ANDROID_VR_CLIENT_ID = "28";
+    static final String ANDROID_VR_CLIENT_NAME = "ANDROID_VR";
+    static final String ANDROID_VR_CLIENT_VERSION = "1.65.10";
+    static final String ANDROID_VR_DEVICE_MAKE = "Oculus";
+    static final String ANDROID_VR_DEVICE_MODEL = "Quest 3";
+    static final String ANDROID_VR_OS_VERSION = "12L";
+    static final int ANDROID_VR_SDK_VERSION = 32;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
@@ -6,6 +6,13 @@ import javax.annotation.Nullable;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_ID;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_NAME;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_ID;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_NAME;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_DEVICE_MAKE;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_DEVICE_MODEL;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_OS_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_SDK_VERSION;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.DESKTOP_CLIENT_PLATFORM;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.EMBED_CLIENT_SCREEN;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.IOS_CLIENT_ID;
@@ -141,5 +148,16 @@ public final class InnertubeClientRequestInfo {
                         IOS_CLIENT_ID, WATCH_CLIENT_SCREEN, null),
                 new InnertubeClientRequestInfo.DeviceInfo(MOBILE_CLIENT_PLATFORM, "Apple",
                         IOS_DEVICE_MODEL, "iOS", IOS_OS_VERSION, -1));
+    }
+
+    @Nonnull
+    public static InnertubeClientRequestInfo ofAndroidVRClient() {
+        return new InnertubeClientRequestInfo(
+                new InnertubeClientRequestInfo.ClientInfo(ANDROID_VR_CLIENT_NAME,
+                        ANDROID_VR_CLIENT_VERSION, ANDROID_VR_CLIENT_ID,
+                        WATCH_CLIENT_SCREEN, null),
+                new InnertubeClientRequestInfo.DeviceInfo(MOBILE_CLIENT_PLATFORM,
+                        ANDROID_VR_DEVICE_MAKE, ANDROID_VR_DEVICE_MODEL,
+                        "Android", ANDROID_VR_OS_VERSION, ANDROID_VR_SDK_VERSION));
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamHelper.java
@@ -228,6 +228,36 @@ public final class YoutubeStreamHelper {
                 getDownloader().postWithContentTypeJson(url, headers, body, localization)));
     }
 
+    public static JsonObject getAndroidVRPlayerResponse(
+            @Nonnull final ContentCountry contentCountry,
+            @Nonnull final Localization localization,
+            @Nonnull final String videoId,
+            @Nonnull final String cpn) throws IOException, ExtractionException {
+        final InnertubeClientRequestInfo innertubeClientRequestInfo =
+                InnertubeClientRequestInfo.ofAndroidVRClient();
+
+        final Map<String, List<String>> headers =
+                getMobileClientHeaders(getAndroidUserAgent(localization));
+
+        innertubeClientRequestInfo.clientInfo.visitorData =
+                YoutubeParsingHelper.getVisitorDataFromInnertube(innertubeClientRequestInfo,
+                        localization, contentCountry, headers, YOUTUBEI_V1_GAPIS_URL, null, false);
+
+        final JsonBuilder<JsonObject> builder = prepareJsonBuilder(localization, contentCountry,
+                innertubeClientRequestInfo, null);
+
+        addVideoIdCpnAndOkChecks(builder, videoId, cpn);
+
+        final byte[] body = JsonWriter.string(builder.done())
+                .getBytes(StandardCharsets.UTF_8);
+
+        final String url = YOUTUBEI_V1_GAPIS_URL + PLAYER + "?" + DISABLE_PRETTY_PRINT_PARAMETER
+                + "&t=" + generateTParameter() + "&id=" + videoId;
+
+        return JsonUtils.toJsonObject(getValidJsonResponseBody(
+                getDownloader().postWithContentTypeJson(url, headers, body, localization)));
+    }
+
     private static void addVideoIdCpnAndOkChecks(@Nonnull final JsonBuilder<JsonObject> builder,
                                                  @Nonnull final String videoId,
                                                  @Nullable final String cpn) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -131,6 +131,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private JsonObject iosStreamingData;
     @Nullable
     private JsonObject androidStreamingData;
+    @Nullable
+    private JsonObject androidVRStreamingData;
 
     private JsonObject videoPrimaryInfoRenderer;
     private JsonObject videoSecondaryInfoRenderer;
@@ -146,6 +148,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     // three different strings are used.
     private String iosCpn;
     private String androidCpn;
+    private String androidVRCpn;
 
     @Nullable
     private String androidStreamingUrlsPoToken;
@@ -328,7 +331,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             return Long.parseLong(duration);
         } catch (final Exception e) {
             return getDurationFromFirstAdaptiveFormat(Arrays.asList(
-                    androidStreamingData, iosStreamingData));
+                    androidStreamingData, androidVRStreamingData, iosStreamingData));
         }
     }
 
@@ -626,7 +629,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         // There is no DASH manifest available with the iOS client
         return getManifestUrl(
                 "dash",
-                List.of(new Pair<>(androidStreamingData, androidStreamingUrlsPoToken)),
+                List.of(new Pair<>(androidStreamingData, androidStreamingUrlsPoToken),
+                        new Pair<>(androidVRStreamingData, (String) null)),
                 // Return version 7 of the DASH manifest, which is the latest one, reducing
                 // manifest size and allowing playback with some DASH players
                 "mpd_version=7");
@@ -645,7 +649,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return getManifestUrl(
                 "hls",
                 List.of(new Pair<>(iosStreamingData, iosStreamingUrlsPoToken),
-                        new Pair<>(androidStreamingData, androidStreamingUrlsPoToken)),
+                        new Pair<>(androidStreamingData, androidStreamingUrlsPoToken),
+                        new Pair<>(androidVRStreamingData, (String) null)),
                 "");
     }
 
@@ -845,6 +850,10 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         fetchAndroidClient(localization, contentCountry, videoId, androidPoTokenResult);
 
+        if (isSabrOnlyStreamingData(androidStreamingData)) {
+            fetchAndroidVRClient(localization, contentCountry, videoId);
+        }
+
         setStreamType();
 
         if (fetchIosClient) {
@@ -948,6 +957,38 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         if (androidPoTokenResult != null) {
             androidStreamingUrlsPoToken = androidPoTokenResult.streamingDataPoToken;
+        }
+    }
+
+    private static boolean isSabrOnlyStreamingData(@Nullable final JsonObject streamingData) {
+        if (streamingData == null) {
+            return true;
+        }
+        final JsonArray adaptiveFormats = streamingData.getArray(ADAPTIVE_FORMATS);
+        if (adaptiveFormats == null || adaptiveFormats.isEmpty()) {
+            return true;
+        }
+        for (int i = 0; i < adaptiveFormats.size(); i++) {
+            final JsonObject fmt = adaptiveFormats.getObject(i);
+            if (fmt.has("url") || fmt.has(SIGNATURE_CIPHER) || fmt.has(CIPHER)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void fetchAndroidVRClient(@Nonnull final Localization localization,
+                                      @Nonnull final ContentCountry contentCountry,
+                                      @Nonnull final String videoId) {
+        try {
+            androidVRCpn = generateContentPlaybackNonce();
+            final JsonObject vrPlayerResponse =
+                    YoutubeStreamHelper.getAndroidVRPlayerResponse(
+                            contentCountry, localization, videoId, androidVRCpn);
+            if (!isPlayerResponseNotValid(vrPlayerResponse, videoId)) {
+                androidVRStreamingData = vrPlayerResponse.getObject(STREAMING_DATA);
+            }
+        } catch (final Exception ignored) {
         }
     }
 
@@ -1108,6 +1149,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             java.util.stream.Stream.of(
                     new Pair<>(androidStreamingData,
                             new Pair<>(androidCpn, androidStreamingUrlsPoToken)),
+                    new Pair<>(androidVRStreamingData,
+                            new Pair<>(androidVRCpn, (String) null)),
                     new Pair<>(iosStreamingData,
                             new Pair<>(iosCpn, iosStreamingUrlsPoToken)))
                     .flatMap(pair -> getStreamsFromStreamingDataKey(


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

## Fixes YouTube videos only playing at 360p

YouTube is enforcing the SABR protocol on standard clients (WEB, ANDROID), which removes traditional stream URLs from adaptive formats. This causes NewPipe to only show the 360p progressive stream (itag 18) with no option for higher quality.

This PR fixes the issue by adding the **ANDROID_VR client** (Oculus Quest 3, client ID 28) as a fallback. When the regular Android client returns SABR-only streaming data, the extractor automatically tries the VR client which still receives traditional stream URLs — restoring 720p, 1080p, and higher quality options.

Fixes TeamNewPipe/NewPipe#13320

## How it works
- Detects SABR-only responses by checking if adaptive formats lack `url`/`signatureCipher`/`cipher` fields
- Falls back to ANDROID_VR client which YouTube still serves traditional streams to
- Includes VR streaming data in stream extraction, DASH/HLS manifests, and duration calculation

## Additional app-side change needed
`ListHelper.SUPPORTED_ITAG_IDS` should also include AV1 itags (394-401) and audio itags (599, 600) so streams from the VR client aren't filtered out.

## Test plan
- [x] Built NewPipe with patched extractor locally
- [x] Installed APK on device and confirmed 720p/1080p+ streams are available
- [x] Verified videos previously stuck at 360p now show all quality options