### PR TITLE
[YouTube] Fallback to avatarThumbnailUrl for comment thumbnails

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
@@ -164,9 +164,17 @@ class YoutubeCommentsEUVMInfoItemExtractor implements CommentsInfoItemExtractor 
     @Nonnull
     @Override
     public List<Image> getUploaderAvatars() throws ParsingException {
-        return getImagesFromThumbnailsArray(commentEntityPayload.getObject("avatar")
-                .getObject("image")
-                .getArray("sources"));
+        final JsonObject avatar = commentEntityPayload.getObject("avatar", null);
+        if (avatar != null) {
+            return getImagesFromThumbnailsArray(avatar.getObject("image")
+                    .getArray("sources"));
+        }
+
+        final JsonObject author = commentEntityPayload.getObject(AUTHOR);
+        return List.of(new Image(author.getString("avatarThumbnailUrl"),
+                88,
+                88,
+                Image.ResolutionLevel.LOW));
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue, where the comment payload does not contain the avatar object, and therefore the channel thumbnail is not extracted. This is currently in an A/B test, so it' doesn't happen every time.

Closes: https://github.com/libre-tube/LibreTube/issues/8619.
Closes: https://github.com/TeamNewPipe/NewPipe/issues/13731

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

I know this probably requires regenerating the mocks, but I spend >30 minutes fighting with gradle, so at this point it's a take-it-or-leave-it situation :)