### PR TITLE
[YouTube] Update n-sig parsing

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeJavaScriptPlayerManager.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeJavaScriptPlayerManager.java
@@ -39,8 +39,6 @@ public final class YoutubeJavaScriptPlayerManager {
     @Nullable
     private static String cachedSignatureDeobfuscationFunction;
     @Nullable
-    private static String cachedThrottlingDeobfuscationFunctionName;
-    @Nullable
     private static String cachedThrottlingDeobfuscationFunction;
 
     @Nullable
@@ -240,14 +238,9 @@ public final class YoutubeJavaScriptPlayerManager {
 
         if (cachedThrottlingDeobfuscationFunction == null) {
             try {
-                cachedThrottlingDeobfuscationFunctionName =
-                        YoutubeThrottlingParameterUtils.getDeobfuscationFunctionName(
-                                cachedJavaScriptPlayerCode);
-
                 cachedThrottlingDeobfuscationFunction =
-                        YoutubeThrottlingParameterUtils.getDeobfuscationFunction(
-                                cachedJavaScriptPlayerCode,
-                                cachedThrottlingDeobfuscationFunctionName);
+                        YoutubeThrottlingParameterUtils.getDeobfuscationCode(
+                                cachedJavaScriptPlayerCode);
             } catch (final ParsingException e) {
                 // Store the exception for future calls of this method, in order to improve
                 // performance
@@ -263,7 +256,7 @@ public final class YoutubeJavaScriptPlayerManager {
         try {
             final String deobfuscatedThrottlingParameter = JavaScript.run(
                     cachedThrottlingDeobfuscationFunction,
-                    cachedThrottlingDeobfuscationFunctionName,
+                    YoutubeThrottlingParameterUtils.DEOBFUSCATION_FUNCTION_NAME,
                     obfuscatedThrottlingParameter);
 
             if (isNullOrEmpty(deobfuscatedThrottlingParameter)) {
@@ -308,7 +301,6 @@ public final class YoutubeJavaScriptPlayerManager {
     public static void clearAllCaches() {
         cachedJavaScriptPlayerCode = null;
         cachedSignatureDeobfuscationFunction = null;
-        cachedThrottlingDeobfuscationFunctionName = null;
         cachedThrottlingDeobfuscationFunction = null;
         cachedSignatureTimestamp = null;
         clearThrottlingParametersCache();

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSignatureUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSignatureUtils.java
@@ -27,6 +27,7 @@ final class YoutubeSignatureUtils {
 
     private static final Pattern[] FUNCTION_REGEXES = {
             // CHECKSTYLE:OFF
+            Pattern.compile("(\\w*)=function(.*)\\{.*set\\(\\\"alr\\\",\\\"yes\\\"\\);\\w&&"),
             Pattern.compile("\\b(?:[a-zA-Z0-9_$]+)&&\\((?:[a-zA-Z0-9_$]+)=([a-zA-Z0-9_$]{2,})\\((\\d+,)decodeURIComponent\\((?:[a-zA-Z0-9_$]+)\\)\\)"),
             Pattern.compile("\\b(?:[a-zA-Z0-9_$]+)&&\\((?:[a-zA-Z0-9_$]+)=([a-zA-Z0-9_$]{2,})\\(decodeURIComponent\\((?:[a-zA-Z0-9_$]+)\\)\\)"),
             Pattern.compile("\\bm=([a-zA-Z0-9$]{2,})\\(decodeURIComponent\\(h\\.s\\)\\)"),
@@ -43,7 +44,7 @@ final class YoutubeSignatureUtils {
 
     // CHECKSTYLE:OFF
     private static final Pattern SIG_DEOBF_GLOBAL_ARRAY_REGEX =
-            Pattern.compile("(var [A-z]=['\"].*['\"].split\\(\"[;{]\"\\))");
+            Pattern.compile("(var [A-z]+=['\"].*['\"].split\\(\"[;{]\"\\))");
     private static final Pattern SIG_DEOBF_HELPER_OBJ_NAME_REGEX =
             Pattern.compile("[;,]([A-Za-z0-9_$]{2,})\\[..");
     private static final String SIG_DEOBF_HELPER_OBJ_REGEX_START = "(var ";

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeThrottlingParameterUtils.java
@@ -18,6 +18,12 @@ import java.util.regex.Pattern;
  */
 final class YoutubeThrottlingParameterUtils {
 
+    /**
+     * The name of the deobfuscation function which needs to be called inside the deobfuscation
+     * code.
+     */
+    static final String DEOBFUSCATION_FUNCTION_NAME = "deobfuscate_n_param";
+
     // NOTE: When changing this you should also change the quick exit/shortcut
     // in getThrottlingParameterFromStreamingUrl
     private static final Pattern THROTTLING_PARAM_PATTERN = Pattern.compile("[&?]n=([^&]+)");
@@ -26,95 +32,14 @@ final class YoutubeThrottlingParameterUtils {
 
     private static final String MULTIPLE_CHARS_REGEX = SINGLE_CHAR_VARIABLE_REGEX + "+";
 
-    private static final String ARRAY_ACCESS_REGEX = "\\[(\\d+)]";
-
     // CHECKSTYLE:OFF
     private static final Pattern[] DEOBFUSCATION_FUNCTION_NAME_REGEXES = {
             /*
-             * Matches the following text, where we want m85:
+             * Matches the following text, where we want QO:
              *
-             * m85=function( ... return Y[45]
+             * QO=function(... F.set("alr","yes" ...)
              */
-            Pattern.compile("([A-Za-z0-9_\\$]{2,})=function.*return [A-Z]\\[\\d+\\]"),
-
-
-            /*
-             * Matches the following text, where we want SDa and the array index accessed:
-             *
-             * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
-             */
-            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
-                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "\\("
-                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(" + MULTIPLE_CHARS_REGEX + "=("
-                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX),
-
-            /*
-             * Matches the following text, where we want Wma:
-             *
-             * a.D&&(b="nn"[+a.D],WL(a),c=a.j[b]||null)&&(c=SDa[0](c),a.set(b,c),SDa.length||Wma("")
-             */
-            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
-                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "\\("
-                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\).+\\|\\|(" + MULTIPLE_CHARS_REGEX
-                    + ")\\(\"\"\\)"),
-
-            /*
-             * Matches the following text, where we want cvb and the array index accessed:
-             *
-             * ,Vb(m),W=m.j[c]||null)&&(W=cvb[0](W),m.set(c,W)
-             */
-            Pattern.compile("," + MULTIPLE_CHARS_REGEX + "\\("
-                    + MULTIPLE_CHARS_REGEX + "\\)," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\." + MULTIPLE_CHARS_REGEX + "\\["
-                    + MULTIPLE_CHARS_REGEX + "]\\|\\|null\\)&&\\(\\b" + MULTIPLE_CHARS_REGEX + "=("
-                    + MULTIPLE_CHARS_REGEX + ")" + ARRAY_ACCESS_REGEX + "\\("
-                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)," + MULTIPLE_CHARS_REGEX
-                    + "\\.set\\((?:\"n+\"|" + MULTIPLE_CHARS_REGEX + ")," + MULTIPLE_CHARS_REGEX
-                    + "\\)"),
-
-            /*
-             * Matches the following text, where we want rma:
-             *
-             * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
-             */
-            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
-                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\.get\\(" + MULTIPLE_CHARS_REGEX + "\\)\\).+\\|\\|("
-                    + MULTIPLE_CHARS_REGEX + ")\\(\"\"\\)"),
-
-            /*
-             * Matches the following text, where we want rDa and the array index accessed:
-             *
-             * a.D&&(b="nn"[+a.D],c=a.get(b))&&(c=rDa[0](c),a.set(b,c),rDa.length||rma("")
-             */
-            Pattern.compile(SINGLE_CHAR_VARIABLE_REGEX + "=\"nn\"\\[\\+" + MULTIPLE_CHARS_REGEX
-                    + "\\." + MULTIPLE_CHARS_REGEX + "]," + MULTIPLE_CHARS_REGEX + "="
-                    + MULTIPLE_CHARS_REGEX + "\\.get\\(" + MULTIPLE_CHARS_REGEX + "\\)\\)&&\\("
-                    + MULTIPLE_CHARS_REGEX + "=(" + MULTIPLE_CHARS_REGEX + ")\\[(\\d+)]"),
-
-            /*
-             * Matches the following text, where we want BDa and the array index accessed:
-             *
-             * (b=String.fromCharCode(110),c=a.get(b))&&(c=BDa[0](c)
-             */
-            Pattern.compile("\\(" + SINGLE_CHAR_VARIABLE_REGEX + "=String\\.fromCharCode\\(110\\),"
-                    + SINGLE_CHAR_VARIABLE_REGEX + "=" + SINGLE_CHAR_VARIABLE_REGEX + "\\.get\\("
-                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)\\)" + "&&\\(" + SINGLE_CHAR_VARIABLE_REGEX
-                    + "=(" + MULTIPLE_CHARS_REGEX + ")" + "(?:" + ARRAY_ACCESS_REGEX + ")?\\("
-                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)"),
-
-            /*
-             * Matches the following text, where we want Yva and the array index accessed:
-             *
-             * .get("n"))&&(b=Yva[0](b)
-             */
-            Pattern.compile("\\.get\\(\"n\"\\)\\)&&\\(" + SINGLE_CHAR_VARIABLE_REGEX
-                    + "=(" + MULTIPLE_CHARS_REGEX + ")(?:" + ARRAY_ACCESS_REGEX + ")?\\("
-                    + SINGLE_CHAR_VARIABLE_REGEX + "\\)")
+            Pattern.compile("(\\w*)=function\\(.*\\)\\{.*set\\(\\\"alr\\\",\\\"yes\\\"\\);\\w&&"),
     };
     // CHECKSTYLE:ON
 
@@ -129,13 +54,6 @@ final class YoutubeThrottlingParameterUtils {
 
     private static final String FUNCTION_NAMES_IN_DEOBFUSCATION_ARRAY_REGEX =
             "\\s*=\\s*\\[(.+?)][;,]";
-
-    private static final String FUNCTION_ARGUMENTS_REGEX =
-            "=\\s*function\\s*\\(\\s*([^)]*)\\s*\\)";
-
-    private static final String EARLY_RETURN_REGEX =
-            ";\\s*if\\s*\\(\\s*typeof\\s+" + MULTIPLE_CHARS_REGEX
-                    + "+\\s*===?\\s*([\"'])undefined\\1\\s*\\)\\s*return\\s+";
 
     private YoutubeThrottlingParameterUtils() {
     }
@@ -193,7 +111,29 @@ final class YoutubeThrottlingParameterUtils {
         } catch (final Exception e) {
             function = parseFunctionWithRegex(javaScriptPlayerCode, functionName);
         }
-        return fixupFunction(function);
+        return function;
+    }
+
+
+    /**
+     * Get the throttling parameter deobfuscation code of YouTube's base JavaScript file.
+     *
+     * @param javaScriptPlayerCode the complete JavaScript base player code
+     * @return the throttling parameter deobfuscation function code
+     * @throws ParsingException if the throttling parameter deobfuscation code couldn't be
+     * extracted
+     */
+    @Nonnull
+    static String getDeobfuscationCode(@Nonnull final String javaScriptPlayerCode)
+            throws ParsingException {
+        final String functionName = getDeobfuscationFunctionName(javaScriptPlayerCode);
+        final String deobfuscationFunction = getDeobfuscationFunction(javaScriptPlayerCode,
+                functionName);
+
+        // Assert the extracted deobfuscation function is valid
+        JavaScript.compileOrThrow(deobfuscationFunction);
+
+        return buildHelperFunction(javaScriptPlayerCode, deobfuscationFunction);
     }
 
     /**
@@ -248,33 +188,68 @@ final class YoutubeThrottlingParameterUtils {
     }
 
     /**
-     * Removes an early return statement from the code of the throttling parameter deobfuscation
-     * function.
+     * Builds a helper function to execute the deobfuscation function.
      *
-     * <p>In newer version of the player code the function contains a check for something defined
-     * outside of the function. If that was not found it will return early.
-     *
-     * <p>The check can look like this (JS):<br>
-     * if(typeof RUQ==="undefined")return p;
-     *
-     * <p>In this example RUQ will always be undefined when running the function as standalone.
-     * If the check is kept it would just return p which is the input parameter and would be wrong.
-     * For that reason this check and return statement needs to be removed.
-     *
-     * @param function the original throttling parameter deobfuscation function code
-     * @return the throttling parameter deobfuscation function code with the early return statement
-     * removed
+     * @param javaScriptPlayerCode the complete JavaScript base player code
+     * @param deobfuscationFunctionName the name of the throttling parameter deobfuscation function
+     * @return code needed to execute the deobfuscation function
      */
     @Nonnull
-    private static String fixupFunction(@Nonnull final String function)
-            throws Parser.RegexException {
-        final String firstArgName = Parser
-                .matchGroup1(FUNCTION_ARGUMENTS_REGEX, function)
-                .split(",")[0].trim();
-        final Pattern earlyReturnPattern = Pattern.compile(
-                EARLY_RETURN_REGEX + firstArgName + ";",
-                Pattern.DOTALL);
-        final Matcher earlyReturnCodeMatcher = earlyReturnPattern.matcher(function);
-        return earlyReturnCodeMatcher.replaceFirst(";");
+    private static String buildHelperFunction(@Nonnull final String javaScriptPlayerCode,
+                                              @Nonnull final String deobfuscationFunctionName) {
+        final String strippedJavaScriptPlayerCode = javaScriptPlayerCode
+                .replace("var _yt_player={};(function(g){var window=this;", "")
+                .replace("})(_yt_player);", "");
+        return """
+                var g = {};
+                if (typeof globalThis.XMLHttpRequest === "undefined") {
+                    globalThis.XMLHttpRequest = { prototype: {} };
+                }
+                if (typeof URL === "undefined") {
+                    globalThis.location = {
+                        hash: "",
+                        host: "www.youtube.com",
+                        hostname: "www.youtube.com",
+                        href: "https://www.youtube.com/watch?v=yt-dlp-wins",
+                        origin: "https://www.youtube.com",
+                        password: "",
+                        pathname: "/watch",
+                        port: "",
+                        protocol: "https:",
+                        search: "?v=yt-dlp-wins",
+                        username: "",
+                    };
+                } else {
+                    globalThis.location = new URL("https://www.youtube.com/watch?v=yt-dlp-wins");
+                }
+                if (typeof globalThis.document === "undefined") {
+                    globalThis.document = Object.create(null);
+                }
+                if (typeof globalThis.navigator === "undefined") {
+                    globalThis.navigator = Object.create(null);
+                }
+                if (typeof globalThis.self === "undefined") {
+                    globalThis.self = globalThis;
+                }
+                if (typeof globalThis.window === "undefined") {
+                    globalThis.window = globalThis;
+                }
+                """ +
+                strippedJavaScriptPlayerCode +
+                String.format("""
+                          function %s(n){
+                          const url = %s("https://youtube.com/watch?v=yt-dlp-wins", "s", undefined);
+                          url.set("n", n);
+                          const proto = Object.getPrototypeOf(url);
+                          const keys = Object.keys(proto).concat(Object.getOwnPropertyNames(proto));
+                          for (let i = 0; i < keys.length; i++) {
+                            const key = keys[i];
+                            if (!["constructor", "set", "get", "clone"].includes(key)) {
+                              url[key]();
+                              break;
+                            }
+                          }
+                          return url.get("n");
+                        }""", DEOBFUSCATION_FUNCTION_NAME, deobfuscationFunctionName);
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScript.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScript.java
@@ -4,7 +4,11 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 
+import javax.annotation.Nullable;
+
 public final class JavaScript {
+    @Nullable
+    private static JavaScriptInterpreter externalJavaScriptInterpreter;
 
     private JavaScript() {
     }
@@ -21,6 +25,10 @@ public final class JavaScript {
     public static String run(final String function,
                              final String functionName,
                              final String... parameters) {
+        if (externalJavaScriptInterpreter != null) {
+            return externalJavaScriptInterpreter.run(function, functionName, parameters);
+        }
+
         try (Context context = Context.enter()) {
             context.setInterpretedMode(true);
             final ScriptableObject scope = context.initSafeStandardObjects();
@@ -32,4 +40,12 @@ public final class JavaScript {
         }
     }
 
+    /**
+     * Sets an external JavaScript interpreter, that is used to run JavaScript code.
+     *
+     * @param javaScriptInterpreter the complete JavaScript base player code
+     */
+    public static void setExternalJavaScriptInterpreter(@Nullable final JavaScriptInterpreter javaScriptInterpreter) {
+        JavaScript.externalJavaScriptInterpreter = javaScriptInterpreter;
+    }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScriptInterpreter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScriptInterpreter.java
@@ -1,0 +1,4 @@
+package org.schabi.newpipe.extractor.utils;
+
+public interface JavaScriptInterpreter {
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScriptInterpreter.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/JavaScriptInterpreter.java
@@ -1,4 +1,26 @@
 package org.schabi.newpipe.extractor.utils;
 
+import javax.annotation.Nonnull;
+
+/**
+ * Interface to execute JavaScript code.
+ *
+ * <p>
+ * Some clients, such as the WEB player, require to execute JavaScript code to allow playback.
+ * </p>
+ */
 public interface JavaScriptInterpreter {
+
+    /**
+     * Runs the specified function in the code.
+     *
+     * @param code the code that contains the function that should be run
+     * @param functionName the name of the function that should be run
+     * @param parameters the parameters to run with the function
+     * @return the result of the run function
+     */
+    String run(@Nonnull final String code,
+               @Nonnull final String functionName,
+               final String... parameters);
 }
+


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Updates the extraction of the n parameter and signature deobfuscation functions (adapted from https://github.com/yt-dlp/ejs/blob/6f8587bb7009a1fc81038538071d2cb66b8b8ed0/src/yt/solver/nsig.ts). While both (`n`, `sig`) use the same deobfuscation function, as far as I could detect, only the `n` deobfuscation is currently used.

Unfortunately, the deobfuscation function uses externally defined functions (i.e. not defined inside the function), requiring to load/parse the entire player code, taking multiple seconds. I did try to optimize this by only extracting the called functions, unfortunately that turned out to be more difficult than expect.
As an alternative, I opted to add a method that allows applications to set their own (faster) JavaScript Interpreter (for example an webview, which is already implemented by most applications to generate poTokens).