### PR TITLE
[YouTube] Fix livestream playback: fetch iOS client and allow HLS/DASH manifest-only streams

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -847,7 +847,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         setStreamType();
 
-        if (fetchIosClient) {
+        // Always fetch the iOS client for livestreams, since its player response returns
+        // adaptiveFormats with actual stream URLs, unlike the Android client which only
+        // returns format metadata without URLs for livestreams.
+        if (fetchIosClient || streamType == StreamType.LIVE_STREAM
+                || streamType == StreamType.POST_LIVE_STREAM) {
             final PoTokenResult iosPoTokenResult = noPoTokenProviderSet ? null
                     : poTokenProviderInstance.getIosClientPoToken(videoId);
             fetchIosClient(localization, contentCountry, videoId, iosPoTokenResult);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -185,7 +185,9 @@ public class StreamInfo extends Info {
 
         // Either audio or video has to be available, otherwise we didn't get a stream (since
         // videoOnly are optional, they don't count).
-        if ((streamInfo.videoStreams.isEmpty()) && (streamInfo.audioStreams.isEmpty())) {
+        // However, if an HLS or DASH manifest is available, the stream can still be played.
+        if ((streamInfo.videoStreams.isEmpty()) && (streamInfo.audioStreams.isEmpty())
+                && isNullOrEmpty(streamInfo.hlsUrl) && isNullOrEmpty(streamInfo.dashMpdUrl)) {
             throw new StreamExtractException(
                     "Could not get any stream. See error variable to get further details.");
         }


### PR DESCRIPTION
Fixes: TeamNewPipe/NewPipe#13556

Description:

YouTube recently changed the Android inner tube client's response format for livestreams. The adaptiveFormats array in the Android player response no longer contains direct stream URLs (url or signatureCipher) it only includes format metadata (itag, bitrate, resolution, etc.) alongside hlsManifestUrl and dashManifestUrl.

This caused StreamInfo.extractStreams() to throw StreamExtractException("Could not get any stream") because both audioStreams and videoStreams were empty, even though a valid HLS manifest URL was present and the stream was perfectly playable.

Changes:
1. YoutubeStreamExtractor: Always fetch the iOS client for livestreams and post-livestreams. The iOS player response continu to return adaptiveFormats with actual stream URLs, allowing the extractor to populate audioStreams and videoOnlyStreams prly.
 2. StreamInfo: Only throw StreamExtractException when both individual streams and manifest URLs are missing. If an HLS or DA manifest is available, the stream can still be played.

Root cause:
  • YouTube API change: Android client adaptiveFormats stripped of URLs for livestreams
  • iOS client unaffected: still returns playable format URLs

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
