### PR TITLE
Fix NPE in getPlaylistHeader() when browseMetadataResponse is null

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -177,10 +177,13 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
     @Nonnull
     private JsonObject getPlaylistHeader() {
         if (playlistHeader == null) {
-            playlistHeader = browseMetadataResponse.getObject(HEADER)
+            if (browseMetadataResponse == null) {
+                return new JsonObject();
+            }
+            final JsonObject headerRenderer = browseMetadataResponse.getObject(HEADER)
                     .getObject("playlistHeaderRenderer");
+            playlistHeader = headerRenderer != null ? headerRenderer : new JsonObject();
         }
-
         return playlistHeader;
     }
 


### PR DESCRIPTION
On playlist continuation pages (getPage()), browseMetadataResponse is not set, causing a NullPointerException when getPlaylistHeader() tries to call .getObject() on it.

Fix by returning an empty JsonObject early when browseMetadataResponse is null, avoiding the crash on subsequent playlist page loads.

Fixes: TeamNewPipe/NewPipe#13593

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
