### PR TITLE
Fix media.ccc.de live streams

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
@@ -58,7 +58,7 @@ public class MediaCCCLiveStreamExtractor extends StreamExtractor {
                 final JsonArray rooms = groups.getObject(g).getArray("rooms");
                 for (int r = 0; r < rooms.size(); r++) {
                     final JsonObject roomObject = rooms.getObject(r);
-                    if (getId().equals(conferenceObject.getString("slug") + "/"
+                    if (getId().equals(conferenceObject.getString("mandator") + "/"
                             + roomObject.getString("slug"))) {
                         conference = conferenceObject;
                         group = groupObject;


### PR DESCRIPTION
This PR fixes the fetching of live streams in NewPipe's media.ccc.de "Live" page with the currently running conference (and probably all future conferences, too). The issue originated from a misconception on our side, based on the fact that none of this was documented on media.ccc.de's side at the time of writing.

Based on discussion with a C3VOC member, we should use the mandator instead of the conference slug.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [x] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API. (No API change required, though, just a dependency update)
